### PR TITLE
refactor: is_kindle_unlimited を not null default false に変更

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -14,4 +14,4 @@ create index if not exists books_price_index on books (price);
 create index if not exists books_discount_rate_index on books (discount_rate);
 create index if not exists books_title_index on books (title);
 alter table books add column if not exists active_at timestamp default null;
-alter table books add column if not exists is_kindle_unlimited boolean default null;
+alter table books add column if not exists is_kindle_unlimited boolean not null default false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ impl BookMeterDiscounts {
                     }
                 };
             active_book.kindle_id = Set(Some(kindle_edition.kindle_id));
-            active_book.is_kindle_unlimited = Set(Some(kindle_edition.is_kindle_unlimited));
+            active_book.is_kindle_unlimited = Set(kindle_edition.is_kindle_unlimited);
             active_book.updated_at = Set(chrono::Utc::now().naive_utc());
             active_book.update(&self.db).await?;
             self.metrics.record_kindle_id_fetched();

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,7 +14,7 @@ pub struct Model {
     pub basis_price: Option<i32>,
     pub price: Option<i32>,
     pub discount_rate: Option<f32>,
-    pub is_kindle_unlimited: Option<bool>,
+    pub is_kindle_unlimited: bool,
     pub updated_at: chrono::NaiveDateTime,
     pub active_at: Option<chrono::NaiveDateTime>,
 }
@@ -34,7 +34,7 @@ impl From<BookMeterBook> for ActiveModel {
             basis_price: Set(None),
             price: Set(None),
             discount_rate: Set(None),
-            is_kindle_unlimited: Set(None),
+            is_kindle_unlimited: Set(false),
             updated_at: Set(chrono::Utc::now().naive_utc()),
             active_at: Set(None),
         }


### PR DESCRIPTION
## 概要

#170 で追加した `books.is_kindle_unlimited` を nullable から `not null default false` に変更する。

既存レコードのバックフィルは行わない方針のため、NULL(未判定)は実質死に値であり、非nullableにすることでモデル(`Option<bool>` → `bool`)とAPIレスポンス(`isKindleUnlimited` が常に `true`/`false`)がシンプルになる。

## 変更内容

- `init.sql`: `alter table books add column if not exists is_kindle_unlimited boolean not null default false;`
- `src/model.rs`: `is_kindle_unlimited: Option<bool>` → `bool`、新規レコードの初期値は `false`
- `src/lib.rs`: `Set(Some(...))` → `Set(...)`

※ #170 のnullable版マイグレーションはまだどのDBにも未適用のため、正規化文は不要(確認済み)。

https://claude.ai/code/session_013BofJdtqRMFggbVPNjmyFR