### PR TITLE
feat: Kindle Unlimited対象判定の追加

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -14,3 +14,4 @@ create index if not exists books_price_index on books (price);
 create index if not exists books_discount_rate_index on books (discount_rate);
 create index if not exists books_title_index on books (title);
 alter table books add column if not exists active_at timestamp default null;
+alter table books add column if not exists is_kindle_unlimited boolean default null;

--- a/src/kindle.rs
+++ b/src/kindle.rs
@@ -11,6 +11,12 @@ pub struct Kindle {
     pub discount_rate: f32,
 }
 
+#[derive(Debug)]
+pub struct KindleEdition {
+    pub kindle_id: String,
+    pub is_kindle_unlimited: bool,
+}
+
 impl Kindle {
     /// `AmazonのURLからIDを取得する`
     ///
@@ -33,29 +39,52 @@ impl Kindle {
         }
     }
 
-    /// `AmazonのURLからKindle IDを取得する`
+    /// `AmazonのURLからKindle IDとKindle Unlimited対象かどうかを取得する`
     ///
     /// # Errors
     ///
     /// Returns an error if the URL is invalid or the Kindle button is not found.
-    pub async fn convert_amazon_url_to_kindle_id(url: &str) -> Result<String> {
+    pub async fn convert_amazon_url_to_kindle_id(url: &str) -> Result<KindleEdition> {
         let id = Self::convert_amazon_url_to_id(url.trim_matches('\''))?;
         let doc = Kindle::get_html_by_amazon_id(&id).await?;
-        let html = Html::parse_document(&doc);
-        let selector = Selector::parse("#tmm-grid-swatch-KINDLE a.a-button-text.a-text-left")
+        Self::parse_kindle_edition(&doc, &id, url)
+    }
+
+    /// `Amazon商品ページのHTMLからKindle IDとKindle Unlimited対象かどうかを取得する`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Kindle button is not found or the Kindle URL is invalid.
+    fn parse_kindle_edition(doc: &str, id: &str, url: &str) -> Result<KindleEdition> {
+        let html = Html::parse_document(doc);
+        let swatch_selector = Selector::parse("#tmm-grid-swatch-KINDLE")
             .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
-        let kindle_url = match html.select(&selector).next() {
-            Some(node) => node
-                .value()
-                .attr("href")
-                .ok_or_else(|| anyhow::anyhow!("href attribute not found"))?,
-            None => return Err(anyhow::anyhow!("Kindle button not found: {url}")),
-        };
-        if kindle_url == "javascript:void(0)" {
-            Ok(id)
+        let button_selector = Selector::parse("a.a-button-text.a-text-left")
+            .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+        let ku_selector = Selector::parse("i.a-icon-kindle-unlimited")
+            .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+        // ボタンとKUアイコンは同一のswatch部分木から取得する
+        let swatch = html
+            .select(&swatch_selector)
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Kindle button not found: {url}"))?;
+        let kindle_url = swatch
+            .select(&button_selector)
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Kindle button not found: {url}"))?
+            .value()
+            .attr("href")
+            .ok_or_else(|| anyhow::anyhow!("href attribute not found"))?;
+        let is_kindle_unlimited = swatch.select(&ku_selector).next().is_some();
+        let kindle_id = if kindle_url == "javascript:void(0)" {
+            id.to_string()
         } else {
-            Self::convert_amazon_url_to_id(&format!("https://www.amazon.co.jp{kindle_url}"))
-        }
+            Self::convert_amazon_url_to_id(&format!("https://www.amazon.co.jp{kindle_url}"))?
+        };
+        Ok(KindleEdition {
+            kindle_id,
+            is_kindle_unlimited,
+        })
     }
 
     /// `AmazonのIDからHTMLを取得する`
@@ -168,6 +197,168 @@ mod tests {
         let kindle_id = Kindle::convert_amazon_url_to_id(url)?;
         assert_eq!(&kindle_id, "B0DJB4QN8R");
 
+        Ok(())
+    }
+
+    // 実際にKU対象の紙書籍ページ(dpページ)から抽出した #tmm-grid-swatch-KINDLE の断片。
+    // href付きのKindleリンクと a-icon-kindle-unlimited アイコンを含む。
+    const PAPER_KU_SWATCH_FRAGMENT: &str = r#"
+        <div id="tmm-grid-swatch-KINDLE" class="a-column a-span6 a-text-left swatchElement unselected celwidget" role="listitem">
+          <span class="a-button a-spacing-none a-button-toggle format kindleALCExtraMessage">
+            <span class="a-button-inner">
+              <a href="/%E6%B1%9A%E3%82%8C%E3%81%9F%E6%89%8B%E3%82%92%E3%81%9D%E3%81%93%E3%81%A7%E6%8B%AD%E3%81%8B%E3%81%AA%E3%81%84-%E6%96%87%E6%98%A5%E6%96%87%E5%BA%AB-%E8%8A%A6%E6%B2%A2-%E5%A4%AE-ebook/dp/B0CM5XVJ7Q/ref=tmm_kin_swatch_0" role="radio" aria-checked="false" aria-current="" class="a-button-text a-text-left">
+                <span class="slot-title"><span aria-label="Kindle版 (電子書籍) 形式:">Kindle版 (電子書籍)</span></span>
+                <span class="slot-price">
+                  <span aria-label="￥0">￥0</span>
+                  <i class="a-icon a-icon-kindle-unlimited a-icon-small" role="img" aria-label="Kindle Unlimitedで"></i>
+                </span>
+              </a>
+            </span>
+          </span>
+        </div>
+    "#;
+
+    // 実際に非KUの紙書籍ページ(ONE PIECE 110)から抽出した #tmm-grid-swatch-KINDLE の断片。
+    // href付きのKindleリンクを含むが、a-icon-kindle-unlimited アイコンは存在しない。
+    const PAPER_NON_KU_SWATCH_FRAGMENT: &str = r#"
+        <div id="tmm-grid-swatch-KINDLE" class="a-column a-span6 a-text-left swatchElement unselected celwidget" role="listitem">
+          <span class="a-button a-spacing-none a-button-toggle format">
+            <span class="a-button-inner">
+              <a href="/ONE-PIECE-%E3%83%A2%E3%83%8E%E3%82%AF%E3%83%AD%E7%89%88-110-%E3%82%B8%E3%83%A3%E3%83%B3%E3%83%97%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9DIGITAL-ebook/dp/B0DJB4QN8R/ref=tmm_kin_swatch_0" role="radio" aria-checked="false" aria-current="" class="a-button-text a-text-left">
+                <span class="slot-title"><span aria-label="Kindle版 (電子書籍) 形式:">Kindle版 (電子書籍)</span></span>
+                <span class="slot-price"><span aria-label="￥543" class="a-size-base a-color-secondary ebook-price-value">￥543</span></span>
+              </a>
+            </span>
+          </span>
+        </div>
+    "#;
+
+    // 実際にKU対象のKindle本ページから抽出した #tmm-grid-swatch-KINDLE の断片。
+    // 選択中の形式なので href="javascript:void(0)"。a-icon-kindle-unlimited アイコンを含む。
+    const KINDLE_PAGE_KU_SWATCH_FRAGMENT: &str = r#"
+        <div id="tmm-grid-swatch-KINDLE" class="a-column a-span6 a-text-left swatchElement selected celwidget" role="listitem">
+          <span class="a-button a-button-selected a-spacing-none a-button-toggle format kindleALCExtraMessage">
+            <span class="a-button-inner">
+              <a href="javascript:void(0)" role="radio" aria-checked="true" aria-current="page" class="a-button-text a-text-left">
+                <span class="slot-title"><span aria-label="Kindle版 (電子書籍) 形式:">Kindle版 (電子書籍)</span></span>
+                <span class="slot-price">
+                  <span aria-label="￥0" class="a-color-price">￥0</span>
+                  <i class="a-icon a-icon-kindle-unlimited a-icon-small" role="img" aria-label="Kindle Unlimitedで"></i>
+                </span>
+              </a>
+            </span>
+          </span>
+        </div>
+    "#;
+
+    // 実際に非KUのKindle本ページから抽出した #tmm-grid-swatch-KINDLE の断片。
+    // 選択中の形式なので href="javascript:void(0)"。a-icon-kindle-unlimited アイコンは存在しない。
+    const KINDLE_PAGE_NON_KU_SWATCH_FRAGMENT: &str = r#"
+        <div id="tmm-grid-swatch-KINDLE" class="a-column a-span6 a-text-left swatchElement selected celwidget" role="listitem">
+          <span class="a-button a-button-selected a-spacing-none a-button-toggle format">
+            <span class="a-button-inner">
+              <a href="javascript:void(0)" role="radio" aria-checked="true" aria-current="page" class="a-button-text a-text-left">
+                <span class="slot-title"><span aria-label="Kindle版 (電子書籍) 形式:">Kindle版 (電子書籍)</span></span>
+                <span class="slot-price"><span aria-label="￥543" class="a-size-base a-color-price a-color-price ebook-price-value">￥543</span></span>
+              </a>
+            </span>
+          </span>
+        </div>
+    "#;
+
+    // 非KUの紙書籍ページのナビゲーションから抽出した「Kindle Unlimited」文字列を含む要素と、
+    // swatch外に置かれた a-icon-kindle-unlimited アイコン。誤検出防止の確認用。
+    const OUTSIDE_SWATCH_KU_NOISE_FRAGMENT: &str = r#"
+        <a href="/kindle-dbs/hz/signup/?_encoding=UTF8&ref_=sv_b_5" class="nav-a" aria-label="Kindle Unlimited 読み放題">
+          <span class="nav-a-content">Kindle Unlimited 読み放題</span>
+        </a>
+        <i class="a-icon a-icon-kindle-unlimited a-icon-small" role="img" aria-label="Kindle Unlimitedで"></i>
+    "#;
+
+    #[test]
+    fn test_parse_kindle_edition_paper_ku() -> Result<()> {
+        let edition = Kindle::parse_kindle_edition(
+            PAPER_KU_SWATCH_FRAGMENT,
+            "4167921251",
+            "https://www.amazon.co.jp/dp/4167921251",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0CM5XVJ7Q");
+        assert!(edition.is_kindle_unlimited);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_paper_non_ku() -> Result<()> {
+        let edition = Kindle::parse_kindle_edition(
+            PAPER_NON_KU_SWATCH_FRAGMENT,
+            "4088843142",
+            "https://www.amazon.co.jp/dp/4088843142",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0DJB4QN8R");
+        assert!(!edition.is_kindle_unlimited);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_kindle_page_ku() -> Result<()> {
+        let edition = Kindle::parse_kindle_edition(
+            KINDLE_PAGE_KU_SWATCH_FRAGMENT,
+            "B0CM5XVJ7Q",
+            "https://www.amazon.co.jp/dp/B0CM5XVJ7Q",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0CM5XVJ7Q");
+        assert!(edition.is_kindle_unlimited);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_kindle_page_non_ku() -> Result<()> {
+        let edition = Kindle::parse_kindle_edition(
+            KINDLE_PAGE_NON_KU_SWATCH_FRAGMENT,
+            "B0DJB4QN8R",
+            "https://www.amazon.co.jp/dp/B0DJB4QN8R",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0DJB4QN8R");
+        assert!(!edition.is_kindle_unlimited);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_button_not_found() {
+        let doc = r#"<div id="tmm-grid-swatch-OTHER" class="a-column a-span6 a-text-left swatchElement selected celwidget"></div>"#;
+        let url = "https://www.amazon.co.jp/dp/4088843142";
+        match Kindle::parse_kindle_edition(doc, "4088843142", url) {
+            Ok(edition) => panic!("expected an error but got {edition:?}"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains(&format!("Kindle button not found: {url}"))),
+        }
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_ignores_ku_signals_outside_swatch() -> Result<()> {
+        let doc = format!("{OUTSIDE_SWATCH_KU_NOISE_FRAGMENT}{PAPER_NON_KU_SWATCH_FRAGMENT}");
+        let edition = Kindle::parse_kindle_edition(
+            &doc,
+            "4088843142",
+            "https://www.amazon.co.jp/dp/4088843142",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0DJB4QN8R");
+        assert!(!edition.is_kindle_unlimited);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_kindle_edition_uses_first_swatch_only() -> Result<()> {
+        // 同じIDのswatchが複数あっても、ボタンとKUアイコンを同一(最初)のswatchから読むこと
+        let doc = format!("{PAPER_NON_KU_SWATCH_FRAGMENT}{PAPER_KU_SWATCH_FRAGMENT}");
+        let edition = Kindle::parse_kindle_edition(
+            &doc,
+            "4088843142",
+            "https://www.amazon.co.jp/dp/4088843142",
+        )?;
+        assert_eq!(&edition.kindle_id, "B0DJB4QN8R");
+        assert!(!edition.is_kindle_unlimited);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,10 @@ impl BookMeterDiscounts {
     /// # Panics
     ///
     /// This function does not panic.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "sequential update steps (fetch, delete, kindle id, price) read clearest inline"
+    )]
     pub async fn update_discounts(&self) -> Result<()> {
         // 読書メーターから本情報の取得
         let max_page = env::var("MAX_PAGE")
@@ -110,24 +114,26 @@ impl BookMeterDiscounts {
                 continue;
             }
             sleep(Duration::from_secs(self.get_amazon_page_interval)).await;
-            let kindle_id = match Kindle::convert_amazon_url_to_kindle_id(&book.amazon_url).await {
-                Ok(id) => id,
-                Err(e) => {
-                    info!(
-                        "error while getting kindle id from {}: {:?}",
-                        book.amazon_url, e
-                    );
-                    if e.to_string().contains("Kindle button not found") {
-                        active_book.active_at = Set(Some(
-                            chrono::Utc::now().naive_utc() + chrono::Duration::days(30),
-                        ));
-                        active_book.updated_at = Set(chrono::Utc::now().naive_utc());
-                        active_book.update(&self.db).await?;
+            let kindle_edition =
+                match Kindle::convert_amazon_url_to_kindle_id(&book.amazon_url).await {
+                    Ok(kindle_edition) => kindle_edition,
+                    Err(e) => {
+                        info!(
+                            "error while getting kindle id from {}: {:?}",
+                            book.amazon_url, e
+                        );
+                        if e.to_string().contains("Kindle button not found") {
+                            active_book.active_at = Set(Some(
+                                chrono::Utc::now().naive_utc() + chrono::Duration::days(30),
+                            ));
+                            active_book.updated_at = Set(chrono::Utc::now().naive_utc());
+                            active_book.update(&self.db).await?;
+                        }
+                        continue;
                     }
-                    continue;
-                }
-            };
-            active_book.kindle_id = Set(Some(kindle_id));
+                };
+            active_book.kindle_id = Set(Some(kindle_edition.kindle_id));
+            active_book.is_kindle_unlimited = Set(Some(kindle_edition.is_kindle_unlimited));
             active_book.updated_at = Set(chrono::Utc::now().naive_utc());
             active_book.update(&self.db).await?;
             self.metrics.record_kindle_id_fetched();

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,6 +14,7 @@ pub struct Model {
     pub basis_price: Option<i32>,
     pub price: Option<i32>,
     pub discount_rate: Option<f32>,
+    pub is_kindle_unlimited: Option<bool>,
     pub updated_at: chrono::NaiveDateTime,
     pub active_at: Option<chrono::NaiveDateTime>,
 }
@@ -33,6 +34,7 @@ impl From<BookMeterBook> for ActiveModel {
             basis_price: Set(None),
             price: Set(None),
             discount_rate: Set(None),
+            is_kindle_unlimited: Set(None),
             updated_at: Set(chrono::Utc::now().naive_utc()),
             active_at: Set(None),
         }


### PR DESCRIPTION
## 概要

kindle_id取得時にクロール済みのAmazon商品ページHTMLから、Kindle Unlimited対象かどうかを判定して `books.is_kindle_unlimited` に保存する。追加のHTTPリクエストは発生しない。

## 変更内容

- `src/kindle.rs`: `KindleEdition { kindle_id, is_kindle_unlimited }` を新設。パース処理を `parse_kindle_edition` に分離し、`#tmm-grid-swatch-KINDLE` 要素の部分木内で Kindleボタン(href)と `i.a-icon-kindle-unlimited` アイコンを検索(同一swatchから読むことでID重複時の不整合を防止)
- `src/lib.rs`: kindle_id取得ループで `is_kindle_unlimited` も同時に保存
- `src/model.rs`: `is_kindle_unlimited: Option<bool>` を追加(APIレスポンスには `isKindleUnlimited` として自動で載る)
- `init.sql`: `alter table books add column if not exists is_kindle_unlimited boolean default null;` を追記
- テスト: 実物のAmazonページHTMLから抽出した `#tmm-grid-swatch-KINDLE` 断片をフィクスチャに、KU対象/非対象 × 紙/Kindleページ、ボタンなし、swatch外ノイズの誤検出防止、swatch重複時の挙動をカバー(計7件追加)

## ⚠️ デプロイ時の注意

`init.sql` はDBデータディレクトリが空の初回起動時にしか自動実行されないため、**既存DBには `init.sql` の再適用(冪等)が必要**。適用しないまま新バイナリを起動すると `Book::find()` が `column "is_kindle_unlimited" does not exist` で失敗する(`active_at` カラム追加時と同じ運用)。

## 既知の制約

- KU判定はAmazon商品ページにアクセスする kindle_id 初回取得時の一度きり。毎回の価格取得元(listasin.net)にはKU情報がないため、KU対象の入れ替わりには追従しない
- 既に kindle_id 取得済みの既存レコードはAmazonページへの再アクセスが発生しないため `is_kindle_unlimited` はNULLのまま(バックフィルが必要なら別途対応)

https://claude.ai/code/session_013BofJdtqRMFggbVPNjmyFR