### PR TITLE
Add used book offers from BOOKOFF / ValueBooks / NetOff

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -15,3 +15,18 @@ create index if not exists books_discount_rate_index on books (discount_rate);
 create index if not exists books_title_index on books (title);
 alter table books add column if not exists active_at timestamp default null;
 alter table books add column if not exists is_kindle_unlimited boolean not null default false;
+alter table books add column if not exists binding_name text;
+
+-- 中古本サイト (bookoff / valuebooks / netoff) の商品オファー
+create table if not exists used_book_offers (
+    bookmeter_id bigint not null references books(bookmeter_id) on delete cascade,
+    site text not null,
+    product_id text,
+    product_url text,
+    price integer,
+    condition text,
+    in_stock boolean not null default false,
+    updated_at timestamp not null,
+    primary key (bookmeter_id, site)
+);
+create index if not exists used_book_offers_product_id_index on used_book_offers (product_id);

--- a/src/bookmeter.rs
+++ b/src/bookmeter.rs
@@ -19,6 +19,8 @@ pub struct BookMeterBook {
     pub id: u32,
     pub title: String,
     pub amazon_url: String,
+    /// 書籍の形式 (コミック / ライトノベル / 文庫 / 新書 / 単行本 など)
+    pub binding_name: Option<String>,
 }
 
 impl BookMeterBook {
@@ -26,35 +28,54 @@ impl BookMeterBook {
     ///
     /// Returns an error if fetching the book title or Amazon URL fails.
     pub async fn from_id(id: u32) -> Result<BookMeterBook> {
-        let title = { || Self::get_title(id) }
+        let doc = Self::get_book_page_with_retry(id).await?;
+        let html = Html::parse_document(&doc);
+        let title = Self::parse_title(&html, id)?;
+        let binding_name = Self::parse_binding_name(&html);
+        let amazon_url = Self::get_amazon_url(id).await?;
+        Ok(BookMeterBook {
+            id,
+            title,
+            amazon_url,
+            binding_name,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    async fn get_book_page(id: u32) -> Result<String> {
+        let url = format!("https://bookmeter.com/books/{id}");
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?;
+        let doc = client.get(&url).send().await?.text().await?;
+        Ok(doc)
+    }
+
+    /// 本ページを指数バックオフでリトライしながら取得する
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request keeps failing.
+    async fn get_book_page_with_retry(id: u32) -> Result<String> {
+        { || Self::get_book_page(id) }
             .retry(
                 ExponentialBuilder::default()
-                    .with_max_delay(Duration::from_secs(3600 * 4))
+                    .with_max_delay(Duration::from_hours(4))
                     .without_max_times(),
             )
             .sleep(tokio::time::sleep)
             .notify(|e, dur| {
                 warn!("retrying after {:?} because {:?}", dur, e);
             })
-            .await?;
-        let amazon_url = Self::get_amazon_url(id).await?;
-        Ok(BookMeterBook {
-            id,
-            title,
-            amazon_url,
-        })
+            .await
     }
 
     /// # Errors
     ///
-    /// Returns an error if the HTTP request fails or the title element is not found.
-    async fn get_title(id: u32) -> Result<String> {
-        let url = format!("https://bookmeter.com/books/{id}");
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()?;
-        let doc = client.get(&url).send().await?.text().await?;
-        let html = Html::parse_document(&doc);
+    /// Returns an error if the title element is not found.
+    fn parse_title(html: &Html, id: u32) -> Result<String> {
         let selector = Selector::parse(".inner__title")
             .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
         let title = html
@@ -64,6 +85,35 @@ impl BookMeterBook {
             .text()
             .collect();
         Ok(title)
+    }
+
+    /// 本ページのHTMLから形式 (コミック / ライトノベル / 文庫 など) を取得する
+    ///
+    /// 形式の要素が見つからない場合や、内容が空の場合は `None` を返す。
+    #[must_use]
+    pub fn parse_binding_name(html: &Html) -> Option<String> {
+        let selector = Selector::parse(".current-book-detail__binding-name").ok()?;
+        html.select(&selector)
+            .next()
+            .map(|e| {
+                e.text()
+                    .collect::<String>()
+                    .trim()
+                    .trim_start_matches("形式：")
+                    .to_string()
+            })
+            .filter(|name| !name.is_empty())
+    }
+
+    /// 既存の本の形式だけを取得する (`binding_name` 未保持の本の補完用)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails after retries.
+    pub async fn fetch_binding_name(id: u32) -> Result<Option<String>> {
+        let doc = Self::get_book_page_with_retry(id).await?;
+        let html = Html::parse_document(&doc);
+        Ok(Self::parse_binding_name(&html))
     }
 
     /// # Errors
@@ -198,5 +248,75 @@ impl BookMeterClient {
         let doc = client.get(&url).send().await?.text().await?;
         let html = Html::parse_document(&doc);
         Ok(html)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_binding_name_from_fragment(fragment: &str) -> Option<String> {
+        let html = Html::parse_fragment(fragment);
+        BookMeterBook::parse_binding_name(&html)
+    }
+
+    // 実際の本ページから抽出した .current-book-detail の断片
+    #[test]
+    fn test_parse_binding_name_light_novel() {
+        let fragment = r#"
+            <div class="current-book-detail">
+              <p class="current-book-detail__binding-name">形式：ライトノベル</p>
+              <p class="current-book-detail__publisher">出版社：スターツ出版</p>
+            </div>
+        "#;
+        assert_eq!(
+            parse_binding_name_from_fragment(fragment),
+            Some("ライトノベル".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_binding_name_comic() {
+        let fragment = r#"
+            <div class="current-book-detail">
+              <p class="current-book-detail__binding-name">形式：コミック</p>
+              <p class="current-book-detail__publisher">出版社：講談社</p>
+            </div>
+        "#;
+        assert_eq!(
+            parse_binding_name_from_fragment(fragment),
+            Some("コミック".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_binding_name_shinsho() {
+        let fragment = r#"
+            <div class="current-book-detail">
+              <p class="current-book-detail__binding-name">形式：新書</p>
+              <p class="current-book-detail__publisher">出版社：スターツ出版</p>
+            </div>
+        "#;
+        assert_eq!(
+            parse_binding_name_from_fragment(fragment),
+            Some("新書".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_binding_name_not_found() {
+        let fragment = r#"<div class="current-book-detail"></div>"#;
+        assert_eq!(parse_binding_name_from_fragment(fragment), None);
+    }
+
+    #[test]
+    fn test_parse_binding_name_empty() {
+        // 要素はあるが内容が空の場合は未取得 (None) として扱う
+        let fragment = r#"
+            <div class="current-book-detail">
+              <p class="current-book-detail__binding-name"></p>
+            </div>
+        "#;
+        assert_eq!(parse_binding_name_from_fragment(fragment), None);
     }
 }

--- a/src/isbn.rs
+++ b/src/isbn.rs
@@ -1,0 +1,67 @@
+//! ISBN-10 から ISBN-13 への変換
+//!
+//! 中古本サイトの検索には ISBN-13 (JAN) を使うため、
+//! Amazon の紙書籍 ASIN (= ISBN-10) を変換する。
+
+use anyhow::Result;
+
+/// ISBN-10 を ISBN-13 に変換する
+///
+/// 先頭に `978` を付け、チェックディジットを計算し直す。
+/// 日本の書籍は全て `978-4` 始まりなので `978` 固定で問題ない。
+///
+/// # Errors
+///
+/// 入力が ISBN-10 の形式 (数字9桁 + 数字またはXのチェックディジット) でない場合にエラーを返す。
+pub fn isbn10_to_isbn13(isbn10: &str) -> Result<String> {
+    let isbn10 = isbn10.trim();
+    let chars: Vec<char> = isbn10.chars().collect();
+    let valid_length = chars.len() == 10;
+    let valid_body = chars.iter().take(9).all(char::is_ascii_digit);
+    let valid_check = chars
+        .last()
+        .is_some_and(|c| c.is_ascii_digit() || *c == 'X');
+    if !(valid_length && valid_body && valid_check) {
+        return Err(anyhow::anyhow!("Invalid ISBN-10: {isbn10}"));
+    }
+    let body12 = format!("978{}", &isbn10[..9]);
+    let sum: u32 = body12
+        .chars()
+        .enumerate()
+        .map(|(i, c)| {
+            let digit = c.to_digit(10).unwrap_or(0);
+            if i % 2 == 0 {
+                digit
+            } else {
+                digit * 3
+            }
+        })
+        .sum();
+    let check = (10 - sum % 10) % 10;
+    Ok(format!("{body12}{check}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_isbn10_to_isbn13() -> Result<()> {
+        // 海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)
+        assert_eq!(isbn10_to_isbn13("4813705189")?, "9784813705185");
+        // 吾輩は猫である (文春文庫)
+        assert_eq!(isbn10_to_isbn13("4167158054")?, "9784167158057");
+        // チェックディジットがXのケース
+        assert_eq!(isbn10_to_isbn13("400000008X")?, "9784000000086");
+        Ok(())
+    }
+
+    #[test]
+    fn test_isbn10_to_isbn13_invalid() {
+        // Kindle ASIN などは変換できない
+        assert!(isbn10_to_isbn13("B0DJB4QN8R").is_err());
+        assert!(isbn10_to_isbn13("481370518").is_err());
+        assert!(isbn10_to_isbn13("48137051890").is_err());
+        assert!(isbn10_to_isbn13("").is_err());
+    }
+}

--- a/src/kindle.rs
+++ b/src/kindle.rs
@@ -23,7 +23,7 @@ impl Kindle {
     /// # Errors
     ///
     /// Returns an error if the URL is invalid or does not contain a product/dp segment.
-    fn convert_amazon_url_to_id(url: &str) -> Result<String> {
+    pub(crate) fn convert_amazon_url_to_id(url: &str) -> Result<String> {
         let url = Url::parse(url.trim_matches('\''))?;
         let mut path_segments = url
             .path_segments()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,16 @@
 use std::{env, sync::Arc, time::Duration};
 
 use anyhow::Result;
-use bookmeter::BookMeterClient;
+use bookmeter::{BookMeterBook, BookMeterClient};
 use tracing::{error, info};
 
 mod bookmeter;
+mod isbn;
 mod kindle;
 mod metrics;
 pub mod model;
+pub mod used_book;
+pub mod used_book_offer;
 use futures::{Stream, TryStreamExt};
 use kindle::Kindle;
 use model::Entity as Book;
@@ -16,6 +19,8 @@ use sea_orm::{
     QueryOrder, QuerySelect, Set,
 };
 use tokio::time::sleep;
+use used_book::UsedBookSite;
+use used_book_offer::Entity as UsedBookOffer;
 
 pub struct BookMeterDiscounts {
     pub user_id: String,
@@ -55,7 +60,7 @@ impl BookMeterDiscounts {
     /// This function does not panic.
     #[expect(
         clippy::too_many_lines,
-        reason = "sequential update steps (fetch, delete, kindle id, price) read clearest inline"
+        reason = "sequential update steps (fetch, delete, kindle id, price, binding name, used book offers) read clearest inline"
     )]
     pub async fn update_discounts(&self) -> Result<()> {
         // 読書メーターから本情報の取得
@@ -168,6 +173,109 @@ impl BookMeterDiscounts {
             self.metrics.record_price_fetched();
         }
 
+        // 書籍の形式 (binding_name) が未取得の本の形式を取得
+        let mut stream = Book::find()
+            .filter(model::Column::BindingName.is_null())
+            .stream(&self.db)
+            .await?;
+        while let Some(item) = stream.try_next().await? {
+            let book: model::Model = item;
+            sleep(Duration::from_secs(self.get_amazon_page_interval)).await;
+            let Ok(bookmeter_id) = u32::try_from(book.bookmeter_id) else {
+                continue;
+            };
+            let binding_name = match BookMeterBook::fetch_binding_name(bookmeter_id).await {
+                Ok(binding_name) => binding_name,
+                Err(e) => {
+                    info!(
+                        "error while getting binding name for {}: {:?}",
+                        book.title, e
+                    );
+                    continue;
+                }
+            };
+            info!("binding name of {}: {:?}", book.title, binding_name);
+            // 形式が取得できなかった場合は NULL のままにし、次回実行時に再取得する
+            let Some(binding_name) = binding_name else {
+                continue;
+            };
+            let mut active_book = book.into_active_model();
+            active_book.binding_name = Set(Some(binding_name));
+            active_book.updated_at = Set(chrono::Utc::now().naive_utc());
+            active_book.update(&self.db).await?;
+        }
+
+        // 漫画・ライトノベル以外の本の中古本オファーを取得
+        let mut stream = Book::find()
+            .filter(model::Column::BindingName.is_not_null())
+            .filter(model::Column::BindingName.is_not_in(["コミック", "ライトノベル"]))
+            .stream(&self.db)
+            .await?;
+        while let Some(item) = stream.try_next().await? {
+            let book: model::Model = item;
+            let isbn13 = match Kindle::convert_amazon_url_to_id(&book.amazon_url)
+                .and_then(|asin| isbn::isbn10_to_isbn13(&asin))
+            {
+                Ok(isbn13) => isbn13,
+                Err(e) => {
+                    info!(
+                        "skip used book offers for {} (invalid ISBN from {}): {:?}",
+                        book.title, book.amazon_url, e
+                    );
+                    continue;
+                }
+            };
+            for site in UsedBookSite::ALL {
+                sleep(Duration::from_secs(self.get_amazon_page_interval)).await;
+                if let Err(e) = self.update_used_book_offer(&book, site, &isbn13).await {
+                    info!(
+                        "error while updating used book offer of {} on {}: {:?}",
+                        book.title,
+                        site.as_str(),
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 1冊・1サイト分の中古本オファーを取得してDBに保存する
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the network or database operation fails.
+    pub async fn update_used_book_offer(
+        &self,
+        book: &model::Model,
+        site: UsedBookSite,
+        isbn13: &str,
+    ) -> Result<()> {
+        let existing = UsedBookOffer::find_by_id((book.bookmeter_id, site.as_str().to_string()))
+            .one(&self.db)
+            .await?;
+        let known_product = existing
+            .as_ref()
+            .and_then(|m| m.product_id.as_deref().zip(m.product_url.as_deref()));
+        let update = site.refresh_offer(isbn13, known_product).await?;
+        if let Some(model) = existing {
+            model
+                .into_active_model()
+                .apply_update(&update)
+                .update(&self.db)
+                .await?;
+        } else {
+            // 検索で商品が見つからなかった場合は行を作らず、次回実行時に再検索する
+            if update.product_id.is_none() {
+                return Ok(());
+            }
+            let mut active = used_book_offer::ActiveModel::from(&update);
+            active.bookmeter_id = Set(book.bookmeter_id);
+            active.site = Set(site.as_str().to_string());
+            UsedBookOffer::insert(active).exec(&self.db).await?;
+        }
+        self.metrics.record_used_book_offer_fetched(site.as_str());
         Ok(())
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,7 @@ pub struct MetricsCollector {
     deleted_books: Counter<u64>,
     kindle_id_fetched: Counter<u64>,
     price_fetched: Counter<u64>,
+    used_book_offer_fetched: Counter<u64>,
 }
 
 impl MetricsCollector {
@@ -33,10 +34,16 @@ impl MetricsCollector {
             .with_description("Number of prices fetched for books with Kindle ID")
             .build();
 
+        let used_book_offer_fetched = meter
+            .u64_counter("bookmeter.used_book_offer_fetched")
+            .with_description("Number of used book offers fetched")
+            .build();
+
         Arc::new(Self {
             deleted_books,
             kindle_id_fetched,
             price_fetched,
+            used_book_offer_fetched,
         })
     }
 
@@ -94,5 +101,10 @@ impl MetricsCollector {
     pub fn record_price_fetched(&self) {
         self.price_fetched
             .add(1, &[KeyValue::new("operation", "fetch_price")]);
+    }
+
+    pub fn record_used_book_offer_fetched(&self, site: &'static str) {
+        self.used_book_offer_fetched
+            .add(1, &[KeyValue::new("site", site)]);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,6 +17,8 @@ pub struct Model {
     pub is_kindle_unlimited: bool,
     pub updated_at: chrono::NaiveDateTime,
     pub active_at: Option<chrono::NaiveDateTime>,
+    /// 書籍の形式 (コミック / ライトノベル / 文庫 / 新書 / 単行本 など)
+    pub binding_name: Option<String>,
 }
 
 impl ActiveModelBehavior for ActiveModel {}
@@ -37,6 +39,7 @@ impl From<BookMeterBook> for ActiveModel {
             is_kindle_unlimited: Set(false),
             updated_at: Set(chrono::Utc::now().naive_utc()),
             active_at: Set(None),
+            binding_name: Set(bookmeter_book.binding_name),
         }
     }
 }

--- a/src/used_book/bookoff.rs
+++ b/src/used_book/bookoff.rs
@@ -1,0 +1,166 @@
+//! BOOKOFF (ブックオフ公式オンラインストア) の検索・商品ページパーサー
+//!
+//! - 検索: `https://shopping.bookoff.co.jp/search/keyword/{isbn13}` (サーバサイドレンダリング)
+//! - 商品ページ: `https://shopping.bookoff.co.jp/used/{product_id}` (JSON-LD 埋め込みあり)
+
+use anyhow::Result;
+use scraper::{Html, Selector};
+
+use super::{http_client, OfferDetails, SearchHit};
+
+const BASE_URL: &str = "https://shopping.bookoff.co.jp";
+
+/// ISBN-13 で検索して最初の商品を取得する
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn search(isbn13: &str) -> Result<Option<SearchHit>> {
+    let url = format!("{BASE_URL}/search/keyword/{isbn13}");
+    let html = http_client()?.get(&url).send().await?.text().await?;
+    parse_search(&html)
+}
+
+/// 商品ページから在庫・価格を取得する
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn fetch_details(product_url: &str) -> Result<OfferDetails> {
+    let html = http_client()?.get(product_url).send().await?.text().await?;
+    parse_product(&html)
+}
+
+/// 検索結果 HTML から最初の商品の ID と URL を取り出す
+///
+/// 中古 (`/used/`) のリンクを優先し、なければ新品 (`/new/`) のリンクを使う。
+/// ヒットなしの場合は `Ok(None)` を返す。
+///
+/// # Errors
+///
+/// セレクタの解析に失敗した場合にエラーを返す。
+pub fn parse_search(html: &str) -> Result<Option<SearchHit>> {
+    let doc = Html::parse_document(html);
+    let item_selector = Selector::parse("a.productItem__link")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let mut used_href = None;
+    let mut new_href = None;
+    for node in doc.select(&item_selector) {
+        let Some(href) = node.value().attr("href") else {
+            continue;
+        };
+        if href.starts_with("/used/") && used_href.is_none() {
+            used_href = Some(href.to_string());
+        } else if href.starts_with("/new/") && new_href.is_none() {
+            new_href = Some(href.to_string());
+        }
+    }
+    let Some(href) = used_href.or(new_href) else {
+        return Ok(None);
+    };
+    let product_id = href
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Invalid product href: {href}"))?
+        .to_string();
+    Ok(Some(SearchHit {
+        product_id,
+        product_url: format!("{BASE_URL}{href}"),
+        details: None,
+    }))
+}
+
+/// 商品ページ HTML から価格・在庫を取り出す
+///
+/// 埋め込み JSON-LD の `offers` を優先し、なければ HTML 要素から読む。
+/// BOOKOFF は商品ごとの状態ランクを持たないため `condition` は `None`。
+///
+/// # Errors
+///
+/// 価格が取得できない場合にエラーを返す。
+pub fn parse_product(html: &str) -> Result<OfferDetails> {
+    if let Some((price, in_stock)) = super::parse_json_ld_offer(html)? {
+        return Ok(OfferDetails {
+            price,
+            condition: None,
+            in_stock,
+        });
+    }
+    // JSON-LD が取れない場合のフォールバック
+    let doc = Html::parse_document(html);
+    let price_selector = Selector::parse(".productInformation__price--large")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let price = doc.select(&price_selector).next().and_then(|e| {
+        e.text()
+            .collect::<String>()
+            .chars()
+            .filter(char::is_ascii_digit)
+            .collect::<String>()
+            .parse::<i32>()
+            .ok()
+    });
+    let stock_selector = Selector::parse(".productInformation__stock span")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let stock_text: String = doc
+        .select(&stock_selector)
+        .next()
+        .map_or_else(String::new, |e| e.text().collect());
+    let in_stock = stock_text.contains("在庫あり");
+    if price.is_none() && !in_stock {
+        return Err(anyhow::anyhow!("Failed to parse BOOKOFF product page"));
+    }
+    Ok(OfferDetails {
+        price,
+        condition: None,
+        in_stock,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // fixtures (tests/fixtures/used_book/):
+    // - bookoff_search.html: ISBN 9784813705185 の検索結果 (1件・在庫あり)
+    // - bookoff_search_empty.html: 該当なしの検索結果
+    // - bookoff_product.html: /used/0019117467 (495円・在庫あり)
+    // - bookoff_product_oos.html: /used/0016731582 吾輩は猫である (220円・在庫なし)
+
+    #[test]
+    fn test_parse_search() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/bookoff_search.html");
+        let hit = parse_search(html)?.ok_or_else(|| anyhow::anyhow!("hit expected"))?;
+        assert_eq!(hit.product_id, "0019117467");
+        assert_eq!(
+            hit.product_url,
+            "https://shopping.bookoff.co.jp/used/0019117467"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_search_empty() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/bookoff_search_empty.html");
+        assert!(parse_search(html)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_product_in_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/bookoff_product.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, Some(495));
+        assert!(details.in_stock);
+        assert_eq!(details.condition, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_product_out_of_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/bookoff_product_oos.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, Some(220));
+        assert!(!details.in_stock);
+        Ok(())
+    }
+}

--- a/src/used_book/mod.rs
+++ b/src/used_book/mod.rs
@@ -1,0 +1,201 @@
+//! 中古本サイト (BOOKOFF・バリューブックス・ネットオフ) からの商品情報取得
+//!
+//! ISBN-13 で各サイトを検索して商品 ID / URL を特定し、
+//! 商品ページから在庫・価格・状態を取得する。
+//! パーサーは HTTP レスポンスの HTML 文字列を受け取る純粋関数として実装し、
+//! `tests/fixtures/used_book/` の保存済み HTML でユニットテストできるようにする。
+
+pub mod bookoff;
+pub mod netoff;
+pub mod valuebooks;
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+/// 対象の中古本サイト
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UsedBookSite {
+    Bookoff,
+    ValueBooks,
+    NetOff,
+}
+
+/// 検索結果 (商品 ID と商品ページ URL)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchHit {
+    pub product_id: String,
+    pub product_url: String,
+    /// 検索レスポンスがそのまま商品ページだった場合の解析結果 (バリューブックス用)
+    pub details: Option<OfferDetails>,
+}
+
+/// 商品ページから取得するオファー情報
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OfferDetails {
+    /// 税込価格 (円)。在庫なしでも価格が分かる場合は Some
+    pub price: Option<i32>,
+    /// 商品状態 (例: "GOOD", "中古品")。サイトが状態を持たない場合は None
+    pub condition: Option<String>,
+    pub in_stock: bool,
+}
+
+/// DB 更新用の1サイト分の結果
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OfferUpdate {
+    pub product_id: Option<String>,
+    pub product_url: Option<String>,
+    pub price: Option<i32>,
+    pub condition: Option<String>,
+    pub in_stock: bool,
+}
+
+impl UsedBookSite {
+    pub const ALL: [UsedBookSite; 3] = [
+        UsedBookSite::Bookoff,
+        UsedBookSite::ValueBooks,
+        UsedBookSite::NetOff,
+    ];
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UsedBookSite::Bookoff => "bookoff",
+            UsedBookSite::ValueBooks => "valuebooks",
+            UsedBookSite::NetOff => "netoff",
+        }
+    }
+
+    /// ISBN-13 で検索して商品 ID / URL を取得する
+    ///
+    /// 見つからなかった場合は `Ok(None)` を返す。
+    ///
+    /// # Errors
+    ///
+    /// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+    pub async fn search(self, isbn13: &str) -> Result<Option<SearchHit>> {
+        match self {
+            UsedBookSite::Bookoff => bookoff::search(isbn13).await,
+            UsedBookSite::ValueBooks => valuebooks::search(isbn13).await,
+            UsedBookSite::NetOff => netoff::search(isbn13).await,
+        }
+    }
+
+    /// 商品ページ URL から在庫・価格・状態を取得する
+    ///
+    /// # Errors
+    ///
+    /// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+    pub async fn fetch_details(self, product_url: &str) -> Result<OfferDetails> {
+        match self {
+            UsedBookSite::Bookoff => bookoff::fetch_details(product_url).await,
+            UsedBookSite::ValueBooks => valuebooks::fetch_details(product_url).await,
+            UsedBookSite::NetOff => netoff::fetch_details(product_url).await,
+        }
+    }
+
+    /// 既知の商品 ID / URL があればそれを、なければ ISBN 検索で、最新のオファー情報を取得する
+    ///
+    /// # Errors
+    ///
+    /// 既知 URL の取得に失敗した場合 (古いデータを消さないよう検索にはフォールバックしない)、
+    /// または検索の HTTP リクエストに失敗した場合にエラーを返す。
+    pub async fn refresh_offer(
+        self,
+        isbn13: &str,
+        known_product: Option<(&str, &str)>,
+    ) -> Result<OfferUpdate> {
+        if let Some((product_id, product_url)) = known_product {
+            let details = self.fetch_details(product_url).await?;
+            return Ok(OfferUpdate {
+                product_id: Some(product_id.to_string()),
+                product_url: Some(product_url.to_string()),
+                price: details.price,
+                condition: details.condition,
+                in_stock: details.in_stock,
+            });
+        }
+        let Some(hit) = self.search(isbn13).await? else {
+            return Ok(OfferUpdate::default());
+        };
+        let details = match hit.details {
+            Some(details) => Some(details),
+            None => match self.fetch_details(&hit.product_url).await {
+                Ok(details) => Some(details),
+                Err(e) => {
+                    // 商品 ID / URL だけでも保持し、詳細は次回更新時に再取得する
+                    tracing::warn!("failed to fetch details from {}: {:?}", hit.product_url, e);
+                    None
+                }
+            },
+        };
+        Ok(OfferUpdate {
+            product_id: Some(hit.product_id),
+            product_url: Some(hit.product_url),
+            price: details.as_ref().and_then(|d| d.price),
+            condition: details.as_ref().and_then(|d| d.condition.clone()),
+            in_stock: details.is_some_and(|d| d.in_stock),
+        })
+    }
+}
+
+/// 中古本サイト向けの共通 HTTP クライアントを組み立てる
+///
+/// ブラウザ UA を名乗らないと 403 を返すサイトがあるため、
+/// `get-amazon-html.sh` と同様の UA を付ける。
+///
+/// # Errors
+///
+/// クライアントの構築に失敗した場合にエラーを返す。
+fn http_client() -> Result<reqwest::Client> {
+    const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36";
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(USER_AGENT)
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                reqwest::header::ACCEPT_LANGUAGE,
+                reqwest::header::HeaderValue::from_static("ja"),
+            );
+            headers
+        })
+        .build()?;
+    Ok(client)
+}
+
+/// JSON-LD (`application/ld+json`) ブロックから最初に見つかったオファーを取り出す
+///
+/// BOOKOFF / バリューブックスの商品ページが埋め込む schema.org データ向け。
+///
+/// # Errors
+///
+/// 常に `Ok` を返す (見つからない場合は `Ok(None)`)。
+fn parse_json_ld_offer(html: &str) -> Result<Option<(Option<i32>, bool)>> {
+    use scraper::{Html, Selector};
+    let doc = Html::parse_document(html);
+    let selector = Selector::parse(r#"script[type="application/ld+json"]"#)
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    for script in doc.select(&selector) {
+        let text: String = script.text().collect();
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        let Some(offers) = json.get("offers") else {
+            continue;
+        };
+        let offers = match offers {
+            serde_json::Value::Array(arr) => arr.clone(),
+            single => vec![single.clone()],
+        };
+        if let Some(offer) = offers.first() {
+            let price = offer.get("price").and_then(serde_json::Value::as_i64);
+            let in_stock = offer
+                .get("availability")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|a| a.ends_with("InStock"));
+            return Ok(Some((price.and_then(|p| i32::try_from(p).ok()), in_stock)));
+        }
+    }
+    Ok(None)
+}

--- a/src/used_book/netoff.rs
+++ b/src/used_book/netoff.rs
@@ -1,0 +1,159 @@
+//! ネットオフの検索・商品ページパーサー
+//!
+//! - 検索: `https://www.netoff.co.jp/cmdtyallsearch/?cat=1002&word={isbn13}`
+//!   (`cat=1002` は「古本・中古本」カテゴリ)
+//! - 商品ページ: `https://www.netoff.co.jp/detail/{product_id}/`
+
+use anyhow::Result;
+use scraper::{Html, Selector};
+
+use super::{http_client, OfferDetails, SearchHit};
+
+const BASE_URL: &str = "https://www.netoff.co.jp";
+
+/// ISBN-13 で検索して最初の商品を取得する
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn search(isbn13: &str) -> Result<Option<SearchHit>> {
+    let url = format!("{BASE_URL}/cmdtyallsearch/?cat=1002&word={isbn13}");
+    let html = http_client()?.get(&url).send().await?.text().await?;
+    parse_search(&html)
+}
+
+/// 商品ページから在庫・価格・状態を取得する
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn fetch_details(product_url: &str) -> Result<OfferDetails> {
+    let html = http_client()?.get(product_url).send().await?.text().await?;
+    parse_product(&html)
+}
+
+/// 検索結果 HTML から最初の商品の ID と URL を取り出す
+///
+/// ヒットなしの場合は `Ok(None)` を返す。
+///
+/// # Errors
+///
+/// セレクタの解析に失敗した場合にエラーを返す。
+pub fn parse_search(html: &str) -> Result<Option<SearchHit>> {
+    let doc = Html::parse_document(html);
+    let selector = Selector::parse("a.c-cassette__title")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let Some(href) = doc
+        .select(&selector)
+        .find_map(|e| e.value().attr("href").map(str::to_string))
+    else {
+        return Ok(None);
+    };
+    // href は "/detail/0012822282/" 形式
+    let product_id = href
+        .trim_matches('/')
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Invalid product href: {href}"))?
+        .to_string();
+    Ok(Some(SearchHit {
+        product_id,
+        product_url: format!("{BASE_URL}{href}"),
+        details: None,
+    }))
+}
+
+/// 商品ページ HTML から価格・在庫・状態を取り出す
+///
+/// # Errors
+///
+/// 価格が取得できない場合にエラーを返す。
+pub fn parse_product(html: &str) -> Result<OfferDetails> {
+    let doc = Html::parse_document(html);
+
+    let price_selector = Selector::parse(".product-price__normal-num")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let price = doc.select(&price_selector).next().and_then(|e| {
+        e.text()
+            .collect::<String>()
+            .trim()
+            .replace(',', "")
+            .parse::<i32>()
+            .ok()
+    });
+
+    // 在庫がある場合は「在庫あとN点！」などの文言が入る (ない場合は要素自体が空)
+    let stock_selector = Selector::parse(".l-product__stock-text")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let in_stock = doc.select(&stock_selector).next().is_some();
+
+    // 「状態：中古品」のような文言から状態を取り出す (在庫がない場合は要素自体がない)
+    let condition_selector = Selector::parse(".l-product__condition-text")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let condition = doc.select(&condition_selector).next().map(|e| {
+        e.text()
+            .collect::<String>()
+            .trim()
+            .trim_start_matches("状態：")
+            .to_string()
+    });
+
+    if price.is_none() {
+        return Err(anyhow::anyhow!("Failed to parse NetOff product page"));
+    }
+    Ok(OfferDetails {
+        price,
+        condition,
+        in_stock,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // fixtures (tests/fixtures/used_book/):
+    // - netoff_search.html: ISBN 9784813705185 の検索結果 (1件)
+    // - netoff_search_empty.html: 該当なしの検索結果
+    // - netoff_product.html: /detail/0012822282/ (220円・在庫あり・状態：中古品)
+    // - netoff_product_oos.html: /detail/0011631528/ (110円・在庫なし)
+
+    #[test]
+    fn test_parse_search() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/netoff_search.html");
+        let hit = parse_search(html)?.ok_or_else(|| anyhow::anyhow!("hit expected"))?;
+        assert_eq!(hit.product_id, "0012822282");
+        assert_eq!(
+            hit.product_url,
+            "https://www.netoff.co.jp/detail/0012822282/"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_search_empty() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/netoff_search_empty.html");
+        assert!(parse_search(html)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_product_in_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/netoff_product.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, Some(220));
+        assert_eq!(details.condition, Some("中古品".to_string()));
+        assert!(details.in_stock);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_product_out_of_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/netoff_product_oos.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, Some(110));
+        assert_eq!(details.condition, None);
+        assert!(!details.in_stock);
+        Ok(())
+    }
+}

--- a/src/used_book/valuebooks.rs
+++ b/src/used_book/valuebooks.rs
@@ -1,0 +1,183 @@
+//! バリューブックスの検索・商品ページパーサー
+//!
+//! - 検索: `https://www.valuebooks.jp/search?keyword={isbn13}`
+//!   ヒットした場合は商品ページ (`/bp/{product_id}`) にリダイレクトされる。
+//!   ヒットしない場合は `/search` に留まる。
+//! - 商品ページ: Vue の `<router-view :item-info="{...}">` に
+//!   状態 (condition) ごとの価格・在庫を持つ JSON が埋め込まれている。
+
+use anyhow::Result;
+use scraper::{Html, Selector};
+use serde::Deserialize;
+
+use super::{http_client, OfferDetails, SearchHit};
+
+const BASE_URL: &str = "https://www.valuebooks.jp";
+
+/// ISBN-13 で検索して商品を取得する
+///
+/// 検索は商品ページへリダイレクトされるため、レスポンス HTML をそのまま解析し
+/// `details` まで埋めて返す。ヒットしない場合は `Ok(None)` を返す。
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn search(isbn13: &str) -> Result<Option<SearchHit>> {
+    let url = format!("{BASE_URL}/search?keyword={isbn13}");
+    let response = http_client()?.get(&url).send().await?;
+    let final_url = response.url().to_string();
+    let html = response.text().await?;
+    let Some(product_id) = product_id_from_url(&final_url) else {
+        return Ok(None);
+    };
+    Ok(Some(SearchHit {
+        product_id,
+        product_url: final_url,
+        details: parse_product(&html).ok(),
+    }))
+}
+
+/// 商品ページから在庫・価格・状態を取得する
+///
+/// # Errors
+///
+/// HTTP リクエストまたは HTML の解析に失敗した場合にエラーを返す。
+pub async fn fetch_details(product_url: &str) -> Result<OfferDetails> {
+    let html = http_client()?.get(product_url).send().await?.text().await?;
+    parse_product(&html)
+}
+
+/// 商品ページ URL (`.../bp/VS0051080734`) から商品 ID を取り出す
+#[must_use]
+pub fn product_id_from_url(url: &str) -> Option<String> {
+    let marker = "/bp/";
+    let start = url.rfind(marker)? + marker.len();
+    let id: String = url[start..]
+        .chars()
+        .take_while(char::is_ascii_alphanumeric)
+        .collect();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id)
+    }
+}
+
+/// `:item-info` に埋め込まれる状態ごとの在庫情報
+#[derive(Debug, Deserialize)]
+struct ItemInfo {
+    #[serde(default, rename = "genpinList")]
+    genpin_list: Vec<Genpin>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Genpin {
+    #[serde(rename = "conditionName")]
+    condition_name: String,
+    price: Option<i32>,
+    #[serde(default)]
+    stock: i64,
+}
+
+/// 商品ページ HTML から価格・在庫・状態を取り出す
+///
+/// 在庫のある状態のうち最安のものを `price` / `condition` とする。
+///
+/// # Errors
+///
+/// ページ構造の解析に失敗した場合にエラーを返す。
+pub fn parse_product(html: &str) -> Result<OfferDetails> {
+    let doc = Html::parse_document(html);
+    let selector = Selector::parse("router-view")
+        .map_err(|e| anyhow::anyhow!("Failed to parse selector: {e:?}"))?;
+    let item_info = doc
+        .select(&selector)
+        .next()
+        .and_then(|e| e.value().attr(":item-info"))
+        .and_then(|json| serde_json::from_str::<ItemInfo>(json).ok());
+
+    if let Some(item_info) = item_info {
+        // 在庫のある状態のうち最安のものを選ぶ
+        let cheapest = item_info
+            .genpin_list
+            .iter()
+            .filter(|g| g.stock > 0 && g.price.is_some())
+            .min_by_key(|g| g.price);
+        return Ok(match cheapest {
+            Some(genpin) => OfferDetails {
+                price: genpin.price,
+                condition: Some(genpin.condition_name.clone()),
+                in_stock: true,
+            },
+            None => OfferDetails {
+                price: None,
+                condition: None,
+                in_stock: false,
+            },
+        });
+    }
+
+    // :item-info が取れない場合は JSON-LD にフォールバック
+    if let Some((price, in_stock)) = super::parse_json_ld_offer(html)? {
+        return Ok(OfferDetails {
+            price,
+            condition: None,
+            in_stock,
+        });
+    }
+    Err(anyhow::anyhow!("Failed to parse ValueBooks product page"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // fixtures (tests/fixtures/used_book/):
+    // - valuebooks_product.html: /bp/VS0051080734 (GOOD 287円・在庫あり)
+    //   ※ ISBN 9784813705185 の検索からリダイレクトされた商品ページ
+    // - valuebooks_product_oos.html: /bp/VS0040563019 (全状態在庫なし)
+    // - valuebooks_search_empty.html: ヒットなし (検索ページに留まる)
+
+    #[test]
+    fn test_product_id_from_url() {
+        assert_eq!(
+            product_id_from_url(
+                "https://www.valuebooks.jp/%E6%B5%B7%E3%81%AB%E9%A1%98%E3%81%84%E3%82%92--%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB-/bp/VS0051080734"
+            ),
+            Some("VS0051080734".to_string())
+        );
+        assert_eq!(
+            product_id_from_url("https://www.valuebooks.jp/search?keyword=9784000000000"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_product_in_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/valuebooks_product.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, Some(287));
+        assert_eq!(details.condition, Some("GOOD".to_string()));
+        assert!(details.in_stock);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_product_out_of_stock() -> Result<()> {
+        let html = include_str!("../../tests/fixtures/used_book/valuebooks_product_oos.html");
+        let details = parse_product(html)?;
+        assert_eq!(details.price, None);
+        assert_eq!(details.condition, None);
+        assert!(!details.in_stock);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_search_empty_page_has_no_product_id() {
+        // ヒットなしの場合は /search に留まり商品 ID を取れない
+        assert_eq!(
+            product_id_from_url("https://www.valuebooks.jp/search?keyword=9784000000000"),
+            None
+        );
+    }
+}

--- a/src/used_book_offer.rs
+++ b/src/used_book_offer.rs
@@ -1,0 +1,50 @@
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
+use serde::{Deserialize, Serialize};
+
+use crate::used_book::OfferUpdate;
+
+/// 中古本サイト (bookoff / valuebooks / netoff) の商品オファー
+#[derive(Clone, Debug, DeriveEntityModel, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[sea_orm(table_name = "used_book_offers")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub bookmeter_id: i64,
+    /// `UsedBookSite::as_str()` の値 (bookoff / valuebooks / netoff)
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub site: String,
+    pub product_id: Option<String>,
+    pub product_url: Option<String>,
+    /// 税込価格 (円)
+    pub price: Option<i32>,
+    /// 商品状態 (バリューブックスの GOOD など)。サイトが状態を持たない場合は None
+    pub condition: Option<String>,
+    pub in_stock: bool,
+    pub updated_at: chrono::NaiveDateTime,
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModel {
+    /// オファー情報の更新結果を `ActiveModel` に反映する
+    #[must_use]
+    pub fn apply_update(mut self, update: &OfferUpdate) -> Self {
+        self.product_id = Set(update.product_id.clone());
+        self.product_url = Set(update.product_url.clone());
+        self.price = Set(update.price);
+        self.condition = Set(update.condition.clone());
+        self.in_stock = Set(update.in_stock);
+        self.updated_at = Set(chrono::Utc::now().naive_utc());
+        self
+    }
+}
+
+impl From<&OfferUpdate> for ActiveModel {
+    fn from(update: &OfferUpdate) -> Self {
+        // bookmeter_id / site は NotSet のまま返すので、呼び出し側でセットする
+        <ActiveModel as Default>::default().apply_update(update)
+    }
+}

--- a/tests/fixtures/used_book/bookoff_product.html
+++ b/tests/fixtures/used_book/bookoff_product.html
@@ -1,0 +1,2066 @@
+<!DOCTYPE html>
+<html data-csrf-tmp-token="121e0c06044dec70" data-csrf-tmp-verifier="e852d5c0168d8f709ad9c7342fdc6265902c8609ea55408ab490f171b49ed769" xmlsn:og="http://ogp.me/ns#" xmlns:fb="http://ogp.me/ns/fb#" lang="ja">
+<head>
+<meta charset="UTF-8">
+
+<link rel="shortcut icon" href="/favicon.ico?dummy=1674087367" />
+<link rel="stylesheet" type="text/css" href="/css/shopping/used.css" charset="UTF-8" />
+<link rel="stylesheet" type="text/css" href="/publis.css" /><meta name="keywords" content="" />
+<meta name="description" content="【定価38%OFF】中古価格 495円(税込)【308円おトク！】「海に願いを風に祈りをそして君に誓いを スターツ出版文庫」汐見夏衛(著者)の中古商品ページです。1,800円以上のご注文で送料無料。本(書籍)、漫画(コミック)、CD、DVD、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<title>海に願いを風に祈りをそして君に誓いを スターツ出版文庫 中古本・書籍 | ブックオフ公式オンラインストア</title>
+<script >
+<!--
+	var pbGlobalAliasBase = '/';
+//-->
+</script>
+<script  src="/public.js"></script>
+<meta name="viewport" content="width=device-width">
+<!--link rel="shortcut icon" href="https://content.bookoffonline.co.jp/favicon.ico"-->
+<link rel="apple-touch-icon" sizes="180x180" href="/library/common/images/apple_touch_icon.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/library/common/images/webclip_android.png">
+<link rel="stylesheet" href="/library/common/css/common.css?d=20250416">
+<link rel="stylesheet" href="/library/common/css/headerFooter.css">
+<script src="https://content.bookoff.co.jp/files/common/js/jquery-2.2.4.min.js"></script>
+<script src="/library/common/js/vendor.bundle.js"></script>
+<script src="/library/common/js/common.js"></script>
+<script src="/library/common/js/headerFooter.js"></script>
+<!--<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>-->
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/items-container.css?rev=20260612" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/plugin/splide.min.js"></script>
+
+<script  src="https://content.bookoff.co.jp/files/common/js/jquery-1.12.4.min.js"></script>
+<script>
+
+	var class_name = 'BocProduct';
+
+$(document).on('click', '.js-ageverification', function(){
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+	var modalBtn = $('#ageVerification__btns--agree');
+
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+
+	// カートに追加、在庫有りのみカートに追加、巻数を指定してカートに追加する
+	$(document).on('click', '.jsBtn-cart', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if (mode == 'disabled') {
+			return false;
+		}
+		if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+			// 在庫有りのみカートに追加の場合、複数回クリック不許可
+			$(this).attr('data-mode', 'disabled');
+		}
+		var ex_param = {};
+		if (mode == 'Add') {
+			ex_param['stockType'] = $(this).attr('data-stock') ?? '';
+		}
+		if (mode == 'AddSelectedItems') {
+			var selectItemIds = {};
+			$('input[type="checkbox"].js-allCheckTarget:checked').each(function(index){
+				selectItemIds[index] = $(this).closest('.productSetItem__checkbox').find('input.item_id').val() ?? '';
+			});
+			ex_param['selectItemIds'] = selectItemIds;
+		}
+		if(age_limit == 1) {
+			ageVerification('cart', mode, item_id, ex_param);
+		} else {
+			ajaxConfig('cart', mode, item_id, ex_param);
+		}
+	});
+	// お気に入り追加・削除
+	$(document).on('click', '.jsBtn-favorite', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('favorite', mode, item_id);
+		} else {
+			ajaxConfig('favorite', mode, item_id);
+		}
+	});
+	// 入荷お知らせ追加・削除、全巻入荷お知らせ追加・削除
+	$(document).on('click', '.jsBtn-arrival', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('arrival', mode, item_id);
+		} else {
+			ajaxConfig('arrival', mode, item_id);
+		}
+	});
+	// 値下げのお知らせ追加・削除
+	$(document).on('click', '.jsBtn-discount', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var ex_param = {};
+		ex_param['price'] = $(this).attr('data-price') ?? 0;
+
+		if (mode == 'Add_PriceChange' || mode == 'PriceChange'){
+		    ex_param['targetPrice'] = $('#modal #discountAlert input[name="discountAlert"]').val() ?? 0;
+			if (ex_param['targetPrice'] == 0 || ex_param['targetPrice'] == '') {
+				discountModalError('1円以上で入力してください');
+			} else if (parseInt(ex_param['targetPrice']) >=  parseInt(ex_param['price'])) {
+				if (item_id.slice(0, 2) == '88') {
+					discountModalError('定価合計価格より小さい金額を入力してください');
+				} else {
+					discountModalError('中古価格より小さい金額を入力してください');
+				}
+			} else if (!ex_param['targetPrice'].match(/^[0-9]+$/)) {
+				discountModalError('半角数字で入力してください');
+			} else {
+				// 「0」埋めの入力は頭削除して登録
+				if (ex_param['targetPrice'].match(/^0+/)) {
+					ex_param['targetPrice'] = new Intl.NumberFormat('ja-JP').format(ex_param['targetPrice']);
+				}
+				ajaxConfig('discount', mode, item_id, ex_param);
+			}
+		} else if(mode == 'Add') {
+		    ex_param['targetPrice'] = $(this).attr('data-target-price') ?? 0;
+			ajaxConfig('discount', mode, item_id, ex_param);
+		} else if(mode == 'Delete') {
+			ajaxConfig('discount', mode, item_id);
+		}
+	});
+	// 最新刊のお知らせ追加・削除
+	$(document).on('click', '.jsBtn-latests', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		ajaxConfig('latests', mode, item_id);
+	});
+
+	// 在庫ない商品一覧表示確認モーダル
+	$(document).on('click', '.jsBtn-cart-modal', function(event){
+		event.preventDefault();
+		$('#modalSetAddCart ul.modalSetAddCart__list').empty();
+		var item_id = $(this).attr('data-item');
+		ajaxConfig('cart', 'RewriteSetModal', item_id);
+	});
+
+	// 値下げのお知らせ価格設定変更モーダル
+	$(document).on('click', '.jsBtn-discount-modal', function(event){
+		event.preventDefault();
+		var item_id = $(this).attr('data-item') ?? '';
+		var price = $(this).attr('data-price') ?? '';
+		var target_price = $(this).attr('data-target-price') ?? '';
+		var modal = $(this).attr('data-modal') ?? '';
+
+		if (modal = 'discountAlert') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-price', price);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-target-price', target_price);
+
+				if (item_id.slice(0, 2) == '88') {
+					$('.modalConfirm__regularPrice').show();
+				}else {
+					$('.modalConfirm__regularPrice').hide();
+				}
+
+				$('#modal #discountAlert #discount-market-price').text(price.toLocaleString());
+				$('#modal #discountAlert #discount-target-price').text(target_price.toLocaleString());
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlert').addClass('-show');
+
+		} else if (modal = 'discountAlertCancel') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlertCancel').addClass('-show');
+		}
+	});
+
+	$(document).on('click', '.js-modalClose', function(event){
+		event.preventDefault();
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+	$(document).on('click', '.modal__overlay', function(event){
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+
+	function initializeDiscountModal () {
+		$('#modal #discountAlert input[name="discountAlert"]').removeClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").hide();
+		$("#modal #discountAlert .modalConfirm__error").text('');
+		$('#modal').removeClass('-show -visible');
+		$('#modal #discountAlert').removeClass('-show');
+		$('#modal #discountAlert input[name="discountAlert"]').val('');
+	}
+
+	function discountModalError (str) {
+		$('#modal #discountAlert input[name="discountAlert"]').addClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").show();
+		$("#modal #discountAlert .modalConfirm__error").text(str);
+	}
+</script><script>
+	function ageVerification(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 773521
+						, 'pageId': 1247
+						, 'revision': 0
+						, 'type': 'ageVerification'
+						, 'mode': 'Agree'
+						, 'itemId': item_id
+					};
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+			// 検索一覧内のボタンをすべて書き換え
+				$('.js-ageverification').each(function() {
+					elmType = $(this).attr('data-type');
+					if (elmType == 'cart') {
+						var btnClass = 'jsBtn-cart';
+					} else if (elmType == 'favorite') {
+						var btnClass = 'jsBtn-favorite';
+					} else if (elmType == 'arrival') {
+						var btnClass = 'jsBtn-arrival';
+					}
+					$(this).addClass(btnClass);
+				});
+				$('.js-ageverification').addClass('ac-click-cv');
+				$('.js-ageverification').removeAttr('data-type');
+				$('.js-ageverification').removeAttr('data-modal');
+				$('.js-ageverification').removeClass('js-modal js-ageverification');
+
+				// モーダルを閉じる
+				$('.modal__inner').removeClass('-show');
+				$('#modal').removeClass('-visible -show');
+				$('body').removeClass('-modalOpen');
+				$('html').removeAttr('data-whatelement data-whatclasses');
+				// モーダルのDOM要素を削除
+				$('[id^="modalAgeVerification"]').remove();
+				// ajaxConfig 実行
+				ajaxConfig(type, mode, item_id, ex_param);
+			} else if (data.status == 'FAILED_AGE_VERIFICATION') {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			} else {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+			$('.ageVerificationBlock__txt--error').text(errMsg);
+			$('.ageVerificationBlock__txt--error').show();
+			return false;
+		});
+	}
+
+	function ajaxConfig(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 773521
+						, 'pageId': 1247
+						, 'revision': 0
+						, 'type': type
+						, 'mode': mode
+						, 'itemId': item_id
+						, 'exParam' : ex_param
+					};
+
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+				// カートに追加
+				if (type == 'cart') {
+					thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-cart-modal[data-item="' + item_id + '"]';
+
+					if (mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocProductSet') {
+							var checkNum = 0;
+							$('.js-allCheckTarget').each(function(){
+								if ($(this).prop('checked')) {
+									checkNum++;
+								}
+							});
+							if (checkNum == 0) {
+								window.location.href = '/cart/';
+							}
+						}
+					}
+
+					if (mode == 'Add' || mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocRankingOfWeekList' || class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSearchResult') {
+							// カートを見るボタンに変更
+							sourceObj = $(thisId);
+							targetObj = $('<a>');
+							sourceObj.removeClass('jsBtn-cart');
+							sourceObj.addClass('-added');
+							targetObj.attr('href', '/cart/');
+							targetObj.text(' カートを見る ');
+							$.each(sourceObj[0].attributes, function() {
+								targetObj.attr(this.name, this.value);
+							});
+							sourceObj.replaceWith(targetObj);
+						} else {
+							$(thisId).attr('href', '/cart/');
+							$(thisId).addClass('-added');
+							$(thisId).text(' カートを見る ');
+							$(thisId).removeClass('jsBtn-cart');
+						}
+					} else if (mode == 'AddSetInStock') {
+						if (class_name == 'BocRankingOfWeekList') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisItemBtnId).addClass('-added');
+							$(thisItemBtnId).text(' カートを見る ');
+							$(thisItemBtnId).attr('data-modal', '');
+							$(thisItemBtnId).attr('data-mode', '');
+							$(thisItemBtnId).off('click');
+							$(thisItemBtnId).attr('href', '/cart/');
+							$(thisItemBtnId).removeClass('jsBtn-cart-modal btn--2l js-modal');
+							// モーダルを閉じる
+							$('.modal__overlay').trigger('click');
+						}
+					} else if (mode == 'RewriteSetModal') {
+						$('#modalSetAddCart .jsBtn-cart').attr('data-item', item_id).attr('data-mode', 'AddSetInStock');
+						$('#modalSetAddCart .modal__title span').text(data.stock_count);
+						for (var i in data.no_stock_items) {
+							var liText = '<li class="modalSetAddCart__item">' + data.no_stock_items[i].item_name + '</li>';
+							$('#modalSetAddCart ul.modalSetAddCart__list').append(liText);
+						}
+						$('#modalSetAddCart .js-modalInnerContent').css('height','500px');
+					}
+				}
+				// お気に入り
+				if (type == 'favorite') {
+					thisId = '.jsBtn-favorite[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $(thisId);
+							displayTooltip(click_ele, type, data.message);
+						}
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite icon-favorite-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite-on icon-favorite-on-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite icon-favorite-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite-on icon-favorite-on-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加済');
+						$(thisId).attr('data-mode', 'Delete');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'delSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Detail');
+						}
+					}
+					if (mode == 'Delete') {
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite-on icon-favorite-on-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite icon-favorite-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite-on icon-favorite-on-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite icon-favorite-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加');
+						$(thisId).attr('data-mode', 'Add');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'addSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Detail');
+						}
+					}
+				}
+				// 入荷お知らせ
+				if (type == 'arrival') {
+					thisId = '.jsBtn-arrival[data-item="' + item_id + '"]';
+					if (mode == 'Add' || mode == 'AddSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							if (data.message) {
+								click_ele = $(thisId);
+								displayTooltip(click_ele, type, data.message);
+							}
+							$(thisId).addClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷お知らせを解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							} else if (mode == 'AddSet') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'DeleteSet');
+							} else if (mode == 'Add') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'delAlertMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'delAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Ranking');
+							}
+						}
+					} else if (mode == 'Delete' || mode == 'DeleteSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId).removeClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷のお知らせを受け取る');
+								$(thisId).attr('data-mode', 'Add');
+							} else if (mode == 'DeleteSet') {
+								$(thisId).text('全巻入荷お知らせ');
+								$(thisId).attr('data-mode', 'AddSet');
+							} else if (mode == 'Delete') {
+								$(thisId).text('入荷お知らせ');
+								$(thisId).attr('data-mode', 'Add');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Ranking');
+							}
+						}
+					}
+				}
+				// 値下げお知らせ
+				if (type == 'discount') {
+					thisId = '.jsBtn-discount[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						}
+					}
+					if (mode == 'PriceChange') {
+						if (class_name == 'BocAlertMailList') {
+							initializeDiscountModal();
+							$('#modal #discountAlert .jsBtn-discount').attr('data-item', '');
+							$('#modal #discountAlert .jsBtn-discount').attr('data-price', '');
+							var thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+							var targetPrice = ex_param['targetPrice'];
+							$(thisItemBtnId).attr('data-target-price', targetPrice);
+							$('#discount-target-price-' + item_id).text(targetPrice.toLocaleString());
+						}
+					}
+					if (mode == 'Add_PriceChange') {
+						if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを登録済');
+							$(thisItemBtnId).attr('data-modal','discountAlertCancel');
+							$(thisItemBtnId).attr('data-mode', 'Delete');
+							// モーダルを閉じる
+							initializeDiscountModal();
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'delSetMailPriceDown_Detail');
+							}
+						}
+					}
+					if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを受け取る');
+							$(thisItemBtnId).attr('data-modal','discountAlert');
+							$(thisItemBtnId).attr('data-mode', 'Add');
+							// モーダルを閉じる
+							$('#modal').removeClass('-show -visible');
+							$('#modal #discountAlertCancel').removeClass('-show');
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'addSetMailPriceDown_Detail');
+							}
+						}
+					}
+				}
+				// 最新刊お知らせ
+				if (type == 'latests') {
+					thisId = '.jsBtn-latests[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを登録済');
+							$(thisId).attr('data-mode', 'Delete');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delNewAlertMail_Detail');
+							}
+						}
+					} else if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを受け取る');
+							$(thisId).attr('data-mode', 'Add');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addNewAlertMail_Detail');
+							}
+						}
+					}
+				}
+			// 在庫なし、もしくは、何らかの原因でカート未追加
+			} else if (data.status == 'NO_STOCK' || data.status == 'FAILED_TO_CART') {
+				if (type == 'cart') {
+					// 他のモーダル開いてたら閉じる
+					if ($('.js-modalInner').hasClass('-show')) {
+						$('#modal').removeClass('-show -visible');
+						$('.js-modalInner').removeClass('-show');
+					}
+					// カートに追加できませんでしたモーダルを開く
+					if($('#modalCartAddStock0').length){
+						if (data.status == 'NO_STOCK' || data.error_code == 'OC456') {
+							$('#modalCartAddStock0 .js-cart-alert').text('在庫がなくなったため、商品をカートに追加できませんでした。再読み込みしてページを更新します');
+						} else {
+							$('#modalCartAddStock0 .js-cart-alert').text('現在お取り扱いのない商品が含まれるため、カートに追加できませんでした。再読み込みしてページを更新します');
+						}
+						$('[data-modal="modalCartAddStock0"]').trigger("click");
+					}
+					// disabledにしたカートボタンを元に戻す
+					if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+						thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+						if($(thisId).attr('data-mode') == 'disabled') {
+							$(thisId).attr('data-mode', mode);
+						}
+					}
+				}
+			// 何らかの原因で処理未完了
+			} else if (data.status == 'NG') {
+				if (type == 'favorite') {
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $('.jsBtn-favorite[data-item="' + item_id + '"]');
+							displayTooltip(click_ele, type, data.message);
+						}
+					}
+				}
+			// 未ログインもしくはAPIエラー
+			} else if (data.status == 'NO_LOGIN' || data.status == 'API_ERROR') {
+				window.location.href = data.url;
+			} else {
+				alert("エラーが発生しました。もう一度設定してください。");
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			alert("エラーが発生しました。");
+		});
+	}
+
+	function displayTooltip(click_ele_selector, btnType, message) {
+		var display_time = 2500;
+		var click_ele = $(click_ele_selector);
+		var original_width = click_ele.outerWidth();
+		// wrap
+		if(!click_ele.parent().hasClass('tipsBalloonArea')){
+			click_ele.each(function() {
+				var self = jQuery(this);
+				var area = jQuery('<div class="tipsBalloonArea"></div>').css({
+					'width': '100%',
+					'margin': self.css('margin'),
+					'margin-bottom': '0'
+				});
+				self.wrap(area);
+			});
+		}
+		// ツールチップHTML
+		var html = '';
+		var isProductPage = !click_ele.hasClass('productItem__favorite');
+		if (isProductPage) {
+			click_ele.parent().addClass('tipsBalloonAreaProductPage');
+			html = '<div class="tipsBalloon tipsBalloon--favorite tipsBalloonFavoriteProductPage"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if (btnType === 'favorite'){
+			html = '<div class="tipsBalloon tipsBalloon--favorite"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if(btnType === 'arrival') {
+			html = '<div class="tipsBalloon tipsBalloon--tail-center"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		}
+		// ツールチップ生成・幅設定・表示
+		var tooltip_ele = $(html).insertBefore(click_ele).hide();
+		if(btnType == 'arrival'){
+			// 入荷お知らせの時のみ調整
+			click_ele.closest('.tipsBalloonArea').each(function() {
+				var self = $(this);
+				if (self.parent().hasClass('cartFloat__btn')) {
+					self.css('position', 'unset');
+				}
+				self.children('.tipsBalloon').css({
+					'min-width': self.children('.jsBtn-arrival').outerWidth(),
+					'bottom': self.children('.jsBtn-arrival').outerHeight() * 1.5,
+					'right': 'unset'
+				});
+			});
+		}
+		tooltip_ele.show();
+		setTimeout(function() {
+			tooltip_ele.fadeOut(200);
+			tooltip_ele.remove();
+			// unwrap
+			if(click_ele.parent().hasClass('tipsBalloonArea')){
+				click_ele.unwrap();
+			}
+		}, display_time);
+	}
+</script>		<script >
+		$(function() {
+			// 商品が入荷した店舗モーダル　絞り込み
+			$('#modalStoreInformation select').change(function() {
+				var prefecture,city;
+				var prefectureObj = $('select[name="prefecture"]');
+				var cityObj = $('select[name="city"]');
+				prefecture = prefectureObj.val();
+				city = cityObj.val();
+
+				if ($(this).attr('name') == 'prefecture'){
+					// 都道府県のselectの場合、市区町村のselectは未選択状態に
+					city = -1;
+				} else if (city != -1){
+					// 市区町村のselectの場合で未選択でない場合、cityから都道府県を取得（都道府県と市区町村の整合性を保つ為）※city={都道府県}-{市区町村}
+					prefecture = city.split('-')[0];
+				}
+
+				// それぞれのselectを選択
+				prefectureObj.val(prefecture);
+				cityObj.val(city);
+
+				// 選択された都道府県の市区町村のselect、それぞれの店舗の表示・非表示を制御
+				prefectureObj.add(cityObj).addClass('-empty');
+				cityObj.find('option').show();
+				$('#modalStoreInformation .modalStoreInformation__list li').show();
+				if (prefecture != -1){
+					prefectureObj.removeClass('-empty');
+					cityObj.find('option:not(.pref_'+prefecture+')').hide();
+					$('#modalStoreInformation .modalStoreInformation__list li:not(.pref_'+prefecture+')').hide();
+				}
+				cityObj.find('option[value="-1"]').show();
+				if (city != -1){
+					cityObj.removeClass('-empty');
+					$('#modalStoreInformation .modalStoreInformation__list li:not(.city_'+ city.split('-')[1] +')').hide();
+				}
+			});
+
+		});
+		</script>
+																
+<script type="application/ld+json">
+{
+	"@context": "https://schema.org/",
+	"@type": "Product",
+	"name": "海に願いを風に祈りをそして君に誓いを スターツ出版文庫",
+	"@id": "https://shopping.bookoff.co.jp/used/0019117467",
+	"url": "https://shopping.bookoff.co.jp/used/0019117467",
+	"image": [
+		"https://content.bookoff.co.jp/goodsimages/LL/001911/0019117467LL.jpg",
+		"https://content.bookoff.co.jp/goodsimages/L/001911/0019117467L.jpg"
+	],
+	"gtin13": "9784813705185",
+	"brand": {
+		"@type": "Brand",
+		"name": "スターツ出版"
+	},
+	"aggregateRating": {
+		"@type": "AggregateRating",
+		"ratingValue": 4.3,
+		"reviewCount": 44
+	},
+	"offers": [
+		{
+			"@type": "Offer",
+			"url": "https://shopping.bookoff.co.jp/used/0019117467",
+			"priceCurrency": "JPY",
+			"price": 495,
+			"itemCondition": "https://schema.org/UsedCondition",
+			"availability": "https://schema.org/InStock"
+		}
+	],
+	"author": [
+		{
+			"@type": "Person",
+			"name": "汐見夏衛"
+		}
+	],
+	"workExample": [
+		{
+			"@type": "Book",
+			"@id": "https://shopping.bookoff.co.jp/used/0019117467",
+			"gtin13": "9784813705185",
+			"bookFormat": "https://schema.org/Paperback",
+			"inLanguage": "ja",
+			"potentialAction": {
+				"@type": "ReadAction",
+				"target": {
+					"@type": "EntryPoint",
+					"urlTemplate": "https://shopping.bookoff.co.jp/cart/",
+					"actionPlatform": [
+						"https://schema.org/DesktopWebPlatform",
+						"https://schema.org/AndroidPlatform",
+						"https://schema.org/IOSPlatform"
+					]
+				}
+			}
+		}
+	]
+}
+</script>
+
+<script src="/library/common/js/detail/notice-display.js"></script>
+
+<script >
+window.headerMenuInfo = window.headerMenuInfo || {
+	pageId: "1247",
+	blockId: "751263"
+};
+</script>
+<script >
+const _boud={};
+</script>
+<meta property="og:site_name" content="ブックオフ公式オンラインストア" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://content.bookoff.co.jp/goodsimages/LL/001911/0019117467LL.jpg" />
+<meta property="og:title" content="海に願いを風に祈りをそして君に誓いを スターツ出版文庫 中古本・書籍 | ブックオフ公式オンラインストア" />
+<meta property="og:description" content="【定価38%OFF】中古価格 495円(税込)【308円おトク！】「海に願いを風に祈りをそして君に誓いを スターツ出版文庫」汐見夏衛(著者)の中古商品ページです。1,800円以上のご注文で送料無料。本(書籍)、漫画(コミック)、CD、DVD、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<meta property="og:url" content="https://shopping.bookoff.co.jp/used/0019117467" />
+<link rel="canonical" href="https://shopping.bookoff.co.jp/used/0019117467">
+
+<script>const _isLogin = false;const _isApp=(function(){const uaList='BookoffApp';const userAgent=navigator.userAgent;return userAgent.includes(uaList)})();</script>
+<link rel="stylesheet" type="text/css" href="/library/init/css/publis4-default.css" />
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>
+<script  src="https://content.bookoff.co.jp/js/roc/csrf_tmp.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/detail.css?rev=20260423" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/detail.js?rev=20260707"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-save.js"></script>
+<link rel="stylesheet" type="text/css" href="" />
+</head>
+<body>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T8MGMLD');</script>
+<!-- End Google Tag Manager -->
+<script src="https://d.adlpo.com/687/2212/js/smartadlpo.js"></script>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8MGMLD" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<noscript><p>このページではjavascriptを使用しています。</p></noscript>
+<div id="page" class="pbPage">
+<div id="headerArea" class="pbHeaderArea">
+	<div id="area1" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7841">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162219">
+						
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162220">
+						<style >
+/* 宅配買取ボタン */
+/* common.css */
+.header__menuSell.sellBtn {
+  display: block;
+  padding: 3px 20px;
+  background-color: #fff000;
+  border: 1px solid #fff000;
+  border-radius: 99px;
+  color: #003894;
+  font-weight: bold;
+  font-size: 16px;
+}
+.header__menuSell {
+  margin-left: 8px;
+}
+/* headerFooter.css */
+.header__menu ul {
+  align-items: center;
+}
+</style>
+<div class="header js-header" id="header">
+  <div class="header__wrap js-headerFixed" style="">
+    <div class="header__inner">
+      <div class="header__logoWrap js-headerLogo">
+
+        <div class="header__logo">
+          <a href="/" class="header__logo__img">
+            <img src="/library/common/images/img-logo.png" alt="BOOKOFF">
+          </a>
+          <div class="header__logo__more">
+            <a class="js-headerLogoBtn" href="/"></a>
+          </div>
+        </div>
+        <div class="header__logoContent js-headerLogoContent">
+          <div class="header__logoContentUserGuide">
+            <a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a>
+          </div>
+          <div class="header__logoContentHeader">
+            <a href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+          </div>
+          <ul>
+            <li>
+              <a href="https://www.bookoff.co.jp/shop/" class="header__linkStore">店舗検索</a>
+            </li>
+            <li>
+              <a href="https://sell.bookoff.co.jp/" class="header__linkPurchase">買取はこちら</a>
+            </li>
+          </ul>
+        </div>
+
+      </div>
+      <nav class="header__navi">
+        <div class="header__naviTop">
+          <div class="header__search js-headerSearch">
+            <div class="header__searchInner">
+              <form name="zsForm" id="zsSearchForm" class="header__searchForm">
+                <input id="zsSearchFormInput" type="search" enterkeyhint="search" name="kw_sn" placeholder="キーワード・品番で検索" autocomplete="off" class="zs-search-input" id="zsSearchFormInput">
+                <span class="header__searchIcon">
+                  <img src="/library/common/svg/search-gray.svg" alt="">
+                </span>
+                <span class="header__searchFormClear">
+                  <img src="/library/common/svg/search-clear.svg" alt="" id="zsSearchClearButton">
+                </span>
+              </form>
+              <div class="header__searchHistory" id="zsHistoryArea">
+                <div class="header__searchHistoryHeading">検索履歴</div>
+                <ul class="js-searchHistory" id="zsSearchHistoryAreaUl">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchHistory -->
+              <div class="header__searchSuggest" id="zsSuggestDiv">
+                <ul class="js-searchSuggest">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchSuggest -->
+            </div>
+          </div>
+          <div class="header__menu">
+                        <ul>
+                <li>
+                  <a class="header__menuSell sellBtn" href="https://sell.bookoff.co.jp/">宅配買取</a>
+                </li>
+                <li>
+                    <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+                </li>
+                <li>
+                    <div class="header__menuAccount js-headerAccount">
+                        <a href="/" class=" js-headerAccountBtn"><img src="/library/common/svg/account.svg" alt=""></a>
+                        <div class="header__menuAccountContent js-headerAccountContent">
+                                                            <div class="header__loginBtn">
+                                    <ul>
+                                        <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+                                        <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+                                    </ul>
+                                </div>
+                                                    </div>
+                    </div>
+                </li>
+                <li>
+                    <a href="/cart" ><img src="/library/common/svg/cart.svg" alt="Cart"></a>
+                </li>
+            </ul>
+                      </div>
+        </div>
+        <div class="header__category js-headerCategory">
+          <ul>
+            <li><a href="/book">書籍</a></li>
+            <li><a href="/comic">コミック</a></li>
+            <li><a href="/cd">CD</a></li>
+            <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+            <li><a href="/game">ゲーム</a></li>
+            <li><a href="/set">セット・まとめ買い</a></li>
+          </ul>
+        </div>
+      </nav>
+
+            <div class="header__naviSp">
+        <div class="header__naviTopSp">
+          <div class="header__menuBtnSp js-spMenuBtn">
+            <img src="/library/common/svg/menu.svg" alt="メニュー">
+          </div>
+          <div class="header__menuSp">
+            <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+            <a href="/cart" ><img src="/library/common/svg/cart.svg" alt=""></a>
+          </div>
+        </div>
+      </div>
+      
+    </div><!-- /header__inner -->
+  </div><!-- /header__wrap -->
+</div><!-- /header js-header -->
+
+<div class="spHeaderMenu js-spHeaderMenu">
+  <div class="spHeaderMenu__close">
+    <span class="js-spHeaderMenuClose" tabindex="0">
+      <img src="/library/common/svg/close.svg" alt="close">
+    </span>
+  </div>
+  <div class="spHeaderMenu__inner">
+
+        <div class="spHeaderMenu__loginBtn">
+        <ul>
+            <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+            <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+        </ul>
+    </div>
+    
+    <div class="spHeaderMenu__heading">カテゴリ</div>
+    <div class="spHeaderMenu__list">
+      <ul>
+        <li><a href="/book">書籍</a></li>
+        <li><a href="/comic">コミック</a></li>
+        <li><a href="/cd">CD</a></li>
+        <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+        <li><a href="/game">ゲーム</a></li>
+        <li><a href="/set">セット・まとめ買い</a></li>
+      </ul>
+    </div>
+    <div class="spHeaderMenu__list">
+      <ul class="spHeaderMenu__listUserGuide">
+      <li><a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a></li>
+      </ul>
+    </div>
+    <a class="spHeaderMenu__linkStore" href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+    <a class="spHeaderMenu__linkSearch" href="https://www.bookoff.co.jp/shop/">店舗検索</a>
+    <a class="spHeaderMenu__linkPurchase" href="https://sell.bookoff.co.jp/">買取はこちら</a>
+  </div>
+</div>
+<div class="spHeaderMenuOverlay js-spHeaderMenuClose">&nbsp;</div>
+<script >
+$(document).ready(function () {
+	$('.logout-link').on('click', function() {
+		const logoutUrl="https://my.bookoff.co.jp/logout";
+		ajax_jquery(logoutUrl)
+		.done(function() {
+			const loginUrl="https://my.bookoff.co.jp/login";
+			window.location.href=loginUrl;
+		})
+		.fail(function(e) {
+			let errUrl="/err/404";
+			switch(true){
+				case e.status==502:
+					errUrl="/err/408";
+					break;
+				case e.status>=500:
+					errUrl="/err/500";
+					break;
+			}
+			window.location.href=errUrl;
+		});
+	});
+});
+
+  // point
+  window.loadPoint = function() {
+    const send_data = {
+      "className": "BocHeaderMenu",
+      "blockId": window.headerMenuInfo.blockId,
+      "pageId": window.headerMenuInfo.pageId,
+      "revision": 0,
+      "type": "loadPoint"
+    };
+    ajax_jquery({
+      url: "/view_interface.php",
+      type: "POST",
+      data: send_data,
+      dataType: "json"
+    })
+    .done(function(data, textStatus, jqXHR) {
+      document.querySelectorAll("div.js-headerAccountContent .header__point,div.js-spHeaderMenu .spHeaderMenu__point")
+        .forEach(el => {
+          el.innerHTML = (data.point || "-") + "<span>P</span>";
+        });
+    });
+  }
+</script>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7842">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock145581">
+						<div class="headerMessage">
+    	<div class="headerMessage__text">1,800円以上の注文で<span class="headerMessage__textDecoration">送料無料</span></div>
+  </div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div><div id="areaWrapper1" class="pbAreaWrapper1"><div id="areaWrapper2" class="pbAreaWrapper2"><div id="mainArea" class="pbMainArea">
+	<div id="area0" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock259237">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock435867">
+						<div class="commonBnr">
+  <div class="commonBnr__inner">
+          <a href="https://shopping.bookoff.co.jp/campaign/19th"  class="commonBnr__link ">
+      <figure class="commonBnr__fig">
+                    <img src="https://content.bookoff.co.jp/assets/images/1200x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="2400" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forPc">
+                            <img src="https://content.bookoff.co.jp/assets/images/375x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="750" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forSp">
+              </figure>
+    </a>
+        </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock275661">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock314591">
+						<div class="campaign campaign--for2col forPc">
+  <div class="campaign__inner">
+          <a class="campaign__items" href="https://shopping.bookoff.co.jp/campaign/20260710-sale">
+      <div class="campaign__item">
+                  <span class="campaign__item__tag infoicon-sale">セール</span>
+              </div>
+      <div class="campaign__item">
+        <span class="campaign__item__ttl"> CD&DVD・ブルーレイSALE 2026/07/23(木)23:59まで</span>
+              </div>
+    </a>
+                                                                                                                                                  </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="mainContent pbNested pbNestedWrapper "  id="pbBlock80098">
+								<div class="pbNested " >
+			<div class="mainContent__inner pbNested pbNestedWrapper "  id="pbBlock80099">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock132785">
+						<div class="breadcrumbs">
+  <ol class="breadcrumbs__list">
+                  <li class="breadcrumbs__item">
+          <a href="/" class="link">トップ</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/12" class="link">書籍</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/1225" class="link">小説・エッセイ・ノンフィクション（文庫）</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/122511" class="link">ライト文芸</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/12251103" class="link">さ行の著者</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          海に願いを風に祈りをそして君に誓いを
+        </li>
+            </ol>
+</div>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock80101">
+						<style >
+#promotionBannerlimitedFixedPc {
+  padding: 8px 0 0;
+}
+</style>
+
+    <div class="mainContent__product">
+  <div class="mainContent__col">
+    <div class="productInformation">
+      <section class="productInformation__inner">
+        <figure class="productInformation__image forPc">
+          <span><img src="https://content.bookoff.co.jp/goodsimages/LL/001911/0019117467LL.jpg" alt="海に願いを風に祈りをそして君に誓いを スターツ出版文庫" class="js-orientation -pt"></span>
+        </figure>
+        <div class="productInformation__detail">
+        <div class="productInformation__tagList--genre">
+          <div class="productInformation__tagList">
+            <ul class="tagList">
+              <li class="tag">中古</li>
+              <li class="tag tag--pickedUpStore">店舗受取可</li>
+            </ul>
+          </div>
+          <ul class="productInformation__genre">
+            <li class="productInformation__genreItem productInformation__genreItem--category">書籍</li>
+            <li class="productInformation__genreItem">文庫</li>
+            <li class="productInformation__genreItem display-genreCode"><div class="displayLabelBox displayLabelBox--genreCode">1225-11-03</div></li>
+          </ul>
+        </div>
+          <h1 class="productInformation__title">海に願いを風に祈りをそして君に誓いを スターツ出版文庫</h1>
+          <p class="productInformation__author">
+            <a href="/search/author/%E6%B1%90%E8%A6%8B%E5%A4%8F%E8%A1%9B">汐見夏衛</a><span>(著者)</span>
+          </p>
+          <div class="review">
+            <div class="review__individual">
+              <div class="review__star">
+                <ul class="review__star__list--small">
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_white_small icon-star_yellow_small-dims"></li>
+                </ul>
+                <span class="review__counter"><a href="#anc-review" class="js-anchor">44件</a></span>
+              </div>
+            </div>
+          </div>
+          <p class="productInformation__favorite forSp">
+            <span class="ProductInformationFavoriteD">追加する</span>
+            <a href="/" class="icon-favorite icon-favorite-dims jsBtn-favorite ac-click-cv" data-cv-name="addBookmark_Detail" data-mode="Add" data-item="0019117467"></a>
+            <span class="ProductInformationFavoriteJ">に追加する</span>
+          </p>
+          <figure class="productInformation__image forSp">
+            <span><img src="https://content.bookoff.co.jp/goodsimages/LL/001911/0019117467LL.jpg" alt="海に願いを風に祈りをそして君に誓いを スターツ出版文庫" class="js-orientation -pt"></span>
+          </figure>
+          <div class="productInformation__Btn">
+            <a href="/used/0019117467" class="productInformation__Btn__used -active">中古</a>
+            <a href="/new/0019117467" class="productInformation__Btn__new ">新品</a>
+          </div>
+          <p class="productInformation__regularPrice">定価 ¥803</p>
+          <p class="productInformation__price">
+            <span class="productInformation__price--large"> 495<span class="productItem__moneyUnit">円</span></span>
+
+            <small>定価より308円（38%）おトク</small>
+          </p>
+          <p class="productInformation__point">獲得ポイント<span>4P</span></p>
+          <div class="productInformation__spCart forSp">
+            <ul class="productInformation__btns">
+              <li class="js-cartFloatTargetSP">
+                  <a href="/" class="btn btn--orange jsBtn-cart ac-click-cv" data-cv-name="oldInCart_Detail" data-mode="Add" data-item="0019117467" data-stock="used">
+                    カートに追加
+                  </a>
+              </li>
+            </ul>
+          </div>
+          <p class="productInformation__stock">
+            <span class="productInformation__stock__alert">在庫あり</span>
+          </p>
+          <p class="productInformation__stock"> 発送時期 1～5日以内に発送 </p>
+          <div class="forSp">
+          <div class="storeService storeService--compact">
+            <div class="storeService__compatible">
+              <div class="storeService__compatible__text">
+                <p class="storeService__compatible__text--title">店舗受取サービス対応商品<span class="storeService__compatible__text--title-color">【送料無料】</span></p>
+                <p class="storeService__compatible__schedule">店舗到着予定：7/27(月)～8/1(土)</p>
+              </div>
+            </div>
+          </div>
+          </div>
+          <div class="productInformation__spCart forSp">
+              <p class="js-discountAlertItem">
+                <a href="/" class="productInformation__discount js-discountAlertModal jsBtn-discount-modal ac-click-cv" data-cv-name="addPriceDownMail_Detail" data-modal="discountAlert" data-item="0019117467">
+                  <span class="icon-mail icon-mail-dims"></span>
+                  <span>値下げのお知らせを受け取る</span>
+                </a>
+              </p>
+          </div>
+          <ul class="productInformation__supplement">
+            <li><a href="https://support-online.bookoff.co.jp/answer/6583dca614cd35d38e3d0cfe" class="link link--arrow" target="_blank">中古商品の品質・付属品について</a></li>
+            <li><a href="https://support-online.bookoff.co.jp/answer/658553fc129d451df9fefb83" class="link link--arrow" target="_blank">返品について</a></li>
+          </ul>
+        </div>
+      </section><!-- /productOverview__inner -->
+    </div><!-- /productOverview -->
+    <div id="js-breadcrumbsDestination-bottom" class="breadcrumbsDestination-bottom"></div>
+    <div id="js-recommendDestination" class="recommendDestination"></div>
+    <div class="forSp">
+        <div class="storeService">
+          <div class="storeService__compatible">
+            <figure class="storeService__compatible__image">
+              <span><img src="/library/dummy/img-pickUp01.jpg" alt=""></span>
+            </figure>
+            <div class="storeService__compatible__text">
+              <p class="storeService__compatible__text--title">店舗受取サービス対応商品</p>
+              <p class="storeService__compatible__text--read">店舗受取なら1点でも<span>送料無料！</span></p>
+            </div>
+          </div>
+          <div class="storeService__plan">
+            <p class="storeService__plan--title">店舗到着予定</p>
+            <p class="storeService__plan--date">7/27(月)～8/1(土)</p>
+          </div>
+        </div>
+        <div class="promotionBanner">
+          <div id="promotionBannerlimitedFixedMb">
+            <div class="promotionBannerDetail">
+              <picture>
+                <source media="(max-width:767px)" srcset="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-750-120.png" width="750" height="120">
+                <img src="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-750-120.png" alt="" width="750" height="120">
+              </picture>
+            </div>
+          </div>
+        </div>
+    </div>
+    <div id="js-breadcrumbsDestination-top" class="breadcrumbsDestination-top"></div>
+    <div class="productDetail">
+      <section class="productDetail__inner">
+        <h2 class="productDetail__ttl">商品詳細</h2>
+        <div class="productDetail__tableWrap">
+          <table class="productDetail__table">
+            <tbody>
+              <tr>
+                <th>内容紹介</th>
+                <td></td>
+              </tr>
+              <tr>
+                <th>販売会社／発売会社</th>
+                <td id="js-company">スターツ出版</td>
+              </tr>
+              <tr>
+                <th>発売年月日</th>
+                <td>2018/08/28
+                  <p class="productDetail__link">
+                    <a href="https://support-online.bookoff.co.jp/answer/6583dca614cd35d38e3d0cfe/" target="_blank">改訂版・発行年月日について</a>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>JAN</th>
+                <td>9784813705185</td>
+              </tr>
+            </tbody>
+          </table>
+        </div><!-- /productDetail__tableWrap -->
+      </section><!-- /productDetail__inner -->
+    </div><!-- /productDetail -->
+  </div><!-- /mainContent__col -->
+  <div class="mainContent__col forPc">
+    <div class="productPurchase">
+      <div class="productPurchase__inner">
+        <ul class="productPurchase__btns">
+          <li class="js-cartFloatTargetPC">
+              <a href="/" class="btn btn--orange jsBtn-cart ac-click-cv" data-cv-name="oldInCart_Detail" data-mode="Add" data-item="0019117467" data-stock="used">
+                カートに追加する
+              </a>
+          </li>
+          <li>
+          </li>
+          <li>
+            <a href="/" class="productPurchase__favorite jsBtn-favorite ac-click-cv" data-cv-name="addBookmark_Detail" data-mode="Add" data-item="0019117467">
+              <span class="icon-favorite icon-favorite-dims"></span>
+              <span class="productPurchase__favoriteTxt">お気に入り追加</span>
+            </a>
+          </li>
+            <li class="js-discountAlertItem">
+              <a href="/" class="productPurchase__discount js-discountAlertModal jsBtn-discount-modal ac-click-cv" data-cv-name="addPriceDownMail_Detail" data-modal="discountAlert" data-item="0019117467">
+                <span class="icon-mail icon-mail-dims"></span>
+                <span>値下げのお知らせを受け取る</span>
+              </a>
+            </li>
+        </ul>
+        <div id="promotionBannerlimitedFixedPc"><img src="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-680-160.png" width="282" height="60"></div>
+        <div class="storeService">
+          <div class="storeService__compatible">
+            <figure class="storeService__compatible__image">
+              <span><img src="/library/dummy/img-pickUp01.jpg" alt=""></span>
+            </figure>
+            <div class="storeService__compatible__text">
+              <p class="storeService__compatible__text--title">店舗受取サービス<br>対応商品</p>
+            </div>
+          </div>
+          <p class="storeService__compatible__text--read">店舗受取なら1点でも<span>送料無料！</span><br>さらに<span>お買い物で使えるポイント</span>がたまる</p>
+          <div class="storeService__plan">
+            <p class="storeService__plan--title">店舗到着予定</p>
+            <p class="storeService__plan--date">7/27(月)～8/1(土)</p>
+          </div>
+        </div>
+      </div><!-- /productPurchase__inner -->
+    </div><!-- /productPurchase -->
+  </div><!-- /mainContent__col -->
+</div>
+<input type="hidden" class="js-modal" data-modal="modalCartAddStock0">
+
+<div id="modal" class="modal">
+  <div class="modal__overlay"></div>
+  <div id="discountAlert" class="modal__dialog" tabindex="0">
+    <div class="modalContent">
+      <div class="modalConfirm">
+        <p class="modalConfirm__ttl">値下げのお知らせメールを受け取る価格を設定してください</p>
+        <div class="modalConfirm__row">
+          <div class="modalConfirm__col">
+            <input type="number" class="modalConfirm__textbox" placeholder="設定価格を入力" name="discountAlert" onkeydown="return event.key !== 'e' && event.key !== 'E' && event.key !== '+' && event.key !== '-' && event.key !== '.'" onInput="checkForm(this)">
+          </div>
+          <p class="modalConfirm__unit">円以下</p>
+          <p class="modalConfirm__error" style="display:none;"></p>
+        </div>
+        <ul class="modalConfirm__btnWrap">
+          <li class="modalConfirm__btn">
+            <a href="/" class="modalConfirm__no js-modalClose" tabindex="0">
+              キャンセル
+            </a>
+          </li>
+          <li class="modalConfirm__btn">
+            <a href="/" class="modalConfirm__yes jsBtn-discount" tabindex="0" data-mode="Add_PriceChange" data-item="0019117467" data-price="495">
+              設定する
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div id="discountAlertCancel" class="modal__dialog" tabindex="0">
+    <div class="modalContent">
+      <div class="modalConfirm">
+        <p class="modalConfirm__ttl">値下げのお知らせ登録を解除します</p>
+        <ul class="modalConfirm__btnWrap">
+          <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+          <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes jsBtn-discount" data-mode="Delete" data-item="0019117467">解除する</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div id="modalStoreInformation" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalStoreInformation">
+        <ul class="modalStoreInformation__genre">
+          <li class="modalStoreInformation__genreItem modalStoreInformation__genreItem--category">書籍</li>
+          <li class="modalStoreInformation__genreItem">文庫</li>
+        </ul>
+        <p class="modalStoreInformation__title">海に願いを風に祈りをそして君に誓いを</p>
+        <div class="modalStoreInformation__body js-modalInnerContent">
+          <p class="modalStoreInformation__heading">商品が入荷した店舗：0店</p>
+		  <p class="modalStoreInformation__txt">店頭で購入可能な商品の入荷情報となります</p>
+          <p class="modalStoreInformation__note">ご来店の際には売り切れの場合もございます</p>
+          <p class="modalStoreInformation__note">オンラインストア上の価格と店頭価格は異なります</p>
+          <p class="modalStoreInformation__note">お電話やお問い合わせフォームでの在庫確認、お客様宅への発送やお取り置き・お取り寄せは行っておりません</p>
+          <div class="modalStoreInformation__storeSearch">
+            <div class="modalStoreInformation__select">
+              <select name="prefecture" class="modalStoreInformation__selectTag -empty">
+                <option value="-1" selected="">都道府県を選択</option>
+                <option value="1">北海道(0)</option>
+                <option value="2">青森県(0)</option>
+                <option value="3">岩手県(0)</option>
+                <option value="4">宮城県(0)</option>
+                <option value="5">秋田県(0)</option>
+                <option value="6">山形県(0)</option>
+                <option value="7">福島県(0)</option>
+                <option value="8">茨城県(0)</option>
+                <option value="9">栃木県(0)</option>
+                <option value="10">群馬県(0)</option>
+                <option value="11">埼玉県(0)</option>
+                <option value="12">千葉県(0)</option>
+                <option value="13">東京都(0)</option>
+                <option value="14">神奈川県(0)</option>
+                <option value="15">新潟県(0)</option>
+                <option value="16">富山県(0)</option>
+                <option value="17">石川県(0)</option>
+                <option value="18">福井県(0)</option>
+                <option value="19">山梨県(0)</option>
+                <option value="20">長野県(0)</option>
+                <option value="21">岐阜県(0)</option>
+                <option value="22">静岡県(0)</option>
+                <option value="23">愛知県(0)</option>
+                <option value="24">三重県(0)</option>
+                <option value="25">滋賀県(0)</option>
+                <option value="26">京都府(0)</option>
+                <option value="27">大阪府(0)</option>
+                <option value="28">兵庫県(0)</option>
+                <option value="29">奈良県(0)</option>
+                <option value="30">和歌山県(0)</option>
+                <option value="31">鳥取県(0)</option>
+                <option value="32">島根県(0)</option>
+                <option value="33">岡山県(0)</option>
+                <option value="34">広島県(0)</option>
+                <option value="35">山口県(0)</option>
+                <option value="36">徳島県(0)</option>
+                <option value="37">香川県(0)</option>
+                <option value="38">愛媛県(0)</option>
+                <option value="39">高知県(0)</option>
+                <option value="40">福岡県(0)</option>
+                <option value="41">佐賀県(0)</option>
+                <option value="42">長崎県(0)</option>
+                <option value="43">熊本県(0)</option>
+                <option value="44">大分県(0)</option>
+                <option value="45">宮崎県(0)</option>
+                <option value="46">鹿児島県(0)</option>
+                <option value="47">沖縄県(0)</option>
+              </select>
+            </div>
+            <div class="modalStoreInformation__select">
+              <select name="city" class="modalStoreInformation__selectTag -empty">
+                <option value="-1" selected="">市区町村を選択</option>
+              </select>
+            </div>
+          </div>
+          <ul class="modalStoreInformation__list">
+          </ul>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose" tabindex="0"><img src="/library/common/svg/close.svg" alt="close"></div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div>
+
+  <div id="modalCartAddStock0" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">カートに追加できませんでした</p>
+        </div>
+        <div class="modalItems">
+          <p class="modalItems__note">
+            <span class="icon-info icon-info-dims"></span>
+            <span class="js-cart-alert"></span>
+          </p>
+        </div>
+      </div>
+      <ul class="modal__confirm modal__confirm--box-shadow-none">
+        <li class="modal__confirmBtn">
+          <a href="/" class="modal__no js-modalClose" tabindex="0">キャンセル</a>
+        </li>
+        <li class="modal__confirmBtn">
+          <a href="/" class="modal__yes js-refreshPage">OK</a>
+        </li>
+      </ul>
+      <div class="modal__close js-modalClose" tabindex="0">
+        <img src="/library/common/svg/close.svg" alt="close">
+      </div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp">
+      <span></span>
+    </div>
+  </div>
+
+  <div id="modalPreviousPrice" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <p class="modal__title">値下げ前価格について</p>
+      <div class="modalPreviousPrice js-modalInnerContent">
+        <div class="modalPreviousPrice__inner">
+          <p class="modalPreviousPrice__txt">
+            <span>本価格は現中古販売価格の「値下げ前価格」となります。<br> 直近約1か月間、値下げ前価格での販売実績があるものだけ表示しております。</span>
+          </p>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose"><img src="/library/common/svg/close.svg" alt="close"></div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div><!-- modalPreviousPrice -->
+
+</div>
+<div class="cartFloat js-cartFloat">
+  <div id="promotionBannerlimitedFloating"></div>
+  <div class="cartFloat__head">
+    <p class="cartFloat__name">海に願いを風に祈りをそして君に誓いを</p>
+    <p class="cartFloat__price">¥495</p>
+  </div>
+  <div class="cartFloat__body">
+    <p class="cartFloat__stock">
+在庫あり
+    </p>
+    <p class="cartFloat__btn">
+        <a href="/" class="btn btn--orange jsBtn-cart ac-click-cv" data-cv-name="oldInCart_Detail" data-mode="Add" data-item="0019117467" data-stock="used">
+          <span class="forPc">カートに追加する</span><span class="forSp">カートにいれる</span>
+        </a>
+    </p>
+  </div>
+</div>
+
+<script>
+function checkForm($this) {
+  let str = $this.value;
+  while (str.match(/[^A-Z^a-z\d\-]/)) {
+      str = str.replace(/[^0-9]/, "");
+  }
+  $this.value = str;
+}
+</script>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock80102">
+						<div class="mainContent__product">
+  <div class="mainContent__col">
+    <div class="review">
+      <section class="review__inner">
+        <h2 class="information__ttl" id="anc-review">商品レビュー</h2>
+        <div class="review__totalEvaluation">
+          <div class="review__star">
+            <div class="review__star__inner">
+              <ul class="review__star__list">
+                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_white_large icon-star_white_large-dims"></li>
+                                              </ul>
+              <p class="review__totalEvaluation__score">4.3</p>
+            </div>
+            <p class="review__totalEvaluation__number">44件のお客様レビュー</p>
+          </div>
+          <p class="btnWrap">
+            <a href="/review/post/0019117467" class="btn btn--s" rel="nofollow">レビューを投稿</a>
+          </p>
+        </div>
+        <div class="review__individualWrap">
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2026/06/30</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                嘘でしょ？嘘だと言って欲しいわ。悲しい。本当にショックを受けすぎて頁を閉じた。瞬間何故こうなるん？という思いが溢れ9章から最終章が衝撃的過ぎて呆然としながら終わりを迎えた。悲し過ぎて切なすぎてどうしていいかわかりません。
+                              </p>
+                                        </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2026/06/18</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                本当に、感情の置き場がなくなった。
+泣きすぎてまた2回目読めるかは分からないけど
+ずっと忘れないで隣に置いておきたい小説。
+                              </p>
+                                        </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2026/03/23</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                映画化された｢あの花が咲く丘で、君とまた出会えたら｣を読んでこの作家さんを知り、他の作品も読みたいと思い｢明日の世界が君に優しくありますように｣を読み、そしてこの作品に出てくる主人公の真波と漣をどこまでも優しく見守るユウさん(優海)とナギサさん(凪砂)の事を描いた作品との事で読ん...
+                              </p>
+                                          <div class="review__individual__continueLink">
+                <a class="js-showmore-btn" tabindex="0">表示する</a>
+              </div>
+              <div class="review__individual__text--hide">
+                                                <p>映画化された｢あの花が咲く丘で、君とまた出会えたら｣を読んでこの作家さんを知り、他の作品も読みたいと思い｢明日の世界が君に優しくありますように｣を読み、そしてこの作品に出てくる主人公の真波と漣をどこまでも優しく見守るユウさん(優海)とナギサさん(凪砂)の事を描いた作品との事で読んでみました。
+なんとも悲しい少しSFのお話で、ユウさんが何故こんなに優しい青年に育ったのかが分かる感動作でした。
+更に最後の方で、凪砂のお祖母さんのタエさんが、｢あの花が咲く丘で、…｣の主人公の百合(福原遥)のお世話していた食堂のタエさん(松坂慶子)だった事に気付かされ、何とも言えない気持ちになりました。
+この3作品の密かな繋がりに感銘を受け、更に他の作品も読みたいと思わされました。</p>
+              </div>
+                          </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                  </div>
+        <p class="review__allshowLink"><a href="/review/detail/0019117467">すべてのレビューを見る</a></p>
+      </section><!-- /review__inner -->
+    </div>
+  </div>
+</div>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock481102">
+						<div class="hashtag">
+  <div class="hashtag__inner">
+    <h2 class="hashtag__heading">関連ワードから探す</h2>
+    <ul class="hashtagList">
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E9%9D%A2%E7%99%BD%E3%81%84" class="hashtagBtn hashtagBtn--link">面白い</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%A5%BD%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">楽しい</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%84%AA%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">優しい</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%84%9F%E5%8B%95" class="hashtagBtn hashtagBtn--link">感動</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%A5%B3%E3%81%AE%E5%AD%90" class="hashtagBtn hashtagBtn--link">女の子</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%B9%B8%E3%81%9B" class="hashtagBtn hashtagBtn--link">幸せ</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E9%AB%98%E6%A0%A1%E7%94%9F" class="hashtagBtn hashtagBtn--link">高校生</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E7%94%9F%E3%81%8D%E6%96%B9" class="hashtagBtn hashtagBtn--link">生き方</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%88%87%E3%81%AA%E3%81%84" class="hashtagBtn hashtagBtn--link">切ない</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%A1%9D%E6%92%83" class="hashtagBtn hashtagBtn--link">衝撃</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%B9%BC%E3%81%AA%E3%81%98%E3%81%BF" class="hashtagBtn hashtagBtn--link">幼なじみ</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%82%AB%E3%83%83%E3%83%97%E3%83%AB" class="hashtagBtn hashtagBtn--link">カップル</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%82%AD%E3%83%A9%E3%82%AD%E3%83%A9" class="hashtagBtn hashtagBtn--link">キラキラ</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%AE%B6%E6%97%8F" class="hashtagBtn hashtagBtn--link">家族</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%84%9B%E6%83%85" class="hashtagBtn hashtagBtn--link">愛情</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%87%90%E3%81%8B%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">懐かしい</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E7%94%B0%E8%88%8E" class="hashtagBtn hashtagBtn--link">田舎</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%A4%A7%E3%83%92%E3%83%83%E3%83%88%E4%BD%9C" class="hashtagBtn hashtagBtn--link">大ヒット作</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%8B%A6%E6%82%A9" class="hashtagBtn hashtagBtn--link">苦悩</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%A6%9A%E6%82%9F" class="hashtagBtn hashtagBtn--link">覚悟</a></li>
+        </ul>
+  </div>
+</div>
+<script>
+	$(document).ready(function() {
+		// ハッシュタグリンクへのquery_string追加
+		var arrQuery = [];
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		var hashtagQuery = makeQueryString(arrQuery);
+		$('.hashtagBtn--link').each(function () {
+			var hashtagUrl = $(this).attr('href') + hashtagQuery;
+			$(this).attr('href', hashtagUrl);
+		});
+	});
+
+	function makeQueryString(arrQuery) {
+		// query_string生成
+		if (arrQuery.length > 0) {
+				var queryString = $.map(arrQuery, function(param) {
+						return encodeURIComponent(param.name) + '=' + encodeURIComponent(param.value);
+				}).join('&');
+				return '?' + queryString;
+		} else {
+			return '';
+		}
+	}
+</script>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock397940">
+								<div class="pbNested " id="js-recommendMove">
+			<div class="pbNested pbNestedWrapper "  id="pbBlock716281">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">関連商品</h2>
+    </div>
+    <div id="js-recRelation" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="211" data-id="detail_relation" data-id-mb="detail_relation-mb" data-id-pc="detail_relation-pc" data-item-id="current" data-genre="genreCode2" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock716282">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">同じジャンルのおすすめ商品</h2>
+    </div>
+    <div id="js-recGenre" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="602" data-id="detail_genre" data-id-mb="detail_genre-mb" data-id-pc="detail_genre-pc" data-item-id="current" data-genre="genreCode2" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock713633">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock713634">
+						<section class="itemsContainer itemsContainer--itemViewHistory js-itemViewHistory">
+  <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop js-displayItemViewHistoryHeader -hidden">
+  <h2 class="itemsContainer__header">最近チェックした商品</h2>
+  <div class="itemsContainer__textBox itemsContainer__textBox--deleteHistory js-delItemViewHistoryArea"><button class="link itemsContainer__actionButton js-delItemViewHistory"><span>履歴を消す</span></button></div> 
+  </div>
+  <div class="itemsContainer__wrapper">
+    <div class="itemsContainer__main splide js-displayItemViewHistory" id="ItemViewHistory">
+    </div>
+    <div class="itemsContainer__textBox itemsContainer__textBox--removeHistory js-undoItemViewHistoryArea -hidden">
+      <div class="itemsContainer__text">履歴をすべて削除しました</div>
+      <div class="itemsContainer__actionBox">
+        <button class="itemsContainer__actionButton js-undoItemViewHistory"><span>もとにもどす</span></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="setProductList pbNested pbNestedWrapper "  id="pbBlock662196">
+								<div class="pbNested " id="js-setProductList">
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock507931">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock505399">
+						<div class="naviElement">
+
+  <!-- スマホで見るボタン start -->
+  <div class="js-modal js-modal-navi boViewSpBtn" data-modal="modal2dcode" data-btn-name="お手持ちのスマホで確認する">
+    お手持ちのスマホで確認する
+  </div>
+  <!-- スマホで見るボタン end -->
+
+
+  <!-- 2dコードモーダル start -->
+  <div id="modal2dcode" class="modal__inner js-modalInner">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">お手持ちのスマホでスキャン</p>
+        </div>
+        <div class="modalItems js-modalInnerContent">
+          <div id="2dcode" class="modalItems__2dcode"></div>
+          <div class="modalItems__text">お近くのスタッフに、表示されたスマホ画面を</div>
+          <div class="modalItems__text">みせていただければ商品をお探しいたします。</div>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose">
+        <img src="/library/common/svg/close.svg" alt="close" width="24" height="24">
+      </div>
+    </div>
+  </div>
+  <!-- 2dコードモーダル end -->
+
+
+  <!-- スマホ画面モーダル -->
+  <div class="modalSpNavi">
+    <div class="modalSpNavi__inner">
+      <div class="modalSpNavi__overlay"></div>
+      <div class="modalSpNavilItems">
+        <div class="modalSpNavilItem__close">
+          <img src="/library/common/svg/close.svg" alt="close" width="24" height="24">
+        </div>
+        <div class="modalSpNavilItem__text modal__title modalSpNavilItem__text--main">ブックオフナビをご利用いただき ありがとうございます</div>
+        <div class="modalSpNavilItem__text">お近くのスタッフにこの商品詳細画面をお見せください。400万点の在庫の中から商品をお探しいたします。</div>
+        <div class="modalSpNavilItem__text modalSpNavilItem__text--alert">※画面に表示されている価格はお取り寄せ時の価格となります。</div>
+      </div>
+    </div>
+  </div>
+  <!-- スマホ画面モーダル -->
+
+
+  <!-- 1dバーコード start -->
+  <div class="barcodeWrap">
+    <img id="barcode" class="barcode__image" width="250" height="38">
+    <div class="barcode__text"></div>
+  </div>
+  <!-- 1dバーコード end -->
+</div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div></div><div id="footerArea" class="pbFooterArea">
+	<div id="area4" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7844">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock161678">
+						<footer class="footer" id="footer">
+    <div class="footer__wrap">
+      <div class="footer__inner">
+        <div class="footer__navi">
+          <p class="footer__pageTop">
+            <a href="#" class="footer__pageTopBtn js-pagetop">
+              <img src="/library/common/images/img-footer-arrow.svg" alt="ページトップへ戻る">
+            </a>
+          </p>
+          <ul>
+            <li class="footer__item footer__item--first"><a href="https://support-online.bookoff.co.jp" class="footer__link">ヘルプ・ご質問</a>
+              <ul>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/64363fbd97ebd8c6491e0a07" class="footer__link">配送料について</a></li>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/65852e8cd29784dd07b9bdc7" class="footer__link">支払い方法について</a></li>
+              </ul>
+            </li>
+            <li class="footer__item"><a href="https://shopping.bookoff.co.jp/service/mail" class="footer__link">メールサービス</a></li>
+            <li class="footer__item"><a href="https://regist11.smp.ne.jp/regist/is?SMPFORM=ofn-latbq-651b190782b21aa1eaa0162e484e578c" class="footer__link">ご意見・ご感想</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer__wrap footer__wrap--bottom">
+      <div class="footer__inner">
+        <ul class="footer__sns">
+          <li>
+            <a href="https://www.facebook.com/%E3%83%96%E3%83%83%E3%82%AF%E3%82%AA%E3%83%95%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3bookoffonline-166258740189848/" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-fb.svg" alt="Facebook">
+            </a>
+          </li>
+          <li>
+            <a href="https://x.com/bookoffonline" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-x.svg" alt="X">
+            </a>
+          </li>
+          <li>
+            <a href="https://page.line.me/iau9918q" class="footer__snsBtn">
+              <img src="/library/common/images/img-footer-line.svg" alt="LINE">
+            </a>
+          </li>
+        </ul>
+        <div class="footer__bottomNavi">
+          <ul>
+           <li><a href="https://www.bookoff.co.jp/" class="footer__bottomLlink" target="_blank">BOOKOFF公式サイト</a></li>
+           <li><a href="https://www.bookoffgroup.co.jp/corporate/business.html" class="footer__bottomLlink" target="_blank">企業情報</a></li>
+           <li><a href="https://member.bookoff.co.jp/bo-member-content/contract/" class="footer__bottomLlink" target="_blank">BOOKOFF会員サービス利用規約</a></li>
+           <li><a href="https://shopping.bookoff.co.jp/policies/terms" class="footer__bottomLlink">利用規約</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/privacy.html" class="footer__bottomLlink" target="_blank">個人情報保護方針</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/socialmedia.html" class="footer__bottomLlink" target="_blank">ソーシャルメディアポリシー</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/customerharassment.html" class="footer__bottomLlink" target="_blank">カスタマーハラスメントに対する基本方針</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/regulatory-disclosure" class="footer__bottomLlink">特定商取引法に基づく表示</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/external-transmission" class="footer__bottomLlink">利用者情報の外部送信について</a></li>
+          <li><a href="https://www.bookoffgroup.co.jp/" class="footer__bottomLlink" target="_blank">ブックオフグループホールディングス株式会社</a></li>
+         </ul>
+        </div>
+        <div class="footer__bottom">
+          <div class="footer__text">
+            <p> ブックオフコーポレーション株式会社<br> 古物商許可番号 第452760001146号 神奈川県公安委員会許可 </p>
+          </div>
+          <div class="footer__copyright"> Copyright(C)BOOKOFF CORPORATION LTD.<br class="forSp">All Rights Reserved. </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock209621">
+						
+<link rel="stylesheet" href="/library/common/css/appli/app-hide-common.css">
+
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock7845">
+						<div id="modal" class="modal">
+      <div class="modal__overlay"></div>
+      <div id="discountAlert" class="modal__dialog" tabindex="0">
+        <div class="modalContent">
+          <div class="modalConfirm">
+            <p class="modalConfirm__ttl">値下げのお知らせメールを受け取る価格を設定してください</p>
+            <div class="modalConfirm__row">
+              <div class="modalConfirm__col">
+                <input type="text" class="modalConfirm__textbox" placeholder="設定価格を入力" name="discountAlert">
+              </div>
+              <p class="modalConfirm__unit">円以下</p>
+            </div>
+            <ul class="modalConfirm__btnWrap">
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes js-discountAlertSubmit" tabindex="0">設定する</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div id="discountAlertCancel" class="modal__dialog" tabindex="0">
+        <div class="modalContent">
+          <div class="modalConfirm">
+            <p class="modalConfirm__ttl">値下げのお知らせ登録を解除します</p>
+            <ul class="modalConfirm__btnWrap">
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes js-discountAlertCancel">解除する</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div id="modalStoreInformation" class="modal__inner js-modalInner" tabindex="0">
+        <div class="modalContent">
+          <div class="modalStoreInformation">
+            <ul class="modalStoreInformation__genre">
+              <li class="modalStoreInformation__genreItem modalStoreInformation__genreItem--category"> DVD・ブルーレイ </li>
+              <li class="modalStoreInformation__genreItem">アニメ</li>
+            </ul>
+            <p class="modalStoreInformation__title">学園黙示録ＨＩＧＨＳＣＨＯＯＬ　ＯＦ　ＴＨＥ　ＤＥＡＤ（限定版）(7)(オリジナルアニメＢｌｕ－ｒａｙ付)</p>
+            <div class="modalStoreInformation__body js-modalInnerContent" style="height: 549.516px;">
+              <p class="modalStoreInformation__heading">商品が入荷した店舗：32店</p>
+              <p class="modalStoreInformation__note">在庫状況は少し前の情報となります。店頭では売り切れの場合もございます。電話でのお取り置きやお取り寄せは行っておりませんのでご注意ください</p>
+              <div class="modalStoreInformation__storeSearch">
+                <div class="modalStoreInformation__select">
+                  <select name="month" class="modalStoreInformation__selectTag -empty">
+                    <option value="" selected="">都道府県を選択</option>
+                    <option value="北海道">北海道</option>
+                    <option value="青森県">青森県</option>
+                    <option value="岩手県">岩手県</option>
+                    <option value="宮城県">宮城県</option>
+                    <option value="秋田県">秋田県</option>
+                    <option value="山形県">山形県</option>
+                    <option value="福島県">福島県</option>
+                    <option value="茨城県">茨城県</option>
+                    <option value="栃木県">栃木県</option>
+                    <option value="群馬県">群馬県</option>
+                    <option value="埼玉県">埼玉県</option>
+                    <option value="千葉県">千葉県</option>
+                    <option value="東京都">東京都</option>
+                    <option value="神奈川県">神奈川県</option>
+                    <option value="新潟県">新潟県</option>
+                    <option value="富山県">富山県</option>
+                    <option value="石川県">石川県</option>
+                    <option value="福井県">福井県</option>
+                    <option value="山梨県">山梨県</option>
+                    <option value="長野県">長野県</option>
+                    <option value="岐阜県">岐阜県</option>
+                    <option value="静岡県">静岡県</option>
+                    <option value="愛知県">愛知県</option>
+                    <option value="三重県">三重県</option>
+                    <option value="滋賀県">滋賀県</option>
+                    <option value="京都府">京都府</option>
+                    <option value="大阪府">大阪府</option>
+                    <option value="兵庫県">兵庫県</option>
+                    <option value="奈良県">奈良県</option>
+                    <option value="和歌山県">和歌山県</option>
+                    <option value="鳥取県">鳥取県</option>
+                    <option value="島根県">島根県</option>
+                    <option value="岡山県">岡山県</option>
+                    <option value="広島県">広島県</option>
+                    <option value="山口県">山口県</option>
+                    <option value="徳島県">徳島県</option>
+                    <option value="香川県">香川県</option>
+                    <option value="愛媛県">愛媛県</option>
+                    <option value="高知県">高知県</option>
+                    <option value="福岡県">福岡県</option>
+                    <option value="佐賀県">佐賀県</option>
+                    <option value="長崎県">長崎県</option>
+                    <option value="熊本県">熊本県</option>
+                    <option value="大分県">大分県</option>
+                    <option value="宮崎県">宮崎県</option>
+                    <option value="鹿児島県">鹿児島県</option>
+                    <option value="沖縄県">沖縄県</option>
+                  </select>
+                </div>
+                <div class="modalStoreInformation__select">
+                  <select name="month" class="modalStoreInformation__selectTag -empty">
+                    <option value="" selected="">市区町村を選択</option>
+                    <option value="札幌市">札幌市</option>
+                  </select>
+                </div>
+              </div>
+              <ul class="modalStoreInformation__list">
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="modal__close js-modalClose" tabindex="0"><img src="/library/common/svg/close.svg" alt="close"></div>
+        </div>
+        <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+      </div>
+    </div>
+			</div>
+		</div>
+	</div>
+
+</div></div>
+<script  src="/library/common/js/sjis_convert.min.js"></script>
+<script  src="/library/common/js/suggest_module.js?d=20240911"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-show.js?rev=20260427"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-item.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-contents.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/core.js"></script>
+</body>
+</html>

--- a/tests/fixtures/used_book/bookoff_product_oos.html
+++ b/tests/fixtures/used_book/bookoff_product_oos.html
@@ -1,0 +1,2050 @@
+<!DOCTYPE html>
+<html data-csrf-tmp-token="23c18002ff10d3d0" data-csrf-tmp-verifier="86fa94fd026e35aec49d98bc6311526a0890543854472b39f89771445789b98f" xmlsn:og="http://ogp.me/ns#" xmlns:fb="http://ogp.me/ns/fb#" lang="ja">
+<head>
+<meta charset="UTF-8">
+
+<link rel="shortcut icon" href="/favicon.ico?dummy=1674087367" />
+<link rel="stylesheet" type="text/css" href="/css/shopping/used.css" charset="UTF-8" />
+<link rel="stylesheet" type="text/css" href="/publis.css" /><meta name="keywords" content="" />
+<meta name="description" content="【定価74%OFF】中古価格 220円(税込)【638円おトク！】「吾輩は猫である 文春文庫」夏目漱石【著】の中古商品ページです。1,800円以上のご注文で送料無料。本(書籍)、漫画(コミック)、CD、DVD、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<title>吾輩は猫である 文春文庫 中古本・書籍 | ブックオフ公式オンラインストア</title>
+<script >
+<!--
+	var pbGlobalAliasBase = '/';
+//-->
+</script>
+<script  src="/public.js"></script>
+<meta name="viewport" content="width=device-width">
+<!--link rel="shortcut icon" href="https://content.bookoffonline.co.jp/favicon.ico"-->
+<link rel="apple-touch-icon" sizes="180x180" href="/library/common/images/apple_touch_icon.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/library/common/images/webclip_android.png">
+<link rel="stylesheet" href="/library/common/css/common.css?d=20250416">
+<link rel="stylesheet" href="/library/common/css/headerFooter.css">
+<script src="https://content.bookoff.co.jp/files/common/js/jquery-2.2.4.min.js"></script>
+<script src="/library/common/js/vendor.bundle.js"></script>
+<script src="/library/common/js/common.js"></script>
+<script src="/library/common/js/headerFooter.js"></script>
+<!--<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>-->
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/items-container.css?rev=20260612" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/plugin/splide.min.js"></script>
+
+<script  src="https://content.bookoff.co.jp/files/common/js/jquery-1.12.4.min.js"></script>
+<script>
+
+	var class_name = 'BocProduct';
+
+$(document).on('click', '.js-ageverification', function(){
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+	var modalBtn = $('#ageVerification__btns--agree');
+
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+
+	// カートに追加、在庫有りのみカートに追加、巻数を指定してカートに追加する
+	$(document).on('click', '.jsBtn-cart', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if (mode == 'disabled') {
+			return false;
+		}
+		if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+			// 在庫有りのみカートに追加の場合、複数回クリック不許可
+			$(this).attr('data-mode', 'disabled');
+		}
+		var ex_param = {};
+		if (mode == 'Add') {
+			ex_param['stockType'] = $(this).attr('data-stock') ?? '';
+		}
+		if (mode == 'AddSelectedItems') {
+			var selectItemIds = {};
+			$('input[type="checkbox"].js-allCheckTarget:checked').each(function(index){
+				selectItemIds[index] = $(this).closest('.productSetItem__checkbox').find('input.item_id').val() ?? '';
+			});
+			ex_param['selectItemIds'] = selectItemIds;
+		}
+		if(age_limit == 1) {
+			ageVerification('cart', mode, item_id, ex_param);
+		} else {
+			ajaxConfig('cart', mode, item_id, ex_param);
+		}
+	});
+	// お気に入り追加・削除
+	$(document).on('click', '.jsBtn-favorite', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('favorite', mode, item_id);
+		} else {
+			ajaxConfig('favorite', mode, item_id);
+		}
+	});
+	// 入荷お知らせ追加・削除、全巻入荷お知らせ追加・削除
+	$(document).on('click', '.jsBtn-arrival', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('arrival', mode, item_id);
+		} else {
+			ajaxConfig('arrival', mode, item_id);
+		}
+	});
+	// 値下げのお知らせ追加・削除
+	$(document).on('click', '.jsBtn-discount', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var ex_param = {};
+		ex_param['price'] = $(this).attr('data-price') ?? 0;
+
+		if (mode == 'Add_PriceChange' || mode == 'PriceChange'){
+		    ex_param['targetPrice'] = $('#modal #discountAlert input[name="discountAlert"]').val() ?? 0;
+			if (ex_param['targetPrice'] == 0 || ex_param['targetPrice'] == '') {
+				discountModalError('1円以上で入力してください');
+			} else if (parseInt(ex_param['targetPrice']) >=  parseInt(ex_param['price'])) {
+				if (item_id.slice(0, 2) == '88') {
+					discountModalError('定価合計価格より小さい金額を入力してください');
+				} else {
+					discountModalError('中古価格より小さい金額を入力してください');
+				}
+			} else if (!ex_param['targetPrice'].match(/^[0-9]+$/)) {
+				discountModalError('半角数字で入力してください');
+			} else {
+				// 「0」埋めの入力は頭削除して登録
+				if (ex_param['targetPrice'].match(/^0+/)) {
+					ex_param['targetPrice'] = new Intl.NumberFormat('ja-JP').format(ex_param['targetPrice']);
+				}
+				ajaxConfig('discount', mode, item_id, ex_param);
+			}
+		} else if(mode == 'Add') {
+		    ex_param['targetPrice'] = $(this).attr('data-target-price') ?? 0;
+			ajaxConfig('discount', mode, item_id, ex_param);
+		} else if(mode == 'Delete') {
+			ajaxConfig('discount', mode, item_id);
+		}
+	});
+	// 最新刊のお知らせ追加・削除
+	$(document).on('click', '.jsBtn-latests', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		ajaxConfig('latests', mode, item_id);
+	});
+
+	// 在庫ない商品一覧表示確認モーダル
+	$(document).on('click', '.jsBtn-cart-modal', function(event){
+		event.preventDefault();
+		$('#modalSetAddCart ul.modalSetAddCart__list').empty();
+		var item_id = $(this).attr('data-item');
+		ajaxConfig('cart', 'RewriteSetModal', item_id);
+	});
+
+	// 値下げのお知らせ価格設定変更モーダル
+	$(document).on('click', '.jsBtn-discount-modal', function(event){
+		event.preventDefault();
+		var item_id = $(this).attr('data-item') ?? '';
+		var price = $(this).attr('data-price') ?? '';
+		var target_price = $(this).attr('data-target-price') ?? '';
+		var modal = $(this).attr('data-modal') ?? '';
+
+		if (modal = 'discountAlert') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-price', price);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-target-price', target_price);
+
+				if (item_id.slice(0, 2) == '88') {
+					$('.modalConfirm__regularPrice').show();
+				}else {
+					$('.modalConfirm__regularPrice').hide();
+				}
+
+				$('#modal #discountAlert #discount-market-price').text(price.toLocaleString());
+				$('#modal #discountAlert #discount-target-price').text(target_price.toLocaleString());
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlert').addClass('-show');
+
+		} else if (modal = 'discountAlertCancel') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlertCancel').addClass('-show');
+		}
+	});
+
+	$(document).on('click', '.js-modalClose', function(event){
+		event.preventDefault();
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+	$(document).on('click', '.modal__overlay', function(event){
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+
+	function initializeDiscountModal () {
+		$('#modal #discountAlert input[name="discountAlert"]').removeClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").hide();
+		$("#modal #discountAlert .modalConfirm__error").text('');
+		$('#modal').removeClass('-show -visible');
+		$('#modal #discountAlert').removeClass('-show');
+		$('#modal #discountAlert input[name="discountAlert"]').val('');
+	}
+
+	function discountModalError (str) {
+		$('#modal #discountAlert input[name="discountAlert"]').addClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").show();
+		$("#modal #discountAlert .modalConfirm__error").text(str);
+	}
+</script><script>
+	function ageVerification(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 773521
+						, 'pageId': 1247
+						, 'revision': 0
+						, 'type': 'ageVerification'
+						, 'mode': 'Agree'
+						, 'itemId': item_id
+					};
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+			// 検索一覧内のボタンをすべて書き換え
+				$('.js-ageverification').each(function() {
+					elmType = $(this).attr('data-type');
+					if (elmType == 'cart') {
+						var btnClass = 'jsBtn-cart';
+					} else if (elmType == 'favorite') {
+						var btnClass = 'jsBtn-favorite';
+					} else if (elmType == 'arrival') {
+						var btnClass = 'jsBtn-arrival';
+					}
+					$(this).addClass(btnClass);
+				});
+				$('.js-ageverification').addClass('ac-click-cv');
+				$('.js-ageverification').removeAttr('data-type');
+				$('.js-ageverification').removeAttr('data-modal');
+				$('.js-ageverification').removeClass('js-modal js-ageverification');
+
+				// モーダルを閉じる
+				$('.modal__inner').removeClass('-show');
+				$('#modal').removeClass('-visible -show');
+				$('body').removeClass('-modalOpen');
+				$('html').removeAttr('data-whatelement data-whatclasses');
+				// モーダルのDOM要素を削除
+				$('[id^="modalAgeVerification"]').remove();
+				// ajaxConfig 実行
+				ajaxConfig(type, mode, item_id, ex_param);
+			} else if (data.status == 'FAILED_AGE_VERIFICATION') {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			} else {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+			$('.ageVerificationBlock__txt--error').text(errMsg);
+			$('.ageVerificationBlock__txt--error').show();
+			return false;
+		});
+	}
+
+	function ajaxConfig(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 773521
+						, 'pageId': 1247
+						, 'revision': 0
+						, 'type': type
+						, 'mode': mode
+						, 'itemId': item_id
+						, 'exParam' : ex_param
+					};
+
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+				// カートに追加
+				if (type == 'cart') {
+					thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-cart-modal[data-item="' + item_id + '"]';
+
+					if (mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocProductSet') {
+							var checkNum = 0;
+							$('.js-allCheckTarget').each(function(){
+								if ($(this).prop('checked')) {
+									checkNum++;
+								}
+							});
+							if (checkNum == 0) {
+								window.location.href = '/cart/';
+							}
+						}
+					}
+
+					if (mode == 'Add' || mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocRankingOfWeekList' || class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSearchResult') {
+							// カートを見るボタンに変更
+							sourceObj = $(thisId);
+							targetObj = $('<a>');
+							sourceObj.removeClass('jsBtn-cart');
+							sourceObj.addClass('-added');
+							targetObj.attr('href', '/cart/');
+							targetObj.text(' カートを見る ');
+							$.each(sourceObj[0].attributes, function() {
+								targetObj.attr(this.name, this.value);
+							});
+							sourceObj.replaceWith(targetObj);
+						} else {
+							$(thisId).attr('href', '/cart/');
+							$(thisId).addClass('-added');
+							$(thisId).text(' カートを見る ');
+							$(thisId).removeClass('jsBtn-cart');
+						}
+					} else if (mode == 'AddSetInStock') {
+						if (class_name == 'BocRankingOfWeekList') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisItemBtnId).addClass('-added');
+							$(thisItemBtnId).text(' カートを見る ');
+							$(thisItemBtnId).attr('data-modal', '');
+							$(thisItemBtnId).attr('data-mode', '');
+							$(thisItemBtnId).off('click');
+							$(thisItemBtnId).attr('href', '/cart/');
+							$(thisItemBtnId).removeClass('jsBtn-cart-modal btn--2l js-modal');
+							// モーダルを閉じる
+							$('.modal__overlay').trigger('click');
+						}
+					} else if (mode == 'RewriteSetModal') {
+						$('#modalSetAddCart .jsBtn-cart').attr('data-item', item_id).attr('data-mode', 'AddSetInStock');
+						$('#modalSetAddCart .modal__title span').text(data.stock_count);
+						for (var i in data.no_stock_items) {
+							var liText = '<li class="modalSetAddCart__item">' + data.no_stock_items[i].item_name + '</li>';
+							$('#modalSetAddCart ul.modalSetAddCart__list').append(liText);
+						}
+						$('#modalSetAddCart .js-modalInnerContent').css('height','500px');
+					}
+				}
+				// お気に入り
+				if (type == 'favorite') {
+					thisId = '.jsBtn-favorite[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $(thisId);
+							displayTooltip(click_ele, type, data.message);
+						}
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite icon-favorite-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite-on icon-favorite-on-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite icon-favorite-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite-on icon-favorite-on-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加済');
+						$(thisId).attr('data-mode', 'Delete');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'delSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Detail');
+						}
+					}
+					if (mode == 'Delete') {
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite-on icon-favorite-on-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite icon-favorite-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite-on icon-favorite-on-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite icon-favorite-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加');
+						$(thisId).attr('data-mode', 'Add');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'addSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Detail');
+						}
+					}
+				}
+				// 入荷お知らせ
+				if (type == 'arrival') {
+					thisId = '.jsBtn-arrival[data-item="' + item_id + '"]';
+					if (mode == 'Add' || mode == 'AddSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							if (data.message) {
+								click_ele = $(thisId);
+								displayTooltip(click_ele, type, data.message);
+							}
+							$(thisId).addClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷お知らせを解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							} else if (mode == 'AddSet') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'DeleteSet');
+							} else if (mode == 'Add') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'delAlertMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'delAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Ranking');
+							}
+						}
+					} else if (mode == 'Delete' || mode == 'DeleteSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId).removeClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷のお知らせを受け取る');
+								$(thisId).attr('data-mode', 'Add');
+							} else if (mode == 'DeleteSet') {
+								$(thisId).text('全巻入荷お知らせ');
+								$(thisId).attr('data-mode', 'AddSet');
+							} else if (mode == 'Delete') {
+								$(thisId).text('入荷お知らせ');
+								$(thisId).attr('data-mode', 'Add');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Ranking');
+							}
+						}
+					}
+				}
+				// 値下げお知らせ
+				if (type == 'discount') {
+					thisId = '.jsBtn-discount[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						}
+					}
+					if (mode == 'PriceChange') {
+						if (class_name == 'BocAlertMailList') {
+							initializeDiscountModal();
+							$('#modal #discountAlert .jsBtn-discount').attr('data-item', '');
+							$('#modal #discountAlert .jsBtn-discount').attr('data-price', '');
+							var thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+							var targetPrice = ex_param['targetPrice'];
+							$(thisItemBtnId).attr('data-target-price', targetPrice);
+							$('#discount-target-price-' + item_id).text(targetPrice.toLocaleString());
+						}
+					}
+					if (mode == 'Add_PriceChange') {
+						if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを登録済');
+							$(thisItemBtnId).attr('data-modal','discountAlertCancel');
+							$(thisItemBtnId).attr('data-mode', 'Delete');
+							// モーダルを閉じる
+							initializeDiscountModal();
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'delSetMailPriceDown_Detail');
+							}
+						}
+					}
+					if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを受け取る');
+							$(thisItemBtnId).attr('data-modal','discountAlert');
+							$(thisItemBtnId).attr('data-mode', 'Add');
+							// モーダルを閉じる
+							$('#modal').removeClass('-show -visible');
+							$('#modal #discountAlertCancel').removeClass('-show');
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'addSetMailPriceDown_Detail');
+							}
+						}
+					}
+				}
+				// 最新刊お知らせ
+				if (type == 'latests') {
+					thisId = '.jsBtn-latests[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを登録済');
+							$(thisId).attr('data-mode', 'Delete');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delNewAlertMail_Detail');
+							}
+						}
+					} else if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを受け取る');
+							$(thisId).attr('data-mode', 'Add');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addNewAlertMail_Detail');
+							}
+						}
+					}
+				}
+			// 在庫なし、もしくは、何らかの原因でカート未追加
+			} else if (data.status == 'NO_STOCK' || data.status == 'FAILED_TO_CART') {
+				if (type == 'cart') {
+					// 他のモーダル開いてたら閉じる
+					if ($('.js-modalInner').hasClass('-show')) {
+						$('#modal').removeClass('-show -visible');
+						$('.js-modalInner').removeClass('-show');
+					}
+					// カートに追加できませんでしたモーダルを開く
+					if($('#modalCartAddStock0').length){
+						if (data.status == 'NO_STOCK' || data.error_code == 'OC456') {
+							$('#modalCartAddStock0 .js-cart-alert').text('在庫がなくなったため、商品をカートに追加できませんでした。再読み込みしてページを更新します');
+						} else {
+							$('#modalCartAddStock0 .js-cart-alert').text('現在お取り扱いのない商品が含まれるため、カートに追加できませんでした。再読み込みしてページを更新します');
+						}
+						$('[data-modal="modalCartAddStock0"]').trigger("click");
+					}
+					// disabledにしたカートボタンを元に戻す
+					if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+						thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+						if($(thisId).attr('data-mode') == 'disabled') {
+							$(thisId).attr('data-mode', mode);
+						}
+					}
+				}
+			// 何らかの原因で処理未完了
+			} else if (data.status == 'NG') {
+				if (type == 'favorite') {
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $('.jsBtn-favorite[data-item="' + item_id + '"]');
+							displayTooltip(click_ele, type, data.message);
+						}
+					}
+				}
+			// 未ログインもしくはAPIエラー
+			} else if (data.status == 'NO_LOGIN' || data.status == 'API_ERROR') {
+				window.location.href = data.url;
+			} else {
+				alert("エラーが発生しました。もう一度設定してください。");
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			alert("エラーが発生しました。");
+		});
+	}
+
+	function displayTooltip(click_ele_selector, btnType, message) {
+		var display_time = 2500;
+		var click_ele = $(click_ele_selector);
+		var original_width = click_ele.outerWidth();
+		// wrap
+		if(!click_ele.parent().hasClass('tipsBalloonArea')){
+			click_ele.each(function() {
+				var self = jQuery(this);
+				var area = jQuery('<div class="tipsBalloonArea"></div>').css({
+					'width': '100%',
+					'margin': self.css('margin'),
+					'margin-bottom': '0'
+				});
+				self.wrap(area);
+			});
+		}
+		// ツールチップHTML
+		var html = '';
+		var isProductPage = !click_ele.hasClass('productItem__favorite');
+		if (isProductPage) {
+			click_ele.parent().addClass('tipsBalloonAreaProductPage');
+			html = '<div class="tipsBalloon tipsBalloon--favorite tipsBalloonFavoriteProductPage"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if (btnType === 'favorite'){
+			html = '<div class="tipsBalloon tipsBalloon--favorite"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if(btnType === 'arrival') {
+			html = '<div class="tipsBalloon tipsBalloon--tail-center"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		}
+		// ツールチップ生成・幅設定・表示
+		var tooltip_ele = $(html).insertBefore(click_ele).hide();
+		if(btnType == 'arrival'){
+			// 入荷お知らせの時のみ調整
+			click_ele.closest('.tipsBalloonArea').each(function() {
+				var self = $(this);
+				if (self.parent().hasClass('cartFloat__btn')) {
+					self.css('position', 'unset');
+				}
+				self.children('.tipsBalloon').css({
+					'min-width': self.children('.jsBtn-arrival').outerWidth(),
+					'bottom': self.children('.jsBtn-arrival').outerHeight() * 1.5,
+					'right': 'unset'
+				});
+			});
+		}
+		tooltip_ele.show();
+		setTimeout(function() {
+			tooltip_ele.fadeOut(200);
+			tooltip_ele.remove();
+			// unwrap
+			if(click_ele.parent().hasClass('tipsBalloonArea')){
+				click_ele.unwrap();
+			}
+		}, display_time);
+	}
+</script>		<script >
+		$(function() {
+			// 商品が入荷した店舗モーダル　絞り込み
+			$('#modalStoreInformation select').change(function() {
+				var prefecture,city;
+				var prefectureObj = $('select[name="prefecture"]');
+				var cityObj = $('select[name="city"]');
+				prefecture = prefectureObj.val();
+				city = cityObj.val();
+
+				if ($(this).attr('name') == 'prefecture'){
+					// 都道府県のselectの場合、市区町村のselectは未選択状態に
+					city = -1;
+				} else if (city != -1){
+					// 市区町村のselectの場合で未選択でない場合、cityから都道府県を取得（都道府県と市区町村の整合性を保つ為）※city={都道府県}-{市区町村}
+					prefecture = city.split('-')[0];
+				}
+
+				// それぞれのselectを選択
+				prefectureObj.val(prefecture);
+				cityObj.val(city);
+
+				// 選択された都道府県の市区町村のselect、それぞれの店舗の表示・非表示を制御
+				prefectureObj.add(cityObj).addClass('-empty');
+				cityObj.find('option').show();
+				$('#modalStoreInformation .modalStoreInformation__list li').show();
+				if (prefecture != -1){
+					prefectureObj.removeClass('-empty');
+					cityObj.find('option:not(.pref_'+prefecture+')').hide();
+					$('#modalStoreInformation .modalStoreInformation__list li:not(.pref_'+prefecture+')').hide();
+				}
+				cityObj.find('option[value="-1"]').show();
+				if (city != -1){
+					cityObj.removeClass('-empty');
+					$('#modalStoreInformation .modalStoreInformation__list li:not(.city_'+ city.split('-')[1] +')').hide();
+				}
+			});
+
+		});
+		</script>
+																
+<script type="application/ld+json">
+{
+	"@context": "https://schema.org/",
+	"@type": "Product",
+	"name": "吾輩は猫である 文春文庫",
+	"@id": "https://shopping.bookoff.co.jp/used/0016731582",
+	"url": "https://shopping.bookoff.co.jp/used/0016731582",
+	"image": [
+		"https://content.bookoff.co.jp/goodsimages/LL/001673/0016731582LL.jpg",
+		"https://content.bookoff.co.jp/goodsimages/L/001673/0016731582L.jpg"
+	],
+	"gtin13": "9784167158057",
+	"brand": {
+		"@type": "Brand",
+		"name": "文藝春秋"
+	},
+	"aggregateRating": {
+		"@type": "AggregateRating",
+		"ratingValue": 3.7,
+		"reviewCount": 18
+	},
+	"offers": [
+		{
+			"@type": "Offer",
+			"url": "https://shopping.bookoff.co.jp/used/0016731582",
+			"priceCurrency": "JPY",
+			"price": 220,
+			"itemCondition": "https://schema.org/UsedCondition",
+			"availability": "https://schema.org/OutOfStock"
+		}
+	],
+	"author": [
+		{
+			"@type": "Person",
+			"name": "夏目漱石"
+		}
+	],
+	"workExample": [
+		{
+			"@type": "Book",
+			"@id": "https://shopping.bookoff.co.jp/used/0016731582",
+			"gtin13": "9784167158057",
+			"bookFormat": "https://schema.org/Paperback",
+			"inLanguage": "ja",
+			"potentialAction": {
+				"@type": "ReadAction",
+				"target": {
+					"@type": "EntryPoint",
+					"urlTemplate": "https://shopping.bookoff.co.jp/cart/",
+					"actionPlatform": [
+						"https://schema.org/DesktopWebPlatform",
+						"https://schema.org/AndroidPlatform",
+						"https://schema.org/IOSPlatform"
+					]
+				}
+			}
+		}
+	]
+}
+</script>
+
+<script src="/library/common/js/detail/notice-display.js"></script>
+
+<script >
+window.headerMenuInfo = window.headerMenuInfo || {
+	pageId: "1247",
+	blockId: "751263"
+};
+</script>
+<script >
+const _boud={};
+</script>
+<meta property="og:site_name" content="ブックオフ公式オンラインストア" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://content.bookoff.co.jp/goodsimages/LL/001673/0016731582LL.jpg" />
+<meta property="og:title" content="吾輩は猫である 文春文庫 中古本・書籍 | ブックオフ公式オンラインストア" />
+<meta property="og:description" content="【定価74%OFF】中古価格 220円(税込)【638円おトク！】「吾輩は猫である 文春文庫」夏目漱石【著】の中古商品ページです。1,800円以上のご注文で送料無料。本(書籍)、漫画(コミック)、CD、DVD、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<meta property="og:url" content="https://shopping.bookoff.co.jp/used/0016731582" />
+<link rel="canonical" href="https://shopping.bookoff.co.jp/used/0016731582">
+
+<script>const _isLogin = false;const _isApp=(function(){const uaList='BookoffApp';const userAgent=navigator.userAgent;return userAgent.includes(uaList)})();</script>
+<link rel="stylesheet" type="text/css" href="/library/init/css/publis4-default.css" />
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>
+<script  src="https://content.bookoff.co.jp/js/roc/csrf_tmp.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/detail.css?rev=20260423" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/detail.js?rev=20260707"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-save.js"></script>
+<link rel="stylesheet" type="text/css" href="" />
+</head>
+<body>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T8MGMLD');</script>
+<!-- End Google Tag Manager -->
+<script src="https://d.adlpo.com/687/2212/js/smartadlpo.js"></script>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8MGMLD" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<noscript><p>このページではjavascriptを使用しています。</p></noscript>
+<div id="page" class="pbPage">
+<div id="headerArea" class="pbHeaderArea">
+	<div id="area1" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7841">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162219">
+						
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162220">
+						<style >
+/* 宅配買取ボタン */
+/* common.css */
+.header__menuSell.sellBtn {
+  display: block;
+  padding: 3px 20px;
+  background-color: #fff000;
+  border: 1px solid #fff000;
+  border-radius: 99px;
+  color: #003894;
+  font-weight: bold;
+  font-size: 16px;
+}
+.header__menuSell {
+  margin-left: 8px;
+}
+/* headerFooter.css */
+.header__menu ul {
+  align-items: center;
+}
+</style>
+<div class="header js-header" id="header">
+  <div class="header__wrap js-headerFixed" style="">
+    <div class="header__inner">
+      <div class="header__logoWrap js-headerLogo">
+
+        <div class="header__logo">
+          <a href="/" class="header__logo__img">
+            <img src="/library/common/images/img-logo.png" alt="BOOKOFF">
+          </a>
+          <div class="header__logo__more">
+            <a class="js-headerLogoBtn" href="/"></a>
+          </div>
+        </div>
+        <div class="header__logoContent js-headerLogoContent">
+          <div class="header__logoContentUserGuide">
+            <a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a>
+          </div>
+          <div class="header__logoContentHeader">
+            <a href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+          </div>
+          <ul>
+            <li>
+              <a href="https://www.bookoff.co.jp/shop/" class="header__linkStore">店舗検索</a>
+            </li>
+            <li>
+              <a href="https://sell.bookoff.co.jp/" class="header__linkPurchase">買取はこちら</a>
+            </li>
+          </ul>
+        </div>
+
+      </div>
+      <nav class="header__navi">
+        <div class="header__naviTop">
+          <div class="header__search js-headerSearch">
+            <div class="header__searchInner">
+              <form name="zsForm" id="zsSearchForm" class="header__searchForm">
+                <input id="zsSearchFormInput" type="search" enterkeyhint="search" name="kw_sn" placeholder="キーワード・品番で検索" autocomplete="off" class="zs-search-input" id="zsSearchFormInput">
+                <span class="header__searchIcon">
+                  <img src="/library/common/svg/search-gray.svg" alt="">
+                </span>
+                <span class="header__searchFormClear">
+                  <img src="/library/common/svg/search-clear.svg" alt="" id="zsSearchClearButton">
+                </span>
+              </form>
+              <div class="header__searchHistory" id="zsHistoryArea">
+                <div class="header__searchHistoryHeading">検索履歴</div>
+                <ul class="js-searchHistory" id="zsSearchHistoryAreaUl">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchHistory -->
+              <div class="header__searchSuggest" id="zsSuggestDiv">
+                <ul class="js-searchSuggest">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchSuggest -->
+            </div>
+          </div>
+          <div class="header__menu">
+                        <ul>
+                <li>
+                  <a class="header__menuSell sellBtn" href="https://sell.bookoff.co.jp/">宅配買取</a>
+                </li>
+                <li>
+                    <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+                </li>
+                <li>
+                    <div class="header__menuAccount js-headerAccount">
+                        <a href="/" class=" js-headerAccountBtn"><img src="/library/common/svg/account.svg" alt=""></a>
+                        <div class="header__menuAccountContent js-headerAccountContent">
+                                                            <div class="header__loginBtn">
+                                    <ul>
+                                        <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+                                        <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+                                    </ul>
+                                </div>
+                                                    </div>
+                    </div>
+                </li>
+                <li>
+                    <a href="/cart" ><img src="/library/common/svg/cart.svg" alt="Cart"></a>
+                </li>
+            </ul>
+                      </div>
+        </div>
+        <div class="header__category js-headerCategory">
+          <ul>
+            <li><a href="/book">書籍</a></li>
+            <li><a href="/comic">コミック</a></li>
+            <li><a href="/cd">CD</a></li>
+            <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+            <li><a href="/game">ゲーム</a></li>
+            <li><a href="/set">セット・まとめ買い</a></li>
+          </ul>
+        </div>
+      </nav>
+
+            <div class="header__naviSp">
+        <div class="header__naviTopSp">
+          <div class="header__menuBtnSp js-spMenuBtn">
+            <img src="/library/common/svg/menu.svg" alt="メニュー">
+          </div>
+          <div class="header__menuSp">
+            <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+            <a href="/cart" ><img src="/library/common/svg/cart.svg" alt=""></a>
+          </div>
+        </div>
+      </div>
+      
+    </div><!-- /header__inner -->
+  </div><!-- /header__wrap -->
+</div><!-- /header js-header -->
+
+<div class="spHeaderMenu js-spHeaderMenu">
+  <div class="spHeaderMenu__close">
+    <span class="js-spHeaderMenuClose" tabindex="0">
+      <img src="/library/common/svg/close.svg" alt="close">
+    </span>
+  </div>
+  <div class="spHeaderMenu__inner">
+
+        <div class="spHeaderMenu__loginBtn">
+        <ul>
+            <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+            <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+        </ul>
+    </div>
+    
+    <div class="spHeaderMenu__heading">カテゴリ</div>
+    <div class="spHeaderMenu__list">
+      <ul>
+        <li><a href="/book">書籍</a></li>
+        <li><a href="/comic">コミック</a></li>
+        <li><a href="/cd">CD</a></li>
+        <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+        <li><a href="/game">ゲーム</a></li>
+        <li><a href="/set">セット・まとめ買い</a></li>
+      </ul>
+    </div>
+    <div class="spHeaderMenu__list">
+      <ul class="spHeaderMenu__listUserGuide">
+      <li><a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a></li>
+      </ul>
+    </div>
+    <a class="spHeaderMenu__linkStore" href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+    <a class="spHeaderMenu__linkSearch" href="https://www.bookoff.co.jp/shop/">店舗検索</a>
+    <a class="spHeaderMenu__linkPurchase" href="https://sell.bookoff.co.jp/">買取はこちら</a>
+  </div>
+</div>
+<div class="spHeaderMenuOverlay js-spHeaderMenuClose">&nbsp;</div>
+<script >
+$(document).ready(function () {
+	$('.logout-link').on('click', function() {
+		const logoutUrl="https://my.bookoff.co.jp/logout";
+		ajax_jquery(logoutUrl)
+		.done(function() {
+			const loginUrl="https://my.bookoff.co.jp/login";
+			window.location.href=loginUrl;
+		})
+		.fail(function(e) {
+			let errUrl="/err/404";
+			switch(true){
+				case e.status==502:
+					errUrl="/err/408";
+					break;
+				case e.status>=500:
+					errUrl="/err/500";
+					break;
+			}
+			window.location.href=errUrl;
+		});
+	});
+});
+
+  // point
+  window.loadPoint = function() {
+    const send_data = {
+      "className": "BocHeaderMenu",
+      "blockId": window.headerMenuInfo.blockId,
+      "pageId": window.headerMenuInfo.pageId,
+      "revision": 0,
+      "type": "loadPoint"
+    };
+    ajax_jquery({
+      url: "/view_interface.php",
+      type: "POST",
+      data: send_data,
+      dataType: "json"
+    })
+    .done(function(data, textStatus, jqXHR) {
+      document.querySelectorAll("div.js-headerAccountContent .header__point,div.js-spHeaderMenu .spHeaderMenu__point")
+        .forEach(el => {
+          el.innerHTML = (data.point || "-") + "<span>P</span>";
+        });
+    });
+  }
+</script>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7842">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock145581">
+						<div class="headerMessage">
+    	<div class="headerMessage__text">1,800円以上の注文で<span class="headerMessage__textDecoration">送料無料</span></div>
+  </div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div><div id="areaWrapper1" class="pbAreaWrapper1"><div id="areaWrapper2" class="pbAreaWrapper2"><div id="mainArea" class="pbMainArea">
+	<div id="area0" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock259237">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock435867">
+						<div class="commonBnr">
+  <div class="commonBnr__inner">
+          <a href="https://shopping.bookoff.co.jp/campaign/19th"  class="commonBnr__link ">
+      <figure class="commonBnr__fig">
+                    <img src="https://content.bookoff.co.jp/assets/images/1200x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="2400" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forPc">
+                            <img src="https://content.bookoff.co.jp/assets/images/375x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="750" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forSp">
+              </figure>
+    </a>
+        </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock275661">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock314591">
+						<div class="campaign campaign--for2col forPc">
+  <div class="campaign__inner">
+          <a class="campaign__items" href="https://shopping.bookoff.co.jp/campaign/20260710-sale">
+      <div class="campaign__item">
+                  <span class="campaign__item__tag infoicon-sale">セール</span>
+              </div>
+      <div class="campaign__item">
+        <span class="campaign__item__ttl"> CD&DVD・ブルーレイSALE 2026/07/23(木)23:59まで</span>
+              </div>
+    </a>
+                                                                                                                                                  </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="mainContent pbNested pbNestedWrapper "  id="pbBlock80098">
+								<div class="pbNested " >
+			<div class="mainContent__inner pbNested pbNestedWrapper "  id="pbBlock80099">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock132785">
+						<div class="breadcrumbs">
+  <ol class="breadcrumbs__list">
+                  <li class="breadcrumbs__item">
+          <a href="/" class="link">トップ</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/12" class="link">書籍</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/1225" class="link">小説・エッセイ・ノンフィクション（文庫）</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/122506" class="link">古典・古文・文豪（日本）</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          <a href="/search/genre/12250605" class="link">な行の著者</a>          <span class="icon-arrow-s-gray icon-arrow-s-gray-dims"></span>
+        </li>
+                        <li class="breadcrumbs__item">
+          吾輩は猫である
+        </li>
+            </ol>
+</div>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock80101">
+						<style >
+#promotionBannerlimitedFixedPc {
+  padding: 8px 0 0;
+}
+</style>
+
+      <div class="mainContent__product">
+  <div class="mainContent__col">
+    <div class="productInformation">
+      <section class="productInformation__inner">
+        <figure class="productInformation__image forPc">
+          <span><img src="https://content.bookoff.co.jp/goodsimages/LL/001673/0016731582LL.jpg" alt="吾輩は猫である 文春文庫" class="js-orientation -pt"></span>
+        </figure>
+        <div class="productInformation__detail">
+        <div class="productInformation__tagList--genre">
+          <div class="productInformation__tagList">
+            <ul class="tagList">
+              <li class="tag">中古</li>
+            </ul>
+          </div>
+          <ul class="productInformation__genre">
+            <li class="productInformation__genreItem productInformation__genreItem--category">書籍</li>
+            <li class="productInformation__genreItem">文庫</li>
+            <li class="productInformation__genreItem display-genreCode"><div class="displayLabelBox displayLabelBox--genreCode">1225-06-05</div></li>
+          </ul>
+        </div>
+          <h1 class="productInformation__title">吾輩は猫である 文春文庫</h1>
+          <p class="productInformation__author">
+            <a href="/search/author/%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3">夏目漱石</a><span>【著】</span>
+          </p>
+          <div class="review">
+            <div class="review__individual">
+              <div class="review__star">
+                <ul class="review__star__list--small">
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                  <li class="icon-star_white_small icon-star_yellow_small-dims"></li>
+                </ul>
+                <span class="review__counter"><a href="#anc-review" class="js-anchor">18件</a></span>
+              </div>
+            </div>
+          </div>
+          <p class="productInformation__favorite forSp">
+            <span class="ProductInformationFavoriteD">追加する</span>
+            <a href="/" class="icon-favorite icon-favorite-dims jsBtn-favorite ac-click-cv" data-cv-name="addBookmark_Detail" data-mode="Add" data-item="0016731582"></a>
+            <span class="ProductInformationFavoriteJ">に追加する</span>
+          </p>
+          <figure class="productInformation__image forSp">
+            <span><img src="https://content.bookoff.co.jp/goodsimages/LL/001673/0016731582LL.jpg" alt="吾輩は猫である 文春文庫" class="js-orientation -pt"></span>
+          </figure>
+          <div class="productInformation__Btn">
+            <a href="/used/0016731582" class="productInformation__Btn__used -active">中古</a>
+            <a href="/new/0016731582" class="productInformation__Btn__new ">新品</a>
+          </div>
+          <p class="productInformation__regularPrice">定価 ¥858</p>
+          <p class="productInformation__price">
+            <span class="productInformation__price--large"> 220<span class="productItem__moneyUnit">円</span></span>
+
+            <small>定価より638円（74%）おトク</small>
+          </p>
+          <p class="productInformation__point">獲得ポイント<span>2P</span></p>
+          <div class="productInformation__spCart forSp">
+            <ul class="productInformation__btns">
+              <li class="js-cartFloatTargetSP">
+                  <a href="/" class="btn jsBtn-arrival ac-click-cv" data-cv-name="addAlertlMail_Detail" data-mode="Add" data-item="0016731582">入荷のお知らせを受け取る</a>
+              </li>
+            </ul>
+          </div>
+          <p class="productInformation__stock">
+            <span class="productInformation__stock--none">在庫なし</span>
+          </p>
+          <p class="productInformation__stock"> 発送時期 1～5日以内に発送 </p>
+          <div class="forSp">
+          </div>
+          <div class="productInformation__spCart forSp">
+              <p class="js-discountAlertItem">
+                <a href="/" class="productInformation__discount js-discountAlertModal jsBtn-discount-modal ac-click-cv" data-cv-name="addPriceDownMail_Detail" data-modal="discountAlert" data-item="0016731582">
+                  <span class="icon-mail icon-mail-dims"></span>
+                  <span>値下げのお知らせを受け取る</span>
+                </a>
+              </p>
+          </div>
+          <ul class="productInformation__supplement">
+            <li><a href="https://support-online.bookoff.co.jp/answer/6583dca614cd35d38e3d0cfe" class="link link--arrow" target="_blank">中古商品の品質・付属品について</a></li>
+            <li><a href="https://support-online.bookoff.co.jp/answer/658553fc129d451df9fefb83" class="link link--arrow" target="_blank">返品について</a></li>
+          </ul>
+        </div>
+      </section><!-- /productOverview__inner -->
+    </div><!-- /productOverview -->
+    <div id="js-breadcrumbsDestination-bottom" class="breadcrumbsDestination-bottom"></div>
+    <div id="js-recommendDestination" class="recommendDestination"></div>
+    <div class="forSp">
+        <div class="promotionBanner">
+          <div id="promotionBannerlimitedFixedMb">
+            <div class="promotionBannerDetail">
+              <picture>
+                <source media="(max-width:767px)" srcset="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-750-120.png" width="750" height="120">
+                <img src="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-750-120.png" alt="" width="750" height="120">
+              </picture>
+            </div>
+          </div>
+        </div>
+    </div>
+    <div id="js-breadcrumbsDestination-top" class="breadcrumbsDestination-top"></div>
+    <div class="productDetail">
+      <section class="productDetail__inner">
+        <h2 class="productDetail__ttl">商品詳細</h2>
+        <div class="productDetail__tableWrap">
+          <table class="productDetail__table">
+            <tbody>
+              <tr>
+                <th>内容紹介</th>
+                <td></td>
+              </tr>
+              <tr>
+                <th>販売会社／発売会社</th>
+                <td id="js-company">文藝春秋</td>
+              </tr>
+              <tr>
+                <th>発売年月日</th>
+                <td>2011/11/10
+                  <p class="productDetail__link">
+                    <a href="https://support-online.bookoff.co.jp/answer/6583dca614cd35d38e3d0cfe/" target="_blank">改訂版・発行年月日について</a>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <th>JAN</th>
+                <td>9784167158057</td>
+              </tr>
+            </tbody>
+          </table>
+        </div><!-- /productDetail__tableWrap -->
+      </section><!-- /productDetail__inner -->
+    </div><!-- /productDetail -->
+  </div><!-- /mainContent__col -->
+  <div class="mainContent__col forPc">
+    <div class="productPurchase">
+      <div class="productPurchase__inner">
+        <ul class="productPurchase__btns">
+          <li class="js-cartFloatTargetPC">
+              <a href="/" class="btn jsBtn-arrival ac-click-cv" data-cv-name="addAlertlMail_Detail" data-mode="Add" data-item="0016731582">入荷のお知らせを受け取る</a>
+          </li>
+          <li>
+          </li>
+          <li>
+            <a href="/" class="productPurchase__favorite jsBtn-favorite ac-click-cv" data-cv-name="addBookmark_Detail" data-mode="Add" data-item="0016731582">
+              <span class="icon-favorite icon-favorite-dims"></span>
+              <span class="productPurchase__favoriteTxt">お気に入り追加</span>
+            </a>
+          </li>
+            <li class="js-discountAlertItem">
+              <a href="/" class="productPurchase__discount js-discountAlertModal jsBtn-discount-modal ac-click-cv" data-cv-name="addPriceDownMail_Detail" data-modal="discountAlert" data-item="0016731582">
+                <span class="icon-mail icon-mail-dims"></span>
+                <span>値下げのお知らせを受け取る</span>
+              </a>
+            </li>
+        </ul>
+        <div id="promotionBannerlimitedFixedPc"><img src="https://content.bookoff.co.jp/assets/images/banner/campaign/limited/blank-680-160.png" width="282" height="60"></div>
+      </div><!-- /productPurchase__inner -->
+    </div><!-- /productPurchase -->
+  </div><!-- /mainContent__col -->
+</div>
+<input type="hidden" class="js-modal" data-modal="modalCartAddStock0">
+
+<div id="modal" class="modal">
+  <div class="modal__overlay"></div>
+  <div id="discountAlert" class="modal__dialog" tabindex="0">
+    <div class="modalContent">
+      <div class="modalConfirm">
+        <p class="modalConfirm__ttl">値下げのお知らせメールを受け取る価格を設定してください</p>
+        <div class="modalConfirm__row">
+          <div class="modalConfirm__col">
+            <input type="number" class="modalConfirm__textbox" placeholder="設定価格を入力" name="discountAlert" onkeydown="return event.key !== 'e' && event.key !== 'E' && event.key !== '+' && event.key !== '-' && event.key !== '.'" onInput="checkForm(this)">
+          </div>
+          <p class="modalConfirm__unit">円以下</p>
+          <p class="modalConfirm__error" style="display:none;"></p>
+        </div>
+        <ul class="modalConfirm__btnWrap">
+          <li class="modalConfirm__btn">
+            <a href="/" class="modalConfirm__no js-modalClose" tabindex="0">
+              キャンセル
+            </a>
+          </li>
+          <li class="modalConfirm__btn">
+            <a href="/" class="modalConfirm__yes jsBtn-discount" tabindex="0" data-mode="Add_PriceChange" data-item="0016731582" data-price="220">
+              設定する
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div id="discountAlertCancel" class="modal__dialog" tabindex="0">
+    <div class="modalContent">
+      <div class="modalConfirm">
+        <p class="modalConfirm__ttl">値下げのお知らせ登録を解除します</p>
+        <ul class="modalConfirm__btnWrap">
+          <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+          <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes jsBtn-discount" data-mode="Delete" data-item="0016731582">解除する</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div id="modalStoreInformation" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalStoreInformation">
+        <ul class="modalStoreInformation__genre">
+          <li class="modalStoreInformation__genreItem modalStoreInformation__genreItem--category">書籍</li>
+          <li class="modalStoreInformation__genreItem">文庫</li>
+        </ul>
+        <p class="modalStoreInformation__title">吾輩は猫である</p>
+        <div class="modalStoreInformation__body js-modalInnerContent">
+          <p class="modalStoreInformation__heading">商品が入荷した店舗：0店</p>
+		  <p class="modalStoreInformation__txt">店頭で購入可能な商品の入荷情報となります</p>
+          <p class="modalStoreInformation__note">ご来店の際には売り切れの場合もございます</p>
+          <p class="modalStoreInformation__note">オンラインストア上の価格と店頭価格は異なります</p>
+          <p class="modalStoreInformation__note">お電話やお問い合わせフォームでの在庫確認、お客様宅への発送やお取り置き・お取り寄せは行っておりません</p>
+          <div class="modalStoreInformation__storeSearch">
+            <div class="modalStoreInformation__select">
+              <select name="prefecture" class="modalStoreInformation__selectTag -empty">
+                <option value="-1" selected="">都道府県を選択</option>
+                <option value="1">北海道(0)</option>
+                <option value="2">青森県(0)</option>
+                <option value="3">岩手県(0)</option>
+                <option value="4">宮城県(0)</option>
+                <option value="5">秋田県(0)</option>
+                <option value="6">山形県(0)</option>
+                <option value="7">福島県(0)</option>
+                <option value="8">茨城県(0)</option>
+                <option value="9">栃木県(0)</option>
+                <option value="10">群馬県(0)</option>
+                <option value="11">埼玉県(0)</option>
+                <option value="12">千葉県(0)</option>
+                <option value="13">東京都(0)</option>
+                <option value="14">神奈川県(0)</option>
+                <option value="15">新潟県(0)</option>
+                <option value="16">富山県(0)</option>
+                <option value="17">石川県(0)</option>
+                <option value="18">福井県(0)</option>
+                <option value="19">山梨県(0)</option>
+                <option value="20">長野県(0)</option>
+                <option value="21">岐阜県(0)</option>
+                <option value="22">静岡県(0)</option>
+                <option value="23">愛知県(0)</option>
+                <option value="24">三重県(0)</option>
+                <option value="25">滋賀県(0)</option>
+                <option value="26">京都府(0)</option>
+                <option value="27">大阪府(0)</option>
+                <option value="28">兵庫県(0)</option>
+                <option value="29">奈良県(0)</option>
+                <option value="30">和歌山県(0)</option>
+                <option value="31">鳥取県(0)</option>
+                <option value="32">島根県(0)</option>
+                <option value="33">岡山県(0)</option>
+                <option value="34">広島県(0)</option>
+                <option value="35">山口県(0)</option>
+                <option value="36">徳島県(0)</option>
+                <option value="37">香川県(0)</option>
+                <option value="38">愛媛県(0)</option>
+                <option value="39">高知県(0)</option>
+                <option value="40">福岡県(0)</option>
+                <option value="41">佐賀県(0)</option>
+                <option value="42">長崎県(0)</option>
+                <option value="43">熊本県(0)</option>
+                <option value="44">大分県(0)</option>
+                <option value="45">宮崎県(0)</option>
+                <option value="46">鹿児島県(0)</option>
+                <option value="47">沖縄県(0)</option>
+              </select>
+            </div>
+            <div class="modalStoreInformation__select">
+              <select name="city" class="modalStoreInformation__selectTag -empty">
+                <option value="-1" selected="">市区町村を選択</option>
+              </select>
+            </div>
+          </div>
+          <ul class="modalStoreInformation__list">
+          </ul>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose" tabindex="0"><img src="/library/common/svg/close.svg" alt="close"></div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div>
+
+  <div id="modalCartAddStock0" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">カートに追加できませんでした</p>
+        </div>
+        <div class="modalItems">
+          <p class="modalItems__note">
+            <span class="icon-info icon-info-dims"></span>
+            <span class="js-cart-alert"></span>
+          </p>
+        </div>
+      </div>
+      <ul class="modal__confirm modal__confirm--box-shadow-none">
+        <li class="modal__confirmBtn">
+          <a href="/" class="modal__no js-modalClose" tabindex="0">キャンセル</a>
+        </li>
+        <li class="modal__confirmBtn">
+          <a href="/" class="modal__yes js-refreshPage">OK</a>
+        </li>
+      </ul>
+      <div class="modal__close js-modalClose" tabindex="0">
+        <img src="/library/common/svg/close.svg" alt="close">
+      </div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp">
+      <span></span>
+    </div>
+  </div>
+
+  <div id="modalPreviousPrice" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <p class="modal__title">値下げ前価格について</p>
+      <div class="modalPreviousPrice js-modalInnerContent">
+        <div class="modalPreviousPrice__inner">
+          <p class="modalPreviousPrice__txt">
+            <span>本価格は現中古販売価格の「値下げ前価格」となります。<br> 直近約1か月間、値下げ前価格での販売実績があるものだけ表示しております。</span>
+          </p>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose"><img src="/library/common/svg/close.svg" alt="close"></div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div><!-- modalPreviousPrice -->
+
+</div>
+<div class="cartFloat js-cartFloat">
+  <div id="promotionBannerlimitedFloating"></div>
+  <div class="cartFloat__head">
+    <p class="cartFloat__name">吾輩は猫である</p>
+    <p class="cartFloat__price">¥220</p>
+  </div>
+  <div class="cartFloat__body">
+    <p class="cartFloat__stock">
+      <span class="cartFloat__alert">在庫なし</span>
+    </p>
+    <p class="cartFloat__btn">
+        <a href="/" class="btn jsBtn-arrival ac-click-cv" data-cv-name="addAlertlMail_Detail" data-mode="Add" data-item="0016731582">入荷のお知らせを受け取る</a>
+    </p>
+  </div>
+</div>
+
+<script>
+function checkForm($this) {
+  let str = $this.value;
+  while (str.match(/[^A-Z^a-z\d\-]/)) {
+      str = str.replace(/[^0-9]/, "");
+  }
+  $this.value = str;
+}
+</script>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock80102">
+						<div class="mainContent__product">
+  <div class="mainContent__col">
+    <div class="review">
+      <section class="review__inner">
+        <h2 class="information__ttl" id="anc-review">商品レビュー</h2>
+        <div class="review__totalEvaluation">
+          <div class="review__star">
+            <div class="review__star__inner">
+              <ul class="review__star__list">
+                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_yellow_large icon-star_yellow_large-dims"></li>
+                                                                <li class="icon-star_white_large icon-star_white_large-dims"></li>
+                                              </ul>
+              <p class="review__totalEvaluation__score">3.7</p>
+            </div>
+            <p class="review__totalEvaluation__number">18件のお客様レビュー</p>
+          </div>
+          <p class="btnWrap">
+            <a href="/review/post/0016731582" class="btn btn--s" rel="nofollow">レビューを投稿</a>
+          </p>
+        </div>
+        <div class="review__individualWrap">
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2026/06/14</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                〇漱石ぐらい読んどこうかなと手を取った３作目。
+
+〇いやーびっくりしました。思ってたのとぜんぜん違う。
+
+難しい漢字のオンパレード、自分の知識をひけらかしたいだけ？の知らない人や本などが続々登場。改行も一切なし。きつい、きつい。
+
+しかも話は面白くない。まあ、風刺小説だからなのか...
+                              </p>
+                                          <div class="review__individual__continueLink">
+                <a class="js-showmore-btn" tabindex="0">表示する</a>
+              </div>
+              <div class="review__individual__text--hide">
+                                                <p>〇漱石ぐらい読んどこうかなと手を取った３作目。
+
+〇いやーびっくりしました。思ってたのとぜんぜん違う。
+
+難しい漢字のオンパレード、自分の知識をひけらかしたいだけ？の知らない人や本などが続々登場。改行も一切なし。きつい、きつい。
+
+しかも話は面白くない。まあ、風刺小説だからなのか知らないけど、斜に構えた皮肉った話がえんえんと続く…。
+
+途中でギブアップしそうになったほど。ネットを見ると、やはりほとんどの人の感想がそんな感じでした。
+
+ただ、面白いとネットで書いている人の記事を読み、この本の意義と読み方を学んで途中からはまあまあ楽しみながら？読み終えました。
+
+とにかく分からない漢字や人物などはすべて意味を調べ、注釈もひたすら読んで、とにかく当時としては斬新だったことも頭に入れ、そしてこれが漱石と同じくらい知識があった仲間たちに向けたものということを意識して読みました。
+
+本当にすごい知識量の人だったんですね。
+
+これを面白いと思える人の知識量、読書力はハンパないですね。</p>
+              </div>
+                          </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2025/12/04</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                主人公の猫がお雑煮を食べて子供達に踊っているみたいと言われるところがお気に入りですが、猫がどこか人間をあまり好いていないところも面白いです。また猫の主人は夏目漱石や夏目漱石の周りの人がモデルとなっているので、夏目漱石の伝記などと一緒に読むとさらに面白く読めます。伝記に夏目漱石の少...
+                              </p>
+                                          <div class="review__individual__continueLink">
+                <a class="js-showmore-btn" tabindex="0">表示する</a>
+              </div>
+              <div class="review__individual__text--hide">
+                                                <p>主人公の猫がお雑煮を食べて子供達に踊っているみたいと言われるところがお気に入りですが、猫がどこか人間をあまり好いていないところも面白いです。また猫の主人は夏目漱石や夏目漱石の周りの人がモデルとなっているので、夏目漱石の伝記などと一緒に読むとさらに面白く読めます。伝記に夏目漱石の少しダメなところなども書いてあって、文豪たちが一気に身近に感じられました。</p>
+              </div>
+                          </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                    <div class="review__individual">
+            <div class="review__star">
+              <ul class="review__star__list--small">
+                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_yellow_small icon-star_yellow_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                                                <li class="icon-star_white_small icon-star_white_small-dims"></li>
+                                              </ul>
+              <span class="review__star--timestamp">2025/09/05</span>
+            </div>
+            <div class="review__individual__textWrap js-showmore">
+                                                                      <p class="review__individual__text">
+                                書き出しは有名だけど、読んだことがなかった本。飼い猫視点で描かれる日常の出来事。本の世界と現代の生活の違いがあって、理解できない単語がちらほらあり、読むのに時間がかかった。それなりに文量があることも時間がかかった理由だと思うが、結末に至るまでは早く読み終わらないかな…と思いながら...
+                              </p>
+                                          <div class="review__individual__continueLink">
+                <a class="js-showmore-btn" tabindex="0">表示する</a>
+              </div>
+              <div class="review__individual__text--hide">
+                                                <p>書き出しは有名だけど、読んだことがなかった本。飼い猫視点で描かれる日常の出来事。本の世界と現代の生活の違いがあって、理解できない単語がちらほらあり、読むのに時間がかかった。それなりに文量があることも時間がかかった理由だと思うが、結末に至るまでは早く読み終わらないかな…と思いながら、どうにか読み終えた感じだった。</p>
+              </div>
+                          </div>
+                        <p class="review__individual__posted">Posted by <img src="/library/common/images/product/bukulog.png" alt="ブクログ"></p>
+                      </div>
+                  </div>
+        <p class="review__allshowLink"><a href="/review/detail/0016731582">すべてのレビューを見る</a></p>
+      </section><!-- /review__inner -->
+    </div>
+  </div>
+</div>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock481102">
+						<div class="hashtag">
+  <div class="hashtag__inner">
+    <h2 class="hashtag__heading">関連ワードから探す</h2>
+    <ul class="hashtagList">
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%A5%BD%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">楽しい</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%AD%90%E4%BE%9B" class="hashtagBtn hashtagBtn--link">子供</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%84%AA%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">優しい</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E9%AB%98%E6%A0%A1" class="hashtagBtn hashtagBtn--link">高校</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E4%BA%BA%E7%94%9F%E8%AB%96" class="hashtagBtn hashtagBtn--link">人生論</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%BF%91%E4%BB%A3" class="hashtagBtn hashtagBtn--link">近代</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E6%98%8E%E6%B2%BB" class="hashtagBtn hashtagBtn--link">明治</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%8B%B1%E5%9B%BD" class="hashtagBtn hashtagBtn--link">英国</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E4%BA%BA%E9%96%93%E6%A8%A1%E6%A7%98" class="hashtagBtn hashtagBtn--link">人間模様</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%AE%B6%E6%97%8F" class="hashtagBtn hashtagBtn--link">家族</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3" class="hashtagBtn hashtagBtn--link">夏目漱石</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%A9%A9%E4%BA%BA" class="hashtagBtn hashtagBtn--link">詩人</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%83%A6%E3%83%BC%E3%83%A2%E3%82%A2" class="hashtagBtn hashtagBtn--link">ユーモア</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%80%8B%E6%80%A7%E8%B1%8A%E3%81%8B" class="hashtagBtn hashtagBtn--link">個性豊か</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%82%A8%E3%83%94%E3%82%BD%E3%83%BC%E3%83%89" class="hashtagBtn hashtagBtn--link">エピソード</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%83%A6%E3%83%BC%E3%83%A2%E3%83%A9%E3%82%B9" class="hashtagBtn hashtagBtn--link">ユーモラス</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%82%B7%E3%83%A7%E3%83%83%E3%82%AF" class="hashtagBtn hashtagBtn--link">ショック</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E3%83%87%E3%83%93%E3%83%A5%E3%83%BC%E4%BD%9C" class="hashtagBtn hashtagBtn--link">デビュー作</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E5%AE%9F%E8%B7%B5" class="hashtagBtn hashtagBtn--link">実践</a></li>
+                      <li class="hashtagList__item"><a href="/search/hashtag/%E8%A6%B3%E5%AF%9F" class="hashtagBtn hashtagBtn--link">観察</a></li>
+        </ul>
+  </div>
+</div>
+<script>
+	$(document).ready(function() {
+		// ハッシュタグリンクへのquery_string追加
+		var arrQuery = [];
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		var hashtagQuery = makeQueryString(arrQuery);
+		$('.hashtagBtn--link').each(function () {
+			var hashtagUrl = $(this).attr('href') + hashtagQuery;
+			$(this).attr('href', hashtagUrl);
+		});
+	});
+
+	function makeQueryString(arrQuery) {
+		// query_string生成
+		if (arrQuery.length > 0) {
+				var queryString = $.map(arrQuery, function(param) {
+						return encodeURIComponent(param.name) + '=' + encodeURIComponent(param.value);
+				}).join('&');
+				return '?' + queryString;
+		} else {
+			return '';
+		}
+	}
+</script>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock397940">
+								<div class="pbNested " id="js-recommendMove">
+			<div class="pbNested pbNestedWrapper "  id="pbBlock716281">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">関連商品</h2>
+    </div>
+    <div id="js-recRelation" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="211" data-id="detail_relation" data-id-mb="detail_relation-mb" data-id-pc="detail_relation-pc" data-item-id="current" data-genre="genreCode2" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock716282">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">同じジャンルのおすすめ商品</h2>
+    </div>
+    <div id="js-recGenre" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="602" data-id="detail_genre" data-id-mb="detail_genre-mb" data-id-pc="detail_genre-pc" data-item-id="current" data-genre="genreCode2" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock713633">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock713634">
+						<section class="itemsContainer itemsContainer--itemViewHistory js-itemViewHistory">
+  <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop js-displayItemViewHistoryHeader -hidden">
+  <h2 class="itemsContainer__header">最近チェックした商品</h2>
+  <div class="itemsContainer__textBox itemsContainer__textBox--deleteHistory js-delItemViewHistoryArea"><button class="link itemsContainer__actionButton js-delItemViewHistory"><span>履歴を消す</span></button></div> 
+  </div>
+  <div class="itemsContainer__wrapper">
+    <div class="itemsContainer__main splide js-displayItemViewHistory" id="ItemViewHistory">
+    </div>
+    <div class="itemsContainer__textBox itemsContainer__textBox--removeHistory js-undoItemViewHistoryArea -hidden">
+      <div class="itemsContainer__text">履歴をすべて削除しました</div>
+      <div class="itemsContainer__actionBox">
+        <button class="itemsContainer__actionButton js-undoItemViewHistory"><span>もとにもどす</span></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="setProductList pbNested pbNestedWrapper "  id="pbBlock662196">
+								<div class="pbNested " id="js-setProductList">
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock507931">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock505399">
+						<div class="naviElement">
+
+  <!-- スマホで見るボタン start -->
+  <div class="js-modal js-modal-navi boViewSpBtn" data-modal="modal2dcode" data-btn-name="お手持ちのスマホで確認する">
+    お手持ちのスマホで確認する
+  </div>
+  <!-- スマホで見るボタン end -->
+
+
+  <!-- 2dコードモーダル start -->
+  <div id="modal2dcode" class="modal__inner js-modalInner">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">お手持ちのスマホでスキャン</p>
+        </div>
+        <div class="modalItems js-modalInnerContent">
+          <div id="2dcode" class="modalItems__2dcode"></div>
+          <div class="modalItems__text">お近くのスタッフに、表示されたスマホ画面を</div>
+          <div class="modalItems__text">みせていただければ商品をお探しいたします。</div>
+        </div>
+      </div>
+      <div class="modal__close js-modalClose">
+        <img src="/library/common/svg/close.svg" alt="close" width="24" height="24">
+      </div>
+    </div>
+  </div>
+  <!-- 2dコードモーダル end -->
+
+
+  <!-- スマホ画面モーダル -->
+  <div class="modalSpNavi">
+    <div class="modalSpNavi__inner">
+      <div class="modalSpNavi__overlay"></div>
+      <div class="modalSpNavilItems">
+        <div class="modalSpNavilItem__close">
+          <img src="/library/common/svg/close.svg" alt="close" width="24" height="24">
+        </div>
+        <div class="modalSpNavilItem__text modal__title modalSpNavilItem__text--main">ブックオフナビをご利用いただき ありがとうございます</div>
+        <div class="modalSpNavilItem__text">お近くのスタッフにこの商品詳細画面をお見せください。400万点の在庫の中から商品をお探しいたします。</div>
+        <div class="modalSpNavilItem__text modalSpNavilItem__text--alert">※画面に表示されている価格はお取り寄せ時の価格となります。</div>
+      </div>
+    </div>
+  </div>
+  <!-- スマホ画面モーダル -->
+
+
+  <!-- 1dバーコード start -->
+  <div class="barcodeWrap">
+    <img id="barcode" class="barcode__image" width="250" height="38">
+    <div class="barcode__text"></div>
+  </div>
+  <!-- 1dバーコード end -->
+</div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div></div><div id="footerArea" class="pbFooterArea">
+	<div id="area4" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock7844">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock161678">
+						<footer class="footer" id="footer">
+    <div class="footer__wrap">
+      <div class="footer__inner">
+        <div class="footer__navi">
+          <p class="footer__pageTop">
+            <a href="#" class="footer__pageTopBtn js-pagetop">
+              <img src="/library/common/images/img-footer-arrow.svg" alt="ページトップへ戻る">
+            </a>
+          </p>
+          <ul>
+            <li class="footer__item footer__item--first"><a href="https://support-online.bookoff.co.jp" class="footer__link">ヘルプ・ご質問</a>
+              <ul>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/64363fbd97ebd8c6491e0a07" class="footer__link">配送料について</a></li>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/65852e8cd29784dd07b9bdc7" class="footer__link">支払い方法について</a></li>
+              </ul>
+            </li>
+            <li class="footer__item"><a href="https://shopping.bookoff.co.jp/service/mail" class="footer__link">メールサービス</a></li>
+            <li class="footer__item"><a href="https://regist11.smp.ne.jp/regist/is?SMPFORM=ofn-latbq-651b190782b21aa1eaa0162e484e578c" class="footer__link">ご意見・ご感想</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer__wrap footer__wrap--bottom">
+      <div class="footer__inner">
+        <ul class="footer__sns">
+          <li>
+            <a href="https://www.facebook.com/%E3%83%96%E3%83%83%E3%82%AF%E3%82%AA%E3%83%95%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3bookoffonline-166258740189848/" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-fb.svg" alt="Facebook">
+            </a>
+          </li>
+          <li>
+            <a href="https://x.com/bookoffonline" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-x.svg" alt="X">
+            </a>
+          </li>
+          <li>
+            <a href="https://page.line.me/iau9918q" class="footer__snsBtn">
+              <img src="/library/common/images/img-footer-line.svg" alt="LINE">
+            </a>
+          </li>
+        </ul>
+        <div class="footer__bottomNavi">
+          <ul>
+           <li><a href="https://www.bookoff.co.jp/" class="footer__bottomLlink" target="_blank">BOOKOFF公式サイト</a></li>
+           <li><a href="https://www.bookoffgroup.co.jp/corporate/business.html" class="footer__bottomLlink" target="_blank">企業情報</a></li>
+           <li><a href="https://member.bookoff.co.jp/bo-member-content/contract/" class="footer__bottomLlink" target="_blank">BOOKOFF会員サービス利用規約</a></li>
+           <li><a href="https://shopping.bookoff.co.jp/policies/terms" class="footer__bottomLlink">利用規約</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/privacy.html" class="footer__bottomLlink" target="_blank">個人情報保護方針</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/socialmedia.html" class="footer__bottomLlink" target="_blank">ソーシャルメディアポリシー</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/customerharassment.html" class="footer__bottomLlink" target="_blank">カスタマーハラスメントに対する基本方針</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/regulatory-disclosure" class="footer__bottomLlink">特定商取引法に基づく表示</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/external-transmission" class="footer__bottomLlink">利用者情報の外部送信について</a></li>
+          <li><a href="https://www.bookoffgroup.co.jp/" class="footer__bottomLlink" target="_blank">ブックオフグループホールディングス株式会社</a></li>
+         </ul>
+        </div>
+        <div class="footer__bottom">
+          <div class="footer__text">
+            <p> ブックオフコーポレーション株式会社<br> 古物商許可番号 第452760001146号 神奈川県公安委員会許可 </p>
+          </div>
+          <div class="footer__copyright"> Copyright(C)BOOKOFF CORPORATION LTD.<br class="forSp">All Rights Reserved. </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock209621">
+						
+<link rel="stylesheet" href="/library/common/css/appli/app-hide-common.css">
+
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock7845">
+						<div id="modal" class="modal">
+      <div class="modal__overlay"></div>
+      <div id="discountAlert" class="modal__dialog" tabindex="0">
+        <div class="modalContent">
+          <div class="modalConfirm">
+            <p class="modalConfirm__ttl">値下げのお知らせメールを受け取る価格を設定してください</p>
+            <div class="modalConfirm__row">
+              <div class="modalConfirm__col">
+                <input type="text" class="modalConfirm__textbox" placeholder="設定価格を入力" name="discountAlert">
+              </div>
+              <p class="modalConfirm__unit">円以下</p>
+            </div>
+            <ul class="modalConfirm__btnWrap">
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes js-discountAlertSubmit" tabindex="0">設定する</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div id="discountAlertCancel" class="modal__dialog" tabindex="0">
+        <div class="modalContent">
+          <div class="modalConfirm">
+            <p class="modalConfirm__ttl">値下げのお知らせ登録を解除します</p>
+            <ul class="modalConfirm__btnWrap">
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__no js-modalClose" tabindex="0">キャンセル</a></li>
+              <li class="modalConfirm__btn"><a href="/" class="modalConfirm__yes js-discountAlertCancel">解除する</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div id="modalStoreInformation" class="modal__inner js-modalInner" tabindex="0">
+        <div class="modalContent">
+          <div class="modalStoreInformation">
+            <ul class="modalStoreInformation__genre">
+              <li class="modalStoreInformation__genreItem modalStoreInformation__genreItem--category"> DVD・ブルーレイ </li>
+              <li class="modalStoreInformation__genreItem">アニメ</li>
+            </ul>
+            <p class="modalStoreInformation__title">学園黙示録ＨＩＧＨＳＣＨＯＯＬ　ＯＦ　ＴＨＥ　ＤＥＡＤ（限定版）(7)(オリジナルアニメＢｌｕ－ｒａｙ付)</p>
+            <div class="modalStoreInformation__body js-modalInnerContent" style="height: 549.516px;">
+              <p class="modalStoreInformation__heading">商品が入荷した店舗：32店</p>
+              <p class="modalStoreInformation__note">在庫状況は少し前の情報となります。店頭では売り切れの場合もございます。電話でのお取り置きやお取り寄せは行っておりませんのでご注意ください</p>
+              <div class="modalStoreInformation__storeSearch">
+                <div class="modalStoreInformation__select">
+                  <select name="month" class="modalStoreInformation__selectTag -empty">
+                    <option value="" selected="">都道府県を選択</option>
+                    <option value="北海道">北海道</option>
+                    <option value="青森県">青森県</option>
+                    <option value="岩手県">岩手県</option>
+                    <option value="宮城県">宮城県</option>
+                    <option value="秋田県">秋田県</option>
+                    <option value="山形県">山形県</option>
+                    <option value="福島県">福島県</option>
+                    <option value="茨城県">茨城県</option>
+                    <option value="栃木県">栃木県</option>
+                    <option value="群馬県">群馬県</option>
+                    <option value="埼玉県">埼玉県</option>
+                    <option value="千葉県">千葉県</option>
+                    <option value="東京都">東京都</option>
+                    <option value="神奈川県">神奈川県</option>
+                    <option value="新潟県">新潟県</option>
+                    <option value="富山県">富山県</option>
+                    <option value="石川県">石川県</option>
+                    <option value="福井県">福井県</option>
+                    <option value="山梨県">山梨県</option>
+                    <option value="長野県">長野県</option>
+                    <option value="岐阜県">岐阜県</option>
+                    <option value="静岡県">静岡県</option>
+                    <option value="愛知県">愛知県</option>
+                    <option value="三重県">三重県</option>
+                    <option value="滋賀県">滋賀県</option>
+                    <option value="京都府">京都府</option>
+                    <option value="大阪府">大阪府</option>
+                    <option value="兵庫県">兵庫県</option>
+                    <option value="奈良県">奈良県</option>
+                    <option value="和歌山県">和歌山県</option>
+                    <option value="鳥取県">鳥取県</option>
+                    <option value="島根県">島根県</option>
+                    <option value="岡山県">岡山県</option>
+                    <option value="広島県">広島県</option>
+                    <option value="山口県">山口県</option>
+                    <option value="徳島県">徳島県</option>
+                    <option value="香川県">香川県</option>
+                    <option value="愛媛県">愛媛県</option>
+                    <option value="高知県">高知県</option>
+                    <option value="福岡県">福岡県</option>
+                    <option value="佐賀県">佐賀県</option>
+                    <option value="長崎県">長崎県</option>
+                    <option value="熊本県">熊本県</option>
+                    <option value="大分県">大分県</option>
+                    <option value="宮崎県">宮崎県</option>
+                    <option value="鹿児島県">鹿児島県</option>
+                    <option value="沖縄県">沖縄県</option>
+                  </select>
+                </div>
+                <div class="modalStoreInformation__select">
+                  <select name="month" class="modalStoreInformation__selectTag -empty">
+                    <option value="" selected="">市区町村を選択</option>
+                    <option value="札幌市">札幌市</option>
+                  </select>
+                </div>
+              </div>
+              <ul class="modalStoreInformation__list">
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+                <li class="modalStoreInformation__item">
+                  <a href="/" class="modalStoreInformation__link"> BOOKOFF 札幌南2条店 <small class="modalStoreInformation__address">北海道札幌市中央区</small>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="modal__close js-modalClose" tabindex="0"><img src="/library/common/svg/close.svg" alt="close"></div>
+        </div>
+        <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+      </div>
+    </div>
+			</div>
+		</div>
+	</div>
+
+</div></div>
+<script  src="/library/common/js/sjis_convert.min.js"></script>
+<script  src="/library/common/js/suggest_module.js?d=20240911"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-show.js?rev=20260427"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-item.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-contents.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/core.js"></script>
+</body>
+</html>

--- a/tests/fixtures/used_book/bookoff_search.html
+++ b/tests/fixtures/used_book/bookoff_search.html
@@ -1,0 +1,2916 @@
+<!DOCTYPE html>
+<html data-csrf-tmp-token="408878399eedc17c" data-csrf-tmp-verifier="84212ef1794567008007fee0ea29c8a507f643388b6e638d2e68d285dd9afcb9" xmlsn:og="http://ogp.me/ns#" xmlns:fb="http://ogp.me/ns/fb#" lang="ja">
+<head>
+<meta charset="UTF-8">
+
+<link rel="shortcut icon" href="/favicon.ico?dummy=1674087367" />
+<link rel="stylesheet" type="text/css" href="/css/shopping/search.css" charset="UTF-8" />
+<link rel="stylesheet" type="text/css" href="/publis.css" /><meta name="keywords" content="ブックオフ公式オンラインストアの検索ページです。有名書籍から人気コミックまで幅広いジャンルでお気に入りの作品が見つかるかも？　本(書籍)、漫画(コミック)、CD、DVD・ブルーレイ、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<meta name="description" content="" />
+<title>検索一覧  | ブックオフ公式オンラインストア</title>
+<script >
+<!--
+	var pbGlobalAliasBase = '/';
+//-->
+</script>
+<script  src="/public.js"></script>
+<meta name="viewport" content="width=device-width">
+<!--link rel="shortcut icon" href="https://content.bookoffonline.co.jp/favicon.ico"-->
+<link rel="apple-touch-icon" sizes="180x180" href="/library/common/images/apple_touch_icon.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/library/common/images/webclip_android.png">
+<link rel="stylesheet" href="/library/common/css/common.css?d=20250416">
+<link rel="stylesheet" href="/library/common/css/headerFooter.css">
+<script src="https://content.bookoff.co.jp/files/common/js/jquery-2.2.4.min.js"></script>
+<script src="/library/common/js/vendor.bundle.js"></script>
+<script src="/library/common/js/common.js"></script>
+<script src="/library/common/js/headerFooter.js"></script>
+<!--<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>-->
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/items-container.css?rev=20260612" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/plugin/splide.min.js"></script>
+
+<script  src="https://content.bookoff.co.jp/files/common/js/jquery-1.12.4.min.js"></script>
+<script>
+
+	var class_name = 'BocSearchResult';
+
+$(document).on('click', '.js-ageverification', function(){
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+	var modalBtn = $('#ageVerification__btns--agree');
+
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+
+	// カートに追加、在庫有りのみカートに追加、巻数を指定してカートに追加する
+	$(document).on('click', '.jsBtn-cart', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if (mode == 'disabled') {
+			return false;
+		}
+		if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+			// 在庫有りのみカートに追加の場合、複数回クリック不許可
+			$(this).attr('data-mode', 'disabled');
+		}
+		var ex_param = {};
+		if (mode == 'Add') {
+			ex_param['stockType'] = $(this).attr('data-stock') ?? '';
+		}
+		if (mode == 'AddSelectedItems') {
+			var selectItemIds = {};
+			$('input[type="checkbox"].js-allCheckTarget:checked').each(function(index){
+				selectItemIds[index] = $(this).closest('.productSetItem__checkbox').find('input.item_id').val() ?? '';
+			});
+			ex_param['selectItemIds'] = selectItemIds;
+		}
+		if(age_limit == 1) {
+			ageVerification('cart', mode, item_id, ex_param);
+		} else {
+			ajaxConfig('cart', mode, item_id, ex_param);
+		}
+	});
+	// お気に入り追加・削除
+	$(document).on('click', '.jsBtn-favorite', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('favorite', mode, item_id);
+		} else {
+			ajaxConfig('favorite', mode, item_id);
+		}
+	});
+	// 入荷お知らせ追加・削除、全巻入荷お知らせ追加・削除
+	$(document).on('click', '.jsBtn-arrival', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('arrival', mode, item_id);
+		} else {
+			ajaxConfig('arrival', mode, item_id);
+		}
+	});
+	// 値下げのお知らせ追加・削除
+	$(document).on('click', '.jsBtn-discount', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var ex_param = {};
+		ex_param['price'] = $(this).attr('data-price') ?? 0;
+
+		if (mode == 'Add_PriceChange' || mode == 'PriceChange'){
+		    ex_param['targetPrice'] = $('#modal #discountAlert input[name="discountAlert"]').val() ?? 0;
+			if (ex_param['targetPrice'] == 0 || ex_param['targetPrice'] == '') {
+				discountModalError('1円以上で入力してください');
+			} else if (parseInt(ex_param['targetPrice']) >=  parseInt(ex_param['price'])) {
+				if (item_id.slice(0, 2) == '88') {
+					discountModalError('定価合計価格より小さい金額を入力してください');
+				} else {
+					discountModalError('中古価格より小さい金額を入力してください');
+				}
+			} else if (!ex_param['targetPrice'].match(/^[0-9]+$/)) {
+				discountModalError('半角数字で入力してください');
+			} else {
+				// 「0」埋めの入力は頭削除して登録
+				if (ex_param['targetPrice'].match(/^0+/)) {
+					ex_param['targetPrice'] = new Intl.NumberFormat('ja-JP').format(ex_param['targetPrice']);
+				}
+				ajaxConfig('discount', mode, item_id, ex_param);
+			}
+		} else if(mode == 'Add') {
+		    ex_param['targetPrice'] = $(this).attr('data-target-price') ?? 0;
+			ajaxConfig('discount', mode, item_id, ex_param);
+		} else if(mode == 'Delete') {
+			ajaxConfig('discount', mode, item_id);
+		}
+	});
+	// 最新刊のお知らせ追加・削除
+	$(document).on('click', '.jsBtn-latests', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		ajaxConfig('latests', mode, item_id);
+	});
+
+	// 在庫ない商品一覧表示確認モーダル
+	$(document).on('click', '.jsBtn-cart-modal', function(event){
+		event.preventDefault();
+		$('#modalSetAddCart ul.modalSetAddCart__list').empty();
+		var item_id = $(this).attr('data-item');
+		ajaxConfig('cart', 'RewriteSetModal', item_id);
+	});
+
+	// 値下げのお知らせ価格設定変更モーダル
+	$(document).on('click', '.jsBtn-discount-modal', function(event){
+		event.preventDefault();
+		var item_id = $(this).attr('data-item') ?? '';
+		var price = $(this).attr('data-price') ?? '';
+		var target_price = $(this).attr('data-target-price') ?? '';
+		var modal = $(this).attr('data-modal') ?? '';
+
+		if (modal = 'discountAlert') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-price', price);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-target-price', target_price);
+
+				if (item_id.slice(0, 2) == '88') {
+					$('.modalConfirm__regularPrice').show();
+				}else {
+					$('.modalConfirm__regularPrice').hide();
+				}
+
+				$('#modal #discountAlert #discount-market-price').text(price.toLocaleString());
+				$('#modal #discountAlert #discount-target-price').text(target_price.toLocaleString());
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlert').addClass('-show');
+
+		} else if (modal = 'discountAlertCancel') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlertCancel').addClass('-show');
+		}
+	});
+
+	$(document).on('click', '.js-modalClose', function(event){
+		event.preventDefault();
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+	$(document).on('click', '.modal__overlay', function(event){
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+
+	function initializeDiscountModal () {
+		$('#modal #discountAlert input[name="discountAlert"]').removeClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").hide();
+		$("#modal #discountAlert .modalConfirm__error").text('');
+		$('#modal').removeClass('-show -visible');
+		$('#modal #discountAlert').removeClass('-show');
+		$('#modal #discountAlert input[name="discountAlert"]').val('');
+	}
+
+	function discountModalError (str) {
+		$('#modal #discountAlert input[name="discountAlert"]').addClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").show();
+		$("#modal #discountAlert .modalConfirm__error").text(str);
+	}
+</script><script>
+	function ageVerification(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 728352
+						, 'pageId': 1316
+						, 'revision': 0
+						, 'type': 'ageVerification'
+						, 'mode': 'Agree'
+						, 'itemId': item_id
+					};
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+			// 検索一覧内のボタンをすべて書き換え
+				$('.js-ageverification').each(function() {
+					elmType = $(this).attr('data-type');
+					if (elmType == 'cart') {
+						var btnClass = 'jsBtn-cart';
+					} else if (elmType == 'favorite') {
+						var btnClass = 'jsBtn-favorite';
+					} else if (elmType == 'arrival') {
+						var btnClass = 'jsBtn-arrival';
+					}
+					$(this).addClass(btnClass);
+				});
+				$('.js-ageverification').addClass('ac-click-cv');
+				$('.js-ageverification').removeAttr('data-type');
+				$('.js-ageverification').removeAttr('data-modal');
+				$('.js-ageverification').removeClass('js-modal js-ageverification');
+
+				// モーダルを閉じる
+				$('.modal__inner').removeClass('-show');
+				$('#modal').removeClass('-visible -show');
+				$('body').removeClass('-modalOpen');
+				$('html').removeAttr('data-whatelement data-whatclasses');
+				// モーダルのDOM要素を削除
+				$('[id^="modalAgeVerification"]').remove();
+				// ajaxConfig 実行
+				ajaxConfig(type, mode, item_id, ex_param);
+			} else if (data.status == 'FAILED_AGE_VERIFICATION') {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			} else {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+			$('.ageVerificationBlock__txt--error').text(errMsg);
+			$('.ageVerificationBlock__txt--error').show();
+			return false;
+		});
+	}
+
+	function ajaxConfig(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 728352
+						, 'pageId': 1316
+						, 'revision': 0
+						, 'type': type
+						, 'mode': mode
+						, 'itemId': item_id
+						, 'exParam' : ex_param
+					};
+
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+				// カートに追加
+				if (type == 'cart') {
+					thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-cart-modal[data-item="' + item_id + '"]';
+
+					if (mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocProductSet') {
+							var checkNum = 0;
+							$('.js-allCheckTarget').each(function(){
+								if ($(this).prop('checked')) {
+									checkNum++;
+								}
+							});
+							if (checkNum == 0) {
+								window.location.href = '/cart/';
+							}
+						}
+					}
+
+					if (mode == 'Add' || mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocRankingOfWeekList' || class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSearchResult') {
+							// カートを見るボタンに変更
+							sourceObj = $(thisId);
+							targetObj = $('<a>');
+							sourceObj.removeClass('jsBtn-cart');
+							sourceObj.addClass('-added');
+							targetObj.attr('href', '/cart/');
+							targetObj.text(' カートを見る ');
+							$.each(sourceObj[0].attributes, function() {
+								targetObj.attr(this.name, this.value);
+							});
+							sourceObj.replaceWith(targetObj);
+						} else {
+							$(thisId).attr('href', '/cart/');
+							$(thisId).addClass('-added');
+							$(thisId).text(' カートを見る ');
+							$(thisId).removeClass('jsBtn-cart');
+						}
+					} else if (mode == 'AddSetInStock') {
+						if (class_name == 'BocRankingOfWeekList') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisItemBtnId).addClass('-added');
+							$(thisItemBtnId).text(' カートを見る ');
+							$(thisItemBtnId).attr('data-modal', '');
+							$(thisItemBtnId).attr('data-mode', '');
+							$(thisItemBtnId).off('click');
+							$(thisItemBtnId).attr('href', '/cart/');
+							$(thisItemBtnId).removeClass('jsBtn-cart-modal btn--2l js-modal');
+							// モーダルを閉じる
+							$('.modal__overlay').trigger('click');
+						}
+					} else if (mode == 'RewriteSetModal') {
+						$('#modalSetAddCart .jsBtn-cart').attr('data-item', item_id).attr('data-mode', 'AddSetInStock');
+						$('#modalSetAddCart .modal__title span').text(data.stock_count);
+						for (var i in data.no_stock_items) {
+							var liText = '<li class="modalSetAddCart__item">' + data.no_stock_items[i].item_name + '</li>';
+							$('#modalSetAddCart ul.modalSetAddCart__list').append(liText);
+						}
+						$('#modalSetAddCart .js-modalInnerContent').css('height','500px');
+					}
+				}
+				// お気に入り
+				if (type == 'favorite') {
+					thisId = '.jsBtn-favorite[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $(thisId);
+							displayTooltip(click_ele, type, data.message);
+						}
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite icon-favorite-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite-on icon-favorite-on-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite icon-favorite-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite-on icon-favorite-on-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加済');
+						$(thisId).attr('data-mode', 'Delete');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'delSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Detail');
+						}
+					}
+					if (mode == 'Delete') {
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite-on icon-favorite-on-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite icon-favorite-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite-on icon-favorite-on-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite icon-favorite-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加');
+						$(thisId).attr('data-mode', 'Add');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'addSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Detail');
+						}
+					}
+				}
+				// 入荷お知らせ
+				if (type == 'arrival') {
+					thisId = '.jsBtn-arrival[data-item="' + item_id + '"]';
+					if (mode == 'Add' || mode == 'AddSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							if (data.message) {
+								click_ele = $(thisId);
+								displayTooltip(click_ele, type, data.message);
+							}
+							$(thisId).addClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷お知らせを解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							} else if (mode == 'AddSet') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'DeleteSet');
+							} else if (mode == 'Add') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'delAlertMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'delAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Ranking');
+							}
+						}
+					} else if (mode == 'Delete' || mode == 'DeleteSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId).removeClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷のお知らせを受け取る');
+								$(thisId).attr('data-mode', 'Add');
+							} else if (mode == 'DeleteSet') {
+								$(thisId).text('全巻入荷お知らせ');
+								$(thisId).attr('data-mode', 'AddSet');
+							} else if (mode == 'Delete') {
+								$(thisId).text('入荷お知らせ');
+								$(thisId).attr('data-mode', 'Add');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Ranking');
+							}
+						}
+					}
+				}
+				// 値下げお知らせ
+				if (type == 'discount') {
+					thisId = '.jsBtn-discount[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						}
+					}
+					if (mode == 'PriceChange') {
+						if (class_name == 'BocAlertMailList') {
+							initializeDiscountModal();
+							$('#modal #discountAlert .jsBtn-discount').attr('data-item', '');
+							$('#modal #discountAlert .jsBtn-discount').attr('data-price', '');
+							var thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+							var targetPrice = ex_param['targetPrice'];
+							$(thisItemBtnId).attr('data-target-price', targetPrice);
+							$('#discount-target-price-' + item_id).text(targetPrice.toLocaleString());
+						}
+					}
+					if (mode == 'Add_PriceChange') {
+						if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを登録済');
+							$(thisItemBtnId).attr('data-modal','discountAlertCancel');
+							$(thisItemBtnId).attr('data-mode', 'Delete');
+							// モーダルを閉じる
+							initializeDiscountModal();
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'delSetMailPriceDown_Detail');
+							}
+						}
+					}
+					if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを受け取る');
+							$(thisItemBtnId).attr('data-modal','discountAlert');
+							$(thisItemBtnId).attr('data-mode', 'Add');
+							// モーダルを閉じる
+							$('#modal').removeClass('-show -visible');
+							$('#modal #discountAlertCancel').removeClass('-show');
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'addSetMailPriceDown_Detail');
+							}
+						}
+					}
+				}
+				// 最新刊お知らせ
+				if (type == 'latests') {
+					thisId = '.jsBtn-latests[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを登録済');
+							$(thisId).attr('data-mode', 'Delete');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delNewAlertMail_Detail');
+							}
+						}
+					} else if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを受け取る');
+							$(thisId).attr('data-mode', 'Add');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addNewAlertMail_Detail');
+							}
+						}
+					}
+				}
+			// 在庫なし、もしくは、何らかの原因でカート未追加
+			} else if (data.status == 'NO_STOCK' || data.status == 'FAILED_TO_CART') {
+				if (type == 'cart') {
+					// 他のモーダル開いてたら閉じる
+					if ($('.js-modalInner').hasClass('-show')) {
+						$('#modal').removeClass('-show -visible');
+						$('.js-modalInner').removeClass('-show');
+					}
+					// カートに追加できませんでしたモーダルを開く
+					if($('#modalCartAddStock0').length){
+						if (data.status == 'NO_STOCK' || data.error_code == 'OC456') {
+							$('#modalCartAddStock0 .js-cart-alert').text('在庫がなくなったため、商品をカートに追加できませんでした。再読み込みしてページを更新します');
+						} else {
+							$('#modalCartAddStock0 .js-cart-alert').text('現在お取り扱いのない商品が含まれるため、カートに追加できませんでした。再読み込みしてページを更新します');
+						}
+						$('[data-modal="modalCartAddStock0"]').trigger("click");
+					}
+					// disabledにしたカートボタンを元に戻す
+					if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+						thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+						if($(thisId).attr('data-mode') == 'disabled') {
+							$(thisId).attr('data-mode', mode);
+						}
+					}
+				}
+			// 何らかの原因で処理未完了
+			} else if (data.status == 'NG') {
+				if (type == 'favorite') {
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $('.jsBtn-favorite[data-item="' + item_id + '"]');
+							displayTooltip(click_ele, type, data.message);
+						}
+					}
+				}
+			// 未ログインもしくはAPIエラー
+			} else if (data.status == 'NO_LOGIN' || data.status == 'API_ERROR') {
+				window.location.href = data.url;
+			} else {
+				alert("エラーが発生しました。もう一度設定してください。");
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			alert("エラーが発生しました。");
+		});
+	}
+
+	function displayTooltip(click_ele_selector, btnType, message) {
+		var display_time = 2500;
+		var click_ele = $(click_ele_selector);
+		var original_width = click_ele.outerWidth();
+		// wrap
+		if(!click_ele.parent().hasClass('tipsBalloonArea')){
+			click_ele.each(function() {
+				var self = jQuery(this);
+				var area = jQuery('<div class="tipsBalloonArea"></div>').css({
+					'width': '100%',
+					'margin': self.css('margin'),
+					'margin-bottom': '0'
+				});
+				self.wrap(area);
+			});
+		}
+		// ツールチップHTML
+		var html = '';
+		var isProductPage = !click_ele.hasClass('productItem__favorite');
+		if (isProductPage) {
+			click_ele.parent().addClass('tipsBalloonAreaProductPage');
+			html = '<div class="tipsBalloon tipsBalloon--favorite tipsBalloonFavoriteProductPage"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if (btnType === 'favorite'){
+			html = '<div class="tipsBalloon tipsBalloon--favorite"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if(btnType === 'arrival') {
+			html = '<div class="tipsBalloon tipsBalloon--tail-center"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		}
+		// ツールチップ生成・幅設定・表示
+		var tooltip_ele = $(html).insertBefore(click_ele).hide();
+		if(btnType == 'arrival'){
+			// 入荷お知らせの時のみ調整
+			click_ele.closest('.tipsBalloonArea').each(function() {
+				var self = $(this);
+				if (self.parent().hasClass('cartFloat__btn')) {
+					self.css('position', 'unset');
+				}
+				self.children('.tipsBalloon').css({
+					'min-width': self.children('.jsBtn-arrival').outerWidth(),
+					'bottom': self.children('.jsBtn-arrival').outerHeight() * 1.5,
+					'right': 'unset'
+				});
+			});
+		}
+		tooltip_ele.show();
+		setTimeout(function() {
+			tooltip_ele.fadeOut(200);
+			tooltip_ele.remove();
+			// unwrap
+			if(click_ele.parent().hasClass('tipsBalloonArea')){
+				click_ele.unwrap();
+			}
+		}, display_time);
+	}
+</script>
+<script >
+window.headerMenuInfo = window.headerMenuInfo || {
+	pageId: "1316",
+	blockId: "751263"
+};
+</script>
+<script type="text/javascript">
+const _boud={};
+</script>
+<meta property="og:site_name" content="ブックオフ公式オンラインストア" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://shopping.bookoff.co.jp/library/common/images/ogp.webp" />
+<meta property="og:title" content="検索一覧  | ブックオフ公式オンラインストア" />
+<meta property="og:description" content="" />
+<meta property="og:url" content="https://shopping.bookoff.co.jp/search/keyword/9784813705185" />
+<link rel="canonical" href="https://shopping.bookoff.co.jp/search/keyword/9784813705185">
+
+<script>const _isLogin = false;const _isApp=(function(){const uaList='BookoffApp';const userAgent=navigator.userAgent;return userAgent.includes(uaList)})();</script>
+<link rel="stylesheet" type="text/css" href="/library/init/css/publis4-default.css" />
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__search.css" />
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/search/parts.css?rev=20240516" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/search.js?rev=20250603"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/parts.js"></script>
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/search.css?rev=20260604" />
+<link rel="stylesheet" type="text/css" href="" />
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/search/normal/parts.css?rev=20260602" />
+<script  src="https://content.bookoff.co.jp/assets/js/search/normal/parts.js?rev=20260707"></script>
+</head>
+<body>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T8MGMLD');</script>
+<!-- End Google Tag Manager -->
+<script src="https://d.adlpo.com/687/2212/js/smartadlpo.js"></script>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8MGMLD" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<script  src="https://content.bookoff.co.jp/assets/js/common/components.js"></script>
+<noscript><p>このページではjavascriptを使用しています。</p></noscript>
+<div id="page" class="pbPage">
+<div id="headerArea" class="pbHeaderArea">
+	<div id="area1" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10023">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162219">
+						
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162220">
+						<style type="text/css">
+/* 宅配買取ボタン */
+/* common.css */
+.header__menuSell.sellBtn {
+  display: block;
+  padding: 3px 20px;
+  background-color: #fff000;
+  border: 1px solid #fff000;
+  border-radius: 99px;
+  color: #003894;
+  font-weight: bold;
+  font-size: 16px;
+}
+.header__menuSell {
+  margin-left: 8px;
+}
+/* headerFooter.css */
+.header__menu ul {
+  align-items: center;
+}
+</style>
+<div class="header js-header" id="header">
+  <div class="header__wrap js-headerFixed" style="">
+    <div class="header__inner">
+      <div class="header__logoWrap js-headerLogo">
+
+        <div class="header__logo">
+          <a href="/" class="header__logo__img">
+            <img src="/library/common/images/img-logo.png" alt="BOOKOFF">
+          </a>
+          <div class="header__logo__more">
+            <a class="js-headerLogoBtn" href="/"></a>
+          </div>
+        </div>
+        <div class="header__logoContent js-headerLogoContent">
+          <div class="header__logoContentUserGuide">
+            <a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a>
+          </div>
+          <div class="header__logoContentHeader">
+            <a href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+          </div>
+          <ul>
+            <li>
+              <a href="https://www.bookoff.co.jp/shop/" class="header__linkStore">店舗検索</a>
+            </li>
+            <li>
+              <a href="https://sell.bookoff.co.jp/" class="header__linkPurchase">買取はこちら</a>
+            </li>
+          </ul>
+        </div>
+
+      </div>
+      <nav class="header__navi">
+        <div class="header__naviTop">
+          <div class="header__search js-headerSearch">
+            <div class="header__searchInner">
+              <form name="zsForm" id="zsSearchForm" class="header__searchForm">
+                <input id="zsSearchFormInput" type="search" enterkeyhint="search" name="kw_sn" placeholder="キーワード・品番で検索" autocomplete="off" class="zs-search-input" id="zsSearchFormInput">
+                <span class="header__searchIcon">
+                  <img src="/library/common/svg/search-gray.svg" alt="">
+                </span>
+                <span class="header__searchFormClear">
+                  <img src="/library/common/svg/search-clear.svg" alt="" id="zsSearchClearButton">
+                </span>
+              </form>
+              <div class="header__searchHistory" id="zsHistoryArea">
+                <div class="header__searchHistoryHeading">検索履歴</div>
+                <ul class="js-searchHistory" id="zsSearchHistoryAreaUl">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchHistory -->
+              <div class="header__searchSuggest" id="zsSuggestDiv">
+                <ul class="js-searchSuggest">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchSuggest -->
+            </div>
+          </div>
+          <div class="header__menu">
+                        <ul>
+                <li>
+                  <a class="header__menuSell sellBtn" href="https://sell.bookoff.co.jp/">宅配買取</a>
+                </li>
+                <li>
+                    <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+                </li>
+                <li>
+                    <div class="header__menuAccount js-headerAccount">
+                        <a href="" class=" js-headerAccountBtn"><img src="/library/common/svg/account.svg" alt=""></a>
+                        <div class="header__menuAccountContent js-headerAccountContent">
+                                                            <div class="header__loginBtn">
+                                    <ul>
+                                        <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+                                        <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+                                    </ul>
+                                </div>
+                                                    </div>
+                    </div>
+                </li>
+                <li>
+                    <a href="/cart" ><img src="/library/common/svg/cart.svg" alt="Cart"></a>
+                </li>
+            </ul>
+                      </div>
+        </div>
+        <div class="header__category js-headerCategory">
+          <ul>
+            <li><a href="/book">書籍</a></li>
+            <li><a href="/comic">コミック</a></li>
+            <li><a href="/cd">CD</a></li>
+            <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+            <li><a href="/game">ゲーム</a></li>
+            <li><a href="/set">セット・まとめ買い</a></li>
+          </ul>
+        </div>
+      </nav>
+
+            <div class="header__naviSp">
+        <div class="header__naviTopSp">
+          <div class="header__menuBtnSp js-spMenuBtn">
+            <img src="/library/common/svg/menu.svg" alt="メニュー">
+          </div>
+          <div class="header__menuSp">
+            <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+            <a href="/cart" ><img src="/library/common/svg/cart.svg" alt=""></a>
+          </div>
+        </div>
+      </div>
+      
+    </div><!-- /header__inner -->
+  </div><!-- /header__wrap -->
+</div><!-- /header js-header -->
+
+<div class="spHeaderMenu js-spHeaderMenu">
+  <div class="spHeaderMenu__close">
+    <span class="js-spHeaderMenuClose" tabindex="0">
+      <img src="/library/common/svg/close.svg" alt="close">
+    </span>
+  </div>
+  <div class="spHeaderMenu__inner">
+
+        <div class="spHeaderMenu__loginBtn">
+        <ul>
+            <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+            <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+        </ul>
+    </div>
+    
+    <div class="spHeaderMenu__heading">カテゴリ</div>
+    <div class="spHeaderMenu__list">
+      <ul>
+        <li><a href="/book">書籍</a></li>
+        <li><a href="/comic">コミック</a></li>
+        <li><a href="/cd">CD</a></li>
+        <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+        <li><a href="/game">ゲーム</a></li>
+        <li><a href="/set">セット・まとめ買い</a></li>
+      </ul>
+    </div>
+    <div class="spHeaderMenu__list">
+      <ul class="spHeaderMenu__listUserGuide">
+      <li><a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a></li>
+      </ul>
+    </div>
+    <a class="spHeaderMenu__linkStore" href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+    <a class="spHeaderMenu__linkSearch" href="https://www.bookoff.co.jp/shop/">店舗検索</a>
+    <a class="spHeaderMenu__linkPurchase" href="https://sell.bookoff.co.jp/">買取はこちら</a>
+  </div>
+</div>
+<div class="spHeaderMenuOverlay js-spHeaderMenuClose">&nbsp;</div>
+<script type="text/javascript">
+$(document).ready(function () {
+	$('.logout-link').on('click', function() {
+		const logoutUrl="https://my.bookoff.co.jp/logout";
+		ajax_jquery(logoutUrl)
+		.done(function() {
+			const loginUrl="https://my.bookoff.co.jp/login";
+			window.location.href=loginUrl;
+		})
+		.fail(function(e) {
+			let errUrl="/err/404";
+			switch(true){
+				case e.status==502:
+					errUrl="/err/408";
+					break;
+				case e.status>=500:
+					errUrl="/err/500";
+					break;
+			}
+			window.location.href=errUrl;
+		});
+	});
+});
+
+  // point
+  window.loadPoint = function() {
+    const send_data = {
+      "className": "BocHeaderMenu",
+      "blockId": window.headerMenuInfo.blockId,
+      "pageId": window.headerMenuInfo.pageId,
+      "revision": 0,
+      "type": "loadPoint"
+    };
+    ajax_jquery({
+      url: "/view_interface.php",
+      type: "POST",
+      data: send_data,
+      dataType: "json"
+    })
+    .done(function(data, textStatus, jqXHR) {
+      document.querySelectorAll("div.js-headerAccountContent .header__point,div.js-spHeaderMenu .spHeaderMenu__point")
+        .forEach(el => {
+          el.innerHTML = (data.point || "-") + "<span>P</span>";
+        });
+    });
+  }
+</script>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock162458">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock145581">
+						<div class="headerMessage">
+    	<div class="headerMessage__text">1,800円以上の注文で<span class="headerMessage__textDecoration">送料無料</span></div>
+  </div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div><div id="areaWrapper1" class="pbAreaWrapper1"><div id="areaWrapper2" class="pbAreaWrapper2"><div id="mainArea" class="pbMainArea">
+	<div id="area0" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock259613">
+								<div class="pbNested " >
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10018">
+								<div class="pbNested " >
+		</div>
+
+			</div>
+			<div class="mainContent pbNested pbNestedWrapper "  id="pbBlock10011">
+								<div class="pbNested " >
+			<div class="mainContent__inner pbNested pbNestedWrapper "  id="pbBlock10012">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock10027">
+						<div class="hashtag">
+	<div class="hashtag__inner js-scrollHorizontalEnd">
+		<ul class="hashtagList js-scrollHorizontalEnd-list">
+													<li class="hashtagList__item"><a href="/search/hashtag/%E9%9D%A2%E7%99%BD%E3%81%84" class="hashtagBtn hashtagBtn--link">面白い</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E6%A5%BD%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">楽しい</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E6%84%9F%E5%8B%95" class="hashtagBtn hashtagBtn--link">感動</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%A5%B3%E3%81%AE%E5%AD%90" class="hashtagBtn hashtagBtn--link">女の子</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%84%AA%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">優しい</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%B9%B8%E3%81%9B" class="hashtagBtn hashtagBtn--link">幸せ</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E9%AB%98%E6%A0%A1%E7%94%9F" class="hashtagBtn hashtagBtn--link">高校生</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E7%94%9F%E3%81%8D%E6%96%B9" class="hashtagBtn hashtagBtn--link">生き方</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%88%87%E3%81%AA%E3%81%84" class="hashtagBtn hashtagBtn--link">切ない</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E8%A1%9D%E6%92%83" class="hashtagBtn hashtagBtn--link">衝撃</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%B9%BC%E3%81%AA%E3%81%98%E3%81%BF" class="hashtagBtn hashtagBtn--link">幼なじみ</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E3%82%AB%E3%83%83%E3%83%97%E3%83%AB" class="hashtagBtn hashtagBtn--link">カップル</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E3%82%AD%E3%83%A9%E3%82%AD%E3%83%A9" class="hashtagBtn hashtagBtn--link">キラキラ</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%AE%B6%E6%97%8F" class="hashtagBtn hashtagBtn--link">家族</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E6%84%9B%E6%83%85" class="hashtagBtn hashtagBtn--link">愛情</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E6%87%90%E3%81%8B%E3%81%97%E3%81%84" class="hashtagBtn hashtagBtn--link">懐かしい</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E7%94%B0%E8%88%8E" class="hashtagBtn hashtagBtn--link">田舎</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E5%A4%A7%E3%83%92%E3%83%83%E3%83%88%E4%BD%9C" class="hashtagBtn hashtagBtn--link">大ヒット作</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E8%8B%A6%E6%82%A9" class="hashtagBtn hashtagBtn--link">苦悩</a></li>
+											<li class="hashtagList__item"><a href="/search/hashtag/%E8%A6%9A%E6%82%9F" class="hashtagBtn hashtagBtn--link">覚悟</a></li>
+				</ul>
+	</div>
+</div>
+<div class="mainContent__search">
+  <div class="mainContent__col">
+    <div class="productSearch">
+      <h1 class="productSearch__ttl">
+        <span class="productSearch__ttlInner">検索結果<span class="productSearch__word">9784813705185</span></span>
+      </h1>
+        <div class="productSearch__inner">
+          <div class="productSearch__control">
+            <div class="productSearch__refinement">
+              <div class="productSearch__item productSearch__item--refinement forSp">
+
+                <a class="productInformation__list__link js-modal ac-click-cv" data-cv-name="filterOpen_Search" data-modal="modalSearchRefinement" data-mode="full">
+                  <span class="icon-refinement icon-refinement-dims"></span>
+                  <span>条件を追加</span>
+                </a>
+
+              </div>
+              <div class="productSearch__item productSearch__item--num">
+                <p class="productSearch__num">1件～1件（全1件）</p>
+              </div>
+            </div>
+            <div class="productSearch__sortGroup">
+              <div class="productSearch__item productSearch__item--sort">
+                <dl id="sort_modal" class="js-sortDropdown listDropDown">
+                  <dt class="listDropDown__heading">
+                    <a href="" class="listDropDown__btn js-sortDropdownBtn ac-click-cv" data-cv-name="sortOpen_Search">
+                      <span class="forPc">ならびかえ</span>
+                      <span class="forSp">
+                        <span class="itemSortText">ならびかえ</span>
+                      </span>
+                      <span class="icon-sort icon-sort-dims"></span>
+                    </a>
+                  </dt>
+                  <dd id="sort_modal_list" class="listDropDown__contents js-sortDropdownContents">
+					  	                    	                                      <ul class="listDropDown__list">
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link -active ac-click-cv" data-listoption="sortkey" data-listoption-param="00" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185">人気順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="50" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=50">中古価格が安い順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="51" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=51">中古価格が高い順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="40" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=40">新品価格が安い順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="41" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=41">新品価格が高い順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="10" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=10">発売日が新しい順</a>
+                      </li>
+                      <li class="listDropDown__item">
+                        <a class="listDropDown__link ac-click-cv" data-listoption="sortkey" data-listoption-param="11" data-cv-name="sortOn_Search" href="/search/keyword/9784813705185?sort=11">発売日が古い順</a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+              </div>
+              <div class="productSearch__item productSearch__item--toggle js-toggleList">
+                <ul class="productSearch__toggle">
+                  <li class="productSearch__toggleItem">
+                    <a href="" id="display_change_list"
+                      class="productSearch__toggleBtn productSearch__toggleBtn--list -active js-toggleListBtn"
+                      data-type="list" aria-label="リスト表示"></a>
+                  </li>
+                  <li class="productSearch__toggleItem">
+                    <a href="" id="display_change_grid"
+                      class="productSearch__toggleBtn productSearch__toggleBtn--grid js-toggleListBtn"
+                      data-type="grid" aria-label="グリッド表示"
+                    ></a>
+                  </li>
+                </ul>
+              </div>
+              <div class="productSearch__item productSearch__item--displayNum">
+                <dl id="display_number_modal" class="js-sortDropdown listDropDown listDropDown--num">
+                  <dt class="listDropDown__heading">
+                    <span class="forPc">表示件数：</span>
+                    <a href="" class="listDropDown__btn js-sortDropdownBtn">
+                    <span id="display_number" class="listDropDown__btnTxt">30件</span>
+                    <span class="icon-arrow-s icon-arrow-s-dims"></span></a>
+                  </dt>
+                  <dd id="display_number_modal_list" class="listDropDown__contents js-sortDropdownContents">
+                                                                            <ul class="listDropDown__list">
+                      <li class="listDropDown__item">
+                          <a class="listDropDown__link -active" data-listoption="pagecount" data-listoption-param="30" href="/search/keyword/9784813705185">30件</a>
+                      </li>
+                      <li class="listDropDown__item">
+                          <a class="listDropDown__link" data-listoption="pagecount" data-listoption-param="60" href="/search/keyword/9784813705185?per-page=60">60件</a>
+                      </li>
+                      <li class="listDropDown__item">
+                          <a class="listDropDown__link" data-listoption="pagecount" data-listoption-param="120" href="/search/keyword/9784813705185?per-page=120">120件</a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="items_field" class="productItems js-toggleListTarget">
+          <div class="productItems__inner">
+              <div class="productItem js-hoverItem">
+                <div class="productItem__inner">
+                  <a href="/used/0019117467" class="productItem__image js-hoverItemLink">
+					  <img src="https://content.bookoff.co.jp/goodsimages/LL/001911/0019117467LL.jpg" alt="海に願いを風に祈りをそして君に誓いを スターツ出版文庫" class="js-gridImg -md" loading="lazy" />
+                  </a>
+                  <div class="productItem__detail">
+                      <a href="/used/0019117467" class="productItem__link js-hoverItemLink">
+                      <div class="productItem__tagList">
+                        <ul class="tagList">
+									                      		                      		                    							<li class="tag ">中古</li>
+														<li class="tag tag--pickedUpStore">店舗受取可</li>
+							                        </ul>
+                      </div>
+                      <ul class="productItem__genre">
+                        <li class="productItem__genreItem productItem__genreItem--category">
+                          書籍
+                        </li>
+                        <li class="productItem__genreItem">文庫</li>
+                      </ul>
+                      <p class="productItem__title">海に願いを風に祈りをそして君に誓いを スターツ出版文庫</p>
+                      <p class="productItem__author">汐見夏衛</p>
+                      <p class="productItem__price">
+					&yen;495<span class="productItem__moneyUnit">円</span><small>定価より308円（38%）おトク</small></p>
+                      <p class="productItem__point">獲得ポイント 4P</p>
+					  	                  	                  	                  
+	                  	                  	                  	                  	                  	                    	                  	                  <p class="productItem__stock"><span class="productItem__stock--alert">在庫あり</span></p>
+                      <p class="productItem__date">発売年月日：2018/08/28</p>
+                    </a>
+                    <div class="productItem__btns">
+                              <div class="btn btn--orange jsBtn-cart ac-click-cv" data-cv-name="oldInCart_Search" data-mode="Add" data-item="0019117467" data-stock="used">
+                              <span class="forPc btn__addTextWrap"><span class="btn__addText"> カートへ追加 </span></span>
+                            <span class="forSp btn__addTextWrap"><span class="btn__addText"> カートへ追加 </span></span>
+                          </div>
+                      <div class="productItem__favorite jsBtn-favorite ac-click-cv" data-cv-name="addBookmark_Search" data-mode="Add" data-item="0019117467">
+                        <span class="icon-favorite icon-favorite-on-dims js-favorite-star"></span>
+                        <span class="productItem__favoriteTxt">お気に入り追加</span>
+                      </div>
+
+                    </div>
+                  </div>
+                </div>
+              </div>
+          </div>
+
+          <!-- /productItems__inner -->
+        </div>
+        <!-- /productItems -->
+        <div class="pagination">
+          <ul class="pagination__list -first">
+            <li class="pagination__item pagination__item--first">
+              <span class="pagination__first -disabled"></span>
+            </li>
+            <li class="pagination__item pagination__item--prev">
+              <span class="pagination__prev -disabled"></span>
+            </li>
+              <li class="pagination__item">
+                <span class="pagination__page pagination__page--current"><span>1</span></span>
+              </li>
+            <li class="pagination__item pagination__item--next">
+              <span class="pagination__next -disabled"></span>
+            </li>
+            <li class="pagination__item pagination__item--last">
+              <span class="pagination__last -disabled"></span>
+            </li>
+          </ul>
+        </div>
+    </div>
+    <!-- /productSearch -->
+  </div>
+  <!--mainContent__col-->
+  <div class="mainContent__col forPc">
+    <section class="refinement js-refinement">
+        <h4 class="refinement__head">
+          <span class="refinement__ttl">絞り込み</span>
+        </h4>
+        <ul class="refinement__list">
+          <li class="refinement__item">
+            <label class="checkbox">
+                <input id='exist_used_check' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+              <span class="checkbox__item"><span class="checkbox__txt">中古のみ</span></span>
+            </label>
+          </li>
+          <li class="refinement__item">
+            <label class="checkbox">
+                <input id='exist_stock_check' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+              <span class="checkbox__item"><span class="checkbox__txt">在庫ありのみ</span></span>
+            </label>
+          </li>
+          <li class="refinement__item">
+            <label class="checkbox">
+                            <input id='exist_store_trans_check' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+                            <span class="checkbox__item"><span class="checkbox__txt">店舗受取可</span></span>
+            </label>
+          </li>
+        </ul>
+        <section>
+          <h5 class="refinement__heading">カテゴリ</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <a href="/search/keyword/9784813705185" class="refinement__link">                <span class="refinement__linkTxt">すべてのカテゴリ</span>
+                <span class="refinement__hit">(1)</span>
+              </a>
+            </li>
+              <li class="refinement__item">
+                <a href="/search/genre/12/keyword/9784813705185" class="refinement__link">
+                  <span class="refinement__linkTxt">書籍</span>
+                  <span class="refinement__hit">(1)</span>
+                </a>
+              </li>
+            <li class="refinement__item">
+              <a href="/set/search/keyword/9784813705185" class="refinement__link categorySetLink">
+                <span class="refinement__linkTxt">セット</span>
+                <span class="modalSearchRefinement__hit"></span>
+              </a>
+            </li>
+          </ul>
+        </section>
+        <section class="refinement__form">
+          <h5 class="refinement__heading">キーワード</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <span class="refinement__keywordBox">
+                  <input id='search_keyword' type="text" class="refinement__text search_form" placeholder="〜を含む" name="or" value="9784813705185" />
+                </span>
+                <span class="refinement__keywordTxt">を含む</span>
+              </p>
+            </li>
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <span class="refinement__keywordBox">
+                  <input id='search_exclusion_keyword' type="text" class="refinement__text search_form" placeholder="〜を含まない" name="not" value="" />
+                </span>
+                <span class="refinement__keywordTxt">を除く</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">著者・作者</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <input id='search_author' type="text" class="refinement__text search_form" placeholder="入力してください" name="author" value="" />
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">販売会社/出版社（メーカー）</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <input id='search_publisher' type="text" class="refinement__text search_form" placeholder="入力してください" name="maker" value="" />
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">中古価格</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__price">
+                <span class="refinement__priceBox">
+                  <input id='search_used_price_min' type="text" class="refinement__text search_form" placeholder="0" name="price1" value="" />
+                </span>
+                <span class="refinement__priceRange">〜</span>
+                <span class="refinement__priceBox">
+                  <input id='search_used_price_max' type="text" class="refinement__text search_form" placeholder="上限なし" name="price2" value="" />
+                </span>
+                <span class="refinement__priceYen">円</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">発売年月</h5>
+          <p class="refinement__note">セットは対象外となります</p>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__date">
+
+                <span class="refinement__dateYearBox">
+                  <span class="refinement__select">
+                    <select id='search_sys' name="year1" class="refinement__selectTag -empty year_select1 search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="2026">2026</option>
+                      <option value="2025">2025</option>
+                      <option value="2024">2024</option>
+                      <option value="2023">2023</option>
+                      <option value="2022">2022</option>
+                      <option value="2021">2021</option>
+                      <option value="2020">2020</option>
+                      <option value="2019">2019</option>
+                      <option value="2018">2018</option>
+                      <option value="2017">2017</option>
+                      <option value="2016">2016</option>
+                      <option value="2015">2015</option>
+                      <option value="2014">2014</option>
+                      <option value="2013">2013</option>
+                      <option value="2012">2012</option>
+                      <option value="2011">2011</option>
+                      <option value="2010">2010</option>
+                      <option value="2009">2009</option>
+                      <option value="2008">2008</option>
+                      <option value="2007">2007</option>
+                      <option value="2006">2006</option>
+                      <option value="2005">2005</option>
+                      <option value="2004">2004</option>
+                      <option value="2003">2003</option>
+                      <option value="2002">2002</option>
+                      <option value="2001">2001</option>
+                      <option value="2000">2000</option>
+                      <option value="1999">1999</option>
+                      <option value="1998">1998</option>
+                      <option value="1997">1997</option>
+                      <option value="1996">1996</option>
+                      <option value="1995">1995</option>
+                      <option value="1994">1994</option>
+                      <option value="1993">1993</option>
+                      <option value="1992">1992</option>
+                      <option value="1991">1991</option>
+                      <option value="1990">1990</option>
+                      <option value="1989">1989</option>
+                      <option value="1988">1988</option>
+                      <option value="1987">1987</option>
+                      <option value="1986">1986</option>
+                      <option value="1985">1985</option>
+                      <option value="1984">1984</option>
+                      <option value="1983">1983</option>
+                      <option value="1982">1982</option>
+                      <option value="1981">1981</option>
+                      <option value="1980">1980</option>
+                      <option value="1979">1979</option>
+                      <option value="1978">1978</option>
+                      <option value="1977">1977</option>
+                      <option value="1976">1976</option>
+                      <option value="1975">1975</option>
+                      <option value="1974">1974</option>
+                      <option value="1973">1973</option>
+                      <option value="1972">1972</option>
+                      <option value="1971">1971</option>
+                      <option value="1970">1970</option>
+                      <option value="1969">1969</option>
+                      <option value="1968">1968</option>
+                      <option value="1967">1967</option>
+                      <option value="1966">1966</option>
+                      <option value="1965">1965</option>
+                      <option value="1964">1964</option>
+                      <option value="1963">1963</option>
+                      <option value="1962">1962</option>
+                      <option value="1961">1961</option>
+                      <option value="1960">1960</option>
+                      <option value="1959">1959</option>
+                      <option value="1958">1958</option>
+                      <option value="1957">1957</option>
+                      <option value="1956">1956</option>
+                      <option value="1955">1955</option>
+                      <option value="1954">1954</option>
+                      <option value="1953">1953</option>
+                      <option value="1952">1952</option>
+                      <option value="1951">1951</option>
+                      <option value="1950">1950</option>
+                      <option value="1949">1949</option>
+                      <option value="1948">1948</option>
+                      <option value="1947">1947</option>
+                      <option value="1946">1946</option>
+                      <option value="1945">1945</option>
+                      <option value="1944">1944</option>
+                      <option value="1943">1943</option>
+                      <option value="1942">1942</option>
+                      <option value="1941">1941</option>
+                      <option value="1940">1940</option>
+                      <option value="1939">1939</option>
+                      <option value="1938">1938</option>
+                      <option value="1937">1937</option>
+                      <option value="1936">1936</option>
+                      <option value="1935">1935</option>
+                      <option value="1934">1934</option>
+                      <option value="1933">1933</option>
+                      <option value="1932">1932</option>
+                      <option value="1931">1931</option>
+                      <option value="1930">1930</option>
+                      <option value="1929">1929</option>
+                      <option value="1928">1928</option>
+                      <option value="1927">1927</option>
+                      <option value="1926">1926</option>
+                      <option value="1925">1925</option>
+                      <option value="1924">1924</option>
+                      <option value="1923">1923</option>
+                      <option value="1922">1922</option>
+                      <option value="1921">1921</option>
+                      <option value="1920">1920</option>
+                      <option value="1919">1919</option>
+                      <option value="1918">1918</option>
+                      <option value="1917">1917</option>
+                      <option value="1916">1916</option>
+                      <option value="1915">1915</option>
+                      <option value="1914">1914</option>
+                      <option value="1913">1913</option>
+                      <option value="1912">1912</option>
+                      <option value="1911">1911</option>
+                      <option value="1910">1910</option>
+                      <option value="1909">1909</option>
+                      <option value="1908">1908</option>
+                      <option value="1907">1907</option>
+                      <option value="1906">1906</option>
+                      <option value="1905">1905</option>
+                      <option value="1904">1904</option>
+                      <option value="1903">1903</option>
+                      <option value="1902">1902</option>
+                      <option value="1901">1901</option>
+                      <option value="1900">1900</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateYear">年</span>
+
+                <span class="refinement__dateMonthBox">
+                  <span class="refinement__select">
+                    <select id='search_sms' name="month1" class="refinement__selectTag -empty search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="01">01</option>
+                      <option value="02">02</option>
+                      <option value="03">03</option>
+                      <option value="04">04</option>
+                      <option value="05">05</option>
+                      <option value="06">06</option>
+                      <option value="07">07</option>
+                      <option value="08">08</option>
+                      <option value="09">09</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateMonth">月〜</span>
+              </p>
+            </li>
+
+            <li class="refinement__item">
+              <p class="refinement__date">
+                <span class="refinement__dateYearBox">
+                  <span class="refinement__select">
+                    <select id='search_sye' name="year2" class="refinement__selectTag -empty year_select2 search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="2026">2026</option>
+                      <option value="2025">2025</option>
+                      <option value="2024">2024</option>
+                      <option value="2023">2023</option>
+                      <option value="2022">2022</option>
+                      <option value="2021">2021</option>
+                      <option value="2020">2020</option>
+                      <option value="2019">2019</option>
+                      <option value="2018">2018</option>
+                      <option value="2017">2017</option>
+                      <option value="2016">2016</option>
+                      <option value="2015">2015</option>
+                      <option value="2014">2014</option>
+                      <option value="2013">2013</option>
+                      <option value="2012">2012</option>
+                      <option value="2011">2011</option>
+                      <option value="2010">2010</option>
+                      <option value="2009">2009</option>
+                      <option value="2008">2008</option>
+                      <option value="2007">2007</option>
+                      <option value="2006">2006</option>
+                      <option value="2005">2005</option>
+                      <option value="2004">2004</option>
+                      <option value="2003">2003</option>
+                      <option value="2002">2002</option>
+                      <option value="2001">2001</option>
+                      <option value="2000">2000</option>
+                      <option value="1999">1999</option>
+                      <option value="1998">1998</option>
+                      <option value="1997">1997</option>
+                      <option value="1996">1996</option>
+                      <option value="1995">1995</option>
+                      <option value="1994">1994</option>
+                      <option value="1993">1993</option>
+                      <option value="1992">1992</option>
+                      <option value="1991">1991</option>
+                      <option value="1990">1990</option>
+                      <option value="1989">1989</option>
+                      <option value="1988">1988</option>
+                      <option value="1987">1987</option>
+                      <option value="1986">1986</option>
+                      <option value="1985">1985</option>
+                      <option value="1984">1984</option>
+                      <option value="1983">1983</option>
+                      <option value="1982">1982</option>
+                      <option value="1981">1981</option>
+                      <option value="1980">1980</option>
+                      <option value="1979">1979</option>
+                      <option value="1978">1978</option>
+                      <option value="1977">1977</option>
+                      <option value="1976">1976</option>
+                      <option value="1975">1975</option>
+                      <option value="1974">1974</option>
+                      <option value="1973">1973</option>
+                      <option value="1972">1972</option>
+                      <option value="1971">1971</option>
+                      <option value="1970">1970</option>
+                      <option value="1969">1969</option>
+                      <option value="1968">1968</option>
+                      <option value="1967">1967</option>
+                      <option value="1966">1966</option>
+                      <option value="1965">1965</option>
+                      <option value="1964">1964</option>
+                      <option value="1963">1963</option>
+                      <option value="1962">1962</option>
+                      <option value="1961">1961</option>
+                      <option value="1960">1960</option>
+                      <option value="1959">1959</option>
+                      <option value="1958">1958</option>
+                      <option value="1957">1957</option>
+                      <option value="1956">1956</option>
+                      <option value="1955">1955</option>
+                      <option value="1954">1954</option>
+                      <option value="1953">1953</option>
+                      <option value="1952">1952</option>
+                      <option value="1951">1951</option>
+                      <option value="1950">1950</option>
+                      <option value="1949">1949</option>
+                      <option value="1948">1948</option>
+                      <option value="1947">1947</option>
+                      <option value="1946">1946</option>
+                      <option value="1945">1945</option>
+                      <option value="1944">1944</option>
+                      <option value="1943">1943</option>
+                      <option value="1942">1942</option>
+                      <option value="1941">1941</option>
+                      <option value="1940">1940</option>
+                      <option value="1939">1939</option>
+                      <option value="1938">1938</option>
+                      <option value="1937">1937</option>
+                      <option value="1936">1936</option>
+                      <option value="1935">1935</option>
+                      <option value="1934">1934</option>
+                      <option value="1933">1933</option>
+                      <option value="1932">1932</option>
+                      <option value="1931">1931</option>
+                      <option value="1930">1930</option>
+                      <option value="1929">1929</option>
+                      <option value="1928">1928</option>
+                      <option value="1927">1927</option>
+                      <option value="1926">1926</option>
+                      <option value="1925">1925</option>
+                      <option value="1924">1924</option>
+                      <option value="1923">1923</option>
+                      <option value="1922">1922</option>
+                      <option value="1921">1921</option>
+                      <option value="1920">1920</option>
+                      <option value="1919">1919</option>
+                      <option value="1918">1918</option>
+                      <option value="1917">1917</option>
+                      <option value="1916">1916</option>
+                      <option value="1915">1915</option>
+                      <option value="1914">1914</option>
+                      <option value="1913">1913</option>
+                      <option value="1912">1912</option>
+                      <option value="1911">1911</option>
+                      <option value="1910">1910</option>
+                      <option value="1909">1909</option>
+                      <option value="1908">1908</option>
+                      <option value="1907">1907</option>
+                      <option value="1906">1906</option>
+                      <option value="1905">1905</option>
+                      <option value="1904">1904</option>
+                      <option value="1903">1903</option>
+                      <option value="1902">1902</option>
+                      <option value="1901">1901</option>
+                      <option value="1900">1900</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateYear">年</span>
+
+                <span class="refinement__dateMonthBox">
+                  <span class="refinement__select">
+                    <select id='search_sme' name="month2" class="refinement__selectTag -empty search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="01">01</option>
+                      <option value="02">02</option>
+                      <option value="03">03</option>
+                      <option value="04">04</option>
+                      <option value="05">05</option>
+                      <option value="06">06</option>
+                      <option value="07">07</option>
+                      <option value="08">08</option>
+                      <option value="09">09</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateMonth">月まで</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <a href="" id="search_btn" class="btn btn--blue ac-click-cv" data-cv-name="sortOn_Search">検索する</a>
+        <a href="" id='search_reset_btn' class="link link--center js-refinementReset">条件をリセット</a>
+    </section>
+    <!-- /.refinement -->
+  </div>
+  <!--mainContent__col forPc-->
+</div>
+<!-- /mainContent__search -->
+<input type="hidden" class="js-modal" data-modal="modalCartAddStock0">
+
+<div id="modal" class="modal">
+    <div class="modal__overlay"></div>
+    <div id="modalSearchRefinement" class="modal__inner js-modalInner forSp" tabindex="0">
+      <div class="modalContent">
+        <!-- /modalRefinementWrap -->
+        <div class="modalRefinementWrap js-modalRefinementWrap" data-level="0" data-id="0">
+          <p class="modal__title">しぼりこみ</p>
+          <div class="modalSearchRefinement js-modalInnerContent js-modalRefinementInnerContent" style="height: 744px;">
+            <div class="modalSearchRefinement__inner">
+              <div class="modalSearchRefinement__content">
+                <ul class="modalSearchRefinement__list modalSearchRefinement__list--checkbox">
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                        <input id='exist_used_check_modal' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+                      <span class="checkbox__item"><span class="checkbox__txt">中古のみ</span></span>
+                    </label>
+                  </li>
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                        <input id='exist_stock_check_modal' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+                    <span class="checkbox__item"><span class="checkbox__txt">在庫ありのみ</span></span>
+                    </label>
+                  </li>
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                          <input id='exist_store_trans_check_modal' type="checkbox" class="js-cartSetItemCheckbox search_check" value="" >
+                      <span class="checkbox__item"><span class="checkbox__txt">店舗受取可</span></span>
+                    </label>
+                  </li>
+                </ul>
+                <p class="modalSearchRefinement__heading">カテゴリ</p>
+                <ul class="modalSearchRefinement__list">
+                  <li class="modalSearchRefinement__item">
+                    <a href="" class="modalSearchRefinement__category js-modalRefinementSp" data-level="1" data-id="0" data-direction="bottom">
+                        すべてのカテゴリ
+                    </a>
+                  </li>
+                </ul>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_keyword_modal">キーワード</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <span class="modalSearchRefinement__keywordBox">
+                          <input id='search_keyword_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="〜を含む" name="or"
+                          value="9784813705185">
+                        </span>
+                        <span class="modalSearchRefinement__keywordTxt">を含む</span>
+                      </p>
+                    </li>
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <span class="modalSearchRefinement__keywordBox">
+                          <input id='search_exclusion_keyword_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="〜を含まない" name="not" value="">
+                        </span>
+                        <span class="modalSearchRefinement__keywordTxt">を除く</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_author_modal">著者・作者</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <input id='search_author_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="入力してください" name="author" value="">
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_publisher_modal">販売会社/出版社（メーカー）</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <input id='search_publisher_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="入力してください" name="maker" value="">
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_used_price_min_modal">中古価格</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__price">
+                        <span class="modalSearchRefinement__priceBox">
+                          <input id='search_used_price_min_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="0" name="price1" value="">
+                        </span>
+                        <span class="modalSearchRefinement__priceRange">〜</span>
+                        <span class="modalSearchRefinement__priceBox">
+                          <input id='search_used_price_max_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="上限なし" name="price2" value="">
+                        </span>
+                        <span class="modalSearchRefinement__priceYen">円</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_sys_modal">発売</label>
+                  <ul class="modalSearchRefinement__list">
+
+                      <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__date">
+
+                        <span class="modalSearchRefinement__dateYearBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sys_modal' name="year1" class="modalSearchRefinement__selectTag -empty year_select1 search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="2026">2026</option>
+                                <option value="2025">2025</option>
+                                <option value="2024">2024</option>
+                                <option value="2023">2023</option>
+                                <option value="2022">2022</option>
+                                <option value="2021">2021</option>
+                                <option value="2020">2020</option>
+                                <option value="2019">2019</option>
+                                <option value="2018">2018</option>
+                                <option value="2017">2017</option>
+                                <option value="2016">2016</option>
+                                <option value="2015">2015</option>
+                                <option value="2014">2014</option>
+                                <option value="2013">2013</option>
+                                <option value="2012">2012</option>
+                                <option value="2011">2011</option>
+                                <option value="2010">2010</option>
+                                <option value="2009">2009</option>
+                                <option value="2008">2008</option>
+                                <option value="2007">2007</option>
+                                <option value="2006">2006</option>
+                                <option value="2005">2005</option>
+                                <option value="2004">2004</option>
+                                <option value="2003">2003</option>
+                                <option value="2002">2002</option>
+                                <option value="2001">2001</option>
+                                <option value="2000">2000</option>
+                                <option value="1999">1999</option>
+                                <option value="1998">1998</option>
+                                <option value="1997">1997</option>
+                                <option value="1996">1996</option>
+                                <option value="1995">1995</option>
+                                <option value="1994">1994</option>
+                                <option value="1993">1993</option>
+                                <option value="1992">1992</option>
+                                <option value="1991">1991</option>
+                                <option value="1990">1990</option>
+                                <option value="1989">1989</option>
+                                <option value="1988">1988</option>
+                                <option value="1987">1987</option>
+                                <option value="1986">1986</option>
+                                <option value="1985">1985</option>
+                                <option value="1984">1984</option>
+                                <option value="1983">1983</option>
+                                <option value="1982">1982</option>
+                                <option value="1981">1981</option>
+                                <option value="1980">1980</option>
+                                <option value="1979">1979</option>
+                                <option value="1978">1978</option>
+                                <option value="1977">1977</option>
+                                <option value="1976">1976</option>
+                                <option value="1975">1975</option>
+                                <option value="1974">1974</option>
+                                <option value="1973">1973</option>
+                                <option value="1972">1972</option>
+                                <option value="1971">1971</option>
+                                <option value="1970">1970</option>
+                                <option value="1969">1969</option>
+                                <option value="1968">1968</option>
+                                <option value="1967">1967</option>
+                                <option value="1966">1966</option>
+                                <option value="1965">1965</option>
+                                <option value="1964">1964</option>
+                                <option value="1963">1963</option>
+                                <option value="1962">1962</option>
+                                <option value="1961">1961</option>
+                                <option value="1960">1960</option>
+                                <option value="1959">1959</option>
+                                <option value="1958">1958</option>
+                                <option value="1957">1957</option>
+                                <option value="1956">1956</option>
+                                <option value="1955">1955</option>
+                                <option value="1954">1954</option>
+                                <option value="1953">1953</option>
+                                <option value="1952">1952</option>
+                                <option value="1951">1951</option>
+                                <option value="1950">1950</option>
+                                <option value="1949">1949</option>
+                                <option value="1948">1948</option>
+                                <option value="1947">1947</option>
+                                <option value="1946">1946</option>
+                                <option value="1945">1945</option>
+                                <option value="1944">1944</option>
+                                <option value="1943">1943</option>
+                                <option value="1942">1942</option>
+                                <option value="1941">1941</option>
+                                <option value="1940">1940</option>
+                                <option value="1939">1939</option>
+                                <option value="1938">1938</option>
+                                <option value="1937">1937</option>
+                                <option value="1936">1936</option>
+                                <option value="1935">1935</option>
+                                <option value="1934">1934</option>
+                                <option value="1933">1933</option>
+                                <option value="1932">1932</option>
+                                <option value="1931">1931</option>
+                                <option value="1930">1930</option>
+                                <option value="1929">1929</option>
+                                <option value="1928">1928</option>
+                                <option value="1927">1927</option>
+                                <option value="1926">1926</option>
+                                <option value="1925">1925</option>
+                                <option value="1924">1924</option>
+                                <option value="1923">1923</option>
+                                <option value="1922">1922</option>
+                                <option value="1921">1921</option>
+                                <option value="1920">1920</option>
+                                <option value="1919">1919</option>
+                                <option value="1918">1918</option>
+                                <option value="1917">1917</option>
+                                <option value="1916">1916</option>
+                                <option value="1915">1915</option>
+                                <option value="1914">1914</option>
+                                <option value="1913">1913</option>
+                                <option value="1912">1912</option>
+                                <option value="1911">1911</option>
+                                <option value="1910">1910</option>
+                                <option value="1909">1909</option>
+                                <option value="1908">1908</option>
+                                <option value="1907">1907</option>
+                                <option value="1906">1906</option>
+                                <option value="1905">1905</option>
+                                <option value="1904">1904</option>
+                                <option value="1903">1903</option>
+                                <option value="1902">1902</option>
+                                <option value="1901">1901</option>
+                                <option value="1900">1900</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateYear">年</span>
+
+                        <span class="modalSearchRefinement__dateMonthBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sms_modal' name="month1" class="modalSearchRefinement__selectTag -empty search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="01">01</option>
+                                <option value="02">02</option>
+                                <option value="03">03</option>
+                                <option value="04">04</option>
+                                <option value="05">05</option>
+                                <option value="06">06</option>
+                                <option value="07">07</option>
+                                <option value="08">08</option>
+                                <option value="09">09</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateMonth">月〜</span>
+                      </p>
+                    </li>
+
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__date">
+
+                        <span class="modalSearchRefinement__dateYearBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sye_modal' name="year2" class="modalSearchRefinement__selectTag -empty year_select2 search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="2026">2026</option>
+                                <option value="2025">2025</option>
+                                <option value="2024">2024</option>
+                                <option value="2023">2023</option>
+                                <option value="2022">2022</option>
+                                <option value="2021">2021</option>
+                                <option value="2020">2020</option>
+                                <option value="2019">2019</option>
+                                <option value="2018">2018</option>
+                                <option value="2017">2017</option>
+                                <option value="2016">2016</option>
+                                <option value="2015">2015</option>
+                                <option value="2014">2014</option>
+                                <option value="2013">2013</option>
+                                <option value="2012">2012</option>
+                                <option value="2011">2011</option>
+                                <option value="2010">2010</option>
+                                <option value="2009">2009</option>
+                                <option value="2008">2008</option>
+                                <option value="2007">2007</option>
+                                <option value="2006">2006</option>
+                                <option value="2005">2005</option>
+                                <option value="2004">2004</option>
+                                <option value="2003">2003</option>
+                                <option value="2002">2002</option>
+                                <option value="2001">2001</option>
+                                <option value="2000">2000</option>
+                                <option value="1999">1999</option>
+                                <option value="1998">1998</option>
+                                <option value="1997">1997</option>
+                                <option value="1996">1996</option>
+                                <option value="1995">1995</option>
+                                <option value="1994">1994</option>
+                                <option value="1993">1993</option>
+                                <option value="1992">1992</option>
+                                <option value="1991">1991</option>
+                                <option value="1990">1990</option>
+                                <option value="1989">1989</option>
+                                <option value="1988">1988</option>
+                                <option value="1987">1987</option>
+                                <option value="1986">1986</option>
+                                <option value="1985">1985</option>
+                                <option value="1984">1984</option>
+                                <option value="1983">1983</option>
+                                <option value="1982">1982</option>
+                                <option value="1981">1981</option>
+                                <option value="1980">1980</option>
+                                <option value="1979">1979</option>
+                                <option value="1978">1978</option>
+                                <option value="1977">1977</option>
+                                <option value="1976">1976</option>
+                                <option value="1975">1975</option>
+                                <option value="1974">1974</option>
+                                <option value="1973">1973</option>
+                                <option value="1972">1972</option>
+                                <option value="1971">1971</option>
+                                <option value="1970">1970</option>
+                                <option value="1969">1969</option>
+                                <option value="1968">1968</option>
+                                <option value="1967">1967</option>
+                                <option value="1966">1966</option>
+                                <option value="1965">1965</option>
+                                <option value="1964">1964</option>
+                                <option value="1963">1963</option>
+                                <option value="1962">1962</option>
+                                <option value="1961">1961</option>
+                                <option value="1960">1960</option>
+                                <option value="1959">1959</option>
+                                <option value="1958">1958</option>
+                                <option value="1957">1957</option>
+                                <option value="1956">1956</option>
+                                <option value="1955">1955</option>
+                                <option value="1954">1954</option>
+                                <option value="1953">1953</option>
+                                <option value="1952">1952</option>
+                                <option value="1951">1951</option>
+                                <option value="1950">1950</option>
+                                <option value="1949">1949</option>
+                                <option value="1948">1948</option>
+                                <option value="1947">1947</option>
+                                <option value="1946">1946</option>
+                                <option value="1945">1945</option>
+                                <option value="1944">1944</option>
+                                <option value="1943">1943</option>
+                                <option value="1942">1942</option>
+                                <option value="1941">1941</option>
+                                <option value="1940">1940</option>
+                                <option value="1939">1939</option>
+                                <option value="1938">1938</option>
+                                <option value="1937">1937</option>
+                                <option value="1936">1936</option>
+                                <option value="1935">1935</option>
+                                <option value="1934">1934</option>
+                                <option value="1933">1933</option>
+                                <option value="1932">1932</option>
+                                <option value="1931">1931</option>
+                                <option value="1930">1930</option>
+                                <option value="1929">1929</option>
+                                <option value="1928">1928</option>
+                                <option value="1927">1927</option>
+                                <option value="1926">1926</option>
+                                <option value="1925">1925</option>
+                                <option value="1924">1924</option>
+                                <option value="1923">1923</option>
+                                <option value="1922">1922</option>
+                                <option value="1921">1921</option>
+                                <option value="1920">1920</option>
+                                <option value="1919">1919</option>
+                                <option value="1918">1918</option>
+                                <option value="1917">1917</option>
+                                <option value="1916">1916</option>
+                                <option value="1915">1915</option>
+                                <option value="1914">1914</option>
+                                <option value="1913">1913</option>
+                                <option value="1912">1912</option>
+                                <option value="1911">1911</option>
+                                <option value="1910">1910</option>
+                                <option value="1909">1909</option>
+                                <option value="1908">1908</option>
+                                <option value="1907">1907</option>
+                                <option value="1906">1906</option>
+                                <option value="1905">1905</option>
+                                <option value="1904">1904</option>
+                                <option value="1903">1903</option>
+                                <option value="1902">1902</option>
+                                <option value="1901">1901</option>
+                                <option value="1900">1900</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateYear">年</span>
+
+                        <span class="modalSearchRefinement__dateMonthBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sme_modal' name="month2" class="modalSearchRefinement__selectTag -empty search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="01">01</option>
+                                <option value="02">02</option>
+                                <option value="03">03</option>
+                                <option value="04">04</option>
+                                <option value="05">05</option>
+                                <option value="06">06</option>
+                                <option value="07">07</option>
+                                <option value="08">08</option>
+                                <option value="09">09</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateMonth">月まで</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <p class="modalSearchRefinement__note">セットは対象外となります</p>
+                <a id='search_btn_modal' class="btn btn--blue ac-click-cv" data-cv-name="sortOn_Search">検索する</a>
+                <a id='search_reset_btn_modal' class="link link--center js-modalRefinementReset">条件をリセット</a>
+              </div><!-- /.modalSearchRefinement__content -->
+            </div>
+          </div>
+        </div>
+        <!-- /modalRefinementWrap -->
+
+        <div class="modalRefinementWrap js-modalRefinementWrap -hide" data-level="1" data-id="0">
+          <p class="modal__title">
+            <span>カテゴリ</span>
+          </p>
+          <div class="modalSearchRefinement js-modalRefinementInnerContent">
+            <div class="modalSearchRefinement__inner">
+              <div class="modalSearchRefinement__content">
+                <ul class="modalSearchRefinement__categoryList">
+                  <li class="modalSearchRefinement__categoryItem">
+                    <a href="/search/keyword/9784813705185" class="modalSearchRefinement__categoryLink modalSearchRefinement__categoryLink--noArrow">                      <span>すべてのカテゴリ</span>
+                      <span class="modalSearchRefinement__hit">(1)</span>
+                    </a>
+                  </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/12/keyword/9784813705185" class="modalSearchRefinement__categoryLink">
+                        <span>書籍</span>
+                        <span class="refinement__hit">(1)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/set/search/keyword/9784813705185" class="modalSearchRefinement__categoryLink categorySetLink">
+                        <span>セット</span>
+                      </a>
+                    </li>
+                </ul>
+              </div><!-- /.modalSearchRefinement__content -->
+            </div>
+          </div>
+          <div class="modal__closeRefineSp js-modalRefinementSp" data-level="0" data-id="0" data-direction="top">
+            <img src="/library/common/svg/close.svg" alt="close" title="close">
+          </div>
+        </div>
+        <!-- /modalRefinementWrap -->
+
+        <div class="modal__close js-modalClose" tabindex="0">
+          <img src="/library/common/svg/close.svg" alt="close" title="close">
+        </div>
+      </div>
+      <!-- /modalContent -->
+      <div class="modal__closeSp js-modalCloseSp">
+        <span></span>
+      </div>
+    </div>
+    <!-- /modal__inner -->
+
+  <div id="modalCartAddStock0" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">カートに追加できませんでした</p>
+        </div>
+        <div class="modalItems">
+          <p class="modalItems__note">
+            <span class="icon-info icon-info-dims"></span>
+            <span class="js-cart-alert"></span>
+          </p>
+        </div>
+      </div>
+      <ul class="modal__confirm modal__confirm--box-shadow-none">
+        <li class="modal__confirmBtn">
+          <a href="" class="modal__no js-modalClose" tabindex="0">キャンセル</a>
+        </li>
+        <li class="modal__confirmBtn">
+          <a href="" class="modal__yes js-refreshPage">OK</a>
+        </li>
+      </ul>
+      <div class="modal__close js-modalClose" tabindex="0">
+        <img src="/library/common/svg/close.svg" alt="close">
+      </div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp">
+      <span></span>
+    </div>
+  </div>
+
+  <div id="modalAgeVerification" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="pageTitle">年齢確認</div>
+      <div class="ageVerificationBlock js-modalInnerContent">
+        <div class="ageVerificationBlock__inner">
+          <div class="ageVerificationBlock__txt--error ageVerificationBlock__txt--bold modalConfirm__error" style="display:none;">エラーにより年齢認証が完了出来ませんでした。</div>
+          <div class="ageVerificationBlock__txt">これより先は18歳未満の方には不適切な表現内容が含まれる商品を取り扱う画面です</div>
+          <div class="ageVerificationBlock__txt">18歳未満の方のアクセスは、固くお断りいたします</div>
+          <div class="ageVerificationBlock__txt--check ageVerificationBlock__txt--bold">あなたは18歳以上ですか？</div>
+          <div class="ageVerification__btns">
+            <div id="ageVerification__btns--agree" class="btn js-agree-submit" data-agelimit="1">はい</div>
+            <div class="btn js-cancel-submit js-modalClose">いいえ</div>
+          </div>
+        </div><!-- /ageVerificationBlock__inner -->
+      </div><!-- /ageVerificationBlock -->
+      <div class="modal__close js-modalClose" tabindex="1"><img src="https://content.bookoff.co.jp/common/images/close.svg" width="24" height="24" alt="close"></div>
+    </div><!--modalContent-->
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div><!-- modalAgeVerification -->
+</div>
+<!-- /modal -->
+
+<script>
+var arrQuery = [];
+var paramName = '';
+var paramValue = '';
+var genreCode = '';
+
+  // 絞り込み（「中古のみ」「在庫ありのみ」）
+$('#exist_stock_check, #exist_used_check, #exist_store_trans_check').on('change', function () {
+	$('.js-cartSetItemCheckbox').prop('disabled', true);
+	let url = '/search/keyword/9784813705185';
+	let destUrl = '';
+	let pattern = '';
+	let replacement = '';
+
+	if($('#exist_used_check').prop('checked')) {
+		if($('#exist_stock_check').prop('checked')) {
+			replacement = '/stock/u';
+		} else {
+			replacement = '/stock/used';
+		}
+	} else {
+		if($('#exist_stock_check').prop('checked')) {
+			replacement = '/stock/z';
+		} else {
+			replacement = '';
+		}
+	}
+	if($('#exist_store_trans_check').prop('checked')) {
+		replacement += '/store-receive/y';
+	}
+	if('a' == 'a' && 'all' == 'all') {
+		pattern = '/search';
+		replacement = '/search' + replacement;
+		destUrl = url.replace(pattern, replacement);
+	} else if('a' != 'a' && 'all' == 'all') {
+		pattern = '/stock/a';
+		destUrl = url.replace(pattern, replacement);
+	} else if('a' == 'a' && 'all' != 'all') {
+		pattern = '/store-receive/all';
+		destUrl = url.replace(pattern, replacement);
+	} else {
+		pattern = '/stock/a/store-receive/all';
+		destUrl = url.replace(pattern, replacement);
+	}
+	window.location.href = destUrl;
+});
+
+let isSubmitting = false;
+// 検索
+$('#search_btn').on('click', function(e) {
+	if (isSubmitting) {
+		e.preventDefault();
+	} else {
+		isSubmitting = true;
+		e.preventDefault();
+		let url = '/search';
+		if($('#exist_used_check').prop('checked')) {
+			if($('#exist_stock_check').prop('checked')) {
+				url += '/stock/u';
+			} else {
+				url += '/stock/used';
+			}
+		} else {
+			if($('#exist_stock_check').prop('checked')) {
+				url += '/stock/z';
+			}
+		}
+		if($('#exist_store_trans_check').prop('checked')) {
+			url += '/store-receive/y';
+		}
+		if (genreCode) {
+			url += '/genre/' + genreCode;
+		}
+		if ($('#search_keyword').val()) {
+			let keyword = $('#search_keyword').val();
+			keyword = encodeMark(keyword);
+			url += '/keyword/' + keyword;
+		}
+		if ($('#search_exclusion_keyword').val()) {
+			let exclusion_keyword = $('#search_exclusion_keyword').val();
+			exclusion_keyword = encodeMark(exclusion_keyword);
+			url += '/not/' + exclusion_keyword;
+		}
+		if ($('#search_author').val()) {
+			let author = $('#search_author').val();
+			author = encodeMark(author);
+			url += '/author/' + author;
+		}
+		if ($('#search_publisher').val()) {
+			let publisher = $('#search_publisher').val();
+			publisher = encodeMark(publisher);
+			url += '/publisher/' + publisher;
+		}
+		if ($('#search_hashtag').text()) {
+			let hashtag = $('#search_hashtag').text();
+			hashtag = encodeMark(hashtag);
+			url += '/hashtag/' + hashtag;
+		}
+
+		// query_string 生成
+		arrQuery.splice(0);
+		if ($('#search_used_price_min').val() || $('#search_used_price_max').val()) {
+			paramName = 'price';
+			paramValue = $('#search_used_price_min').val() + '-' + $('#search_used_price_max').val();
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		// 発売年月 未入力補完
+		var searchYearStart = $('#search_sys').val();
+		var searchMonthStart = $('#search_sms').val();
+		var searchYearEnd = $('#search_sye').val();
+		var searchMonthEnd = $('#search_sme').val();
+		var searchStart = null;
+		var searchEnd = null;
+		if (searchYearStart && searchMonthStart) {
+			// 開始年：入力　開始月：入力　の場合は、searchStartをセット
+			searchStart = searchYearStart + searchMonthStart;
+		} else if (!searchYearStart && !searchMonthStart) {
+			// 開始年：未入力　開始月：未入力　の場合は、searchStart = null をセット
+			searchStart = null;
+		} else if (searchYearStart && !searchMonthStart) {
+			// 開始年：入力　開始月：未入力　の場合は、searchMonthStart = '01' をセット
+			searchStart = searchYearStart + '01';
+		} else {
+			// 開始年：未入力　開始月：入力　の場合は、searchYearEnd により分岐
+			if(searchYearEnd) {
+				// searchYearEnd：入力　の場合は、searchYearStart = searchYearEnd
+				searchStart = searchYearEnd + searchMonthStart;
+			} else {
+				// searchYearEnd：未入力　の場合は、searchYearStart = now
+				searchYearStart = new Date().getFullYear().toString();
+				searchStart = searchYearStart + searchMonthStart;
+			}
+		}
+		if (searchYearEnd && searchMonthEnd) {
+			// 終了年：入力　終了月：入力　の場合は、searchEndをセット
+			searchEnd = searchYearEnd + searchMonthEnd;
+		} else if (!searchYearEnd && !searchMonthEnd) {
+			// 終了年：未入力　終了月：未入力　の場合は、searchEnd = null をセット
+			searchEnd = null;
+		} else if (searchYearEnd && !searchMonthEnd) {
+			// 終了年：入力　終了月：未入力　の場合は、searchMonthEnd = '12' をセット
+			searchEnd = searchYearEnd + '12';
+		} else {
+			// 終了年：未入力　終了月：入力　の場合は、searchYearStart により分岐
+			if(searchYearStart) {
+				// searchYearEnd：入力　の場合は、searchYearEnd = searchYearEnd
+				searchEnd = searchYearStart + searchMonthEnd;
+			} else {
+				// searchYearStart：未入力　の場合は、searchYearEnd = now
+				searchYearEnd = new Date().getFullYear().toString();
+				searchEnd = searchYearEnd + searchMonthEnd;
+			}
+		}
+		if (searchStart) {
+			paramName = 'date-min';
+			paramValue = searchStart;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (searchEnd) {
+			paramName = 'date-max';
+			paramValue = searchEnd;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if(url.endsWith(".0")) {
+			url += '/';
+		}
+		// query_string生成
+		url += makeQueryString(arrQuery);
+		window.location.href = url;
+	}
+});
+
+// 検索（モーダル）
+$('#search_btn_modal').on('click', function(e) {
+	if (isSubmitting) {
+		e.preventDefault();
+	} else {
+		isSubmitting = true;
+		e.preventDefault();
+		let url = '/search';
+		if($('#exist_used_check_modal').prop('checked')) {
+			if($('#exist_stock_check_modal').prop('checked')) {
+				url += '/stock/u';
+			} else {
+				url += '/stock/used';
+			}
+		} else {
+			if($('#exist_stock_check_modal').prop('checked')) {
+				url += '/stock/z';
+			}
+		}
+		if($('#exist_store_trans_check_modal').prop('checked')) {
+			url += '/store-receive/y';
+		}
+		if (genreCode) {
+			url += '/genre/' + genreCode;
+		}
+		if ($('#search_keyword_modal').val()) {
+			let keyword = $('#search_keyword_modal').val();
+			keyword = encodeMark(keyword);
+			url += '/keyword/' + keyword;
+		}
+		if ($('#search_exclusion_keyword_modal').val()) {
+			let exclusion_keyword = $('#search_exclusion_keyword_modal').val();
+			exclusion_keyword = encodeMark(exclusion_keyword);
+			url += '/not/' + exclusion_keyword;
+		}
+		if ($('#search_author_modal').val()) {
+			let author = $('#search_author_modal').val();
+			author = encodeMark(author);
+			url += '/author/' + author;
+		}
+		if ($('#search_publisher_modal').val()) {
+			let publisher = $('#search_publisher_modal').val();
+			publisher = encodeMark(publisher);
+			url += '/publisher/' + publisher;
+		}
+		if ($('#search_hashtag_modal').text()) {
+			let hashtag = $('#search_hashtag_modal').text();
+			hashtag = encodeMark(hashtag);
+			url += '/hashtag/' + hashtag;
+		}
+
+		// query_string 生成
+		arrQuery.splice(0);
+		if ($('#search_used_price_min_modal').val() || $('#search_used_price_max_modal').val()) {
+			paramName = 'price';
+			paramValue = $('#search_used_price_min_modal').val() + '-' + $('#search_used_price_max_modal').val();
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+			// 発売年月 未入力補完
+		var searchYearStartModal = $('#search_sys_modal').val();
+		var searchMonthStartModal = $('#search_sms_modal').val();
+		var searchYearEndModal = $('#search_sye_modal').val();
+		var searchMonthEndModal = $('#search_sme_modal').val();
+		var searchStartModal = null;
+		var searchEndModal = null;
+		if (searchYearStartModal && searchMonthStartModal) {
+			// 開始年：入力　開始月：入力　の場合は、searchStartModalをセット
+			searchStartModal = searchYearStartModal + searchMonthStartModal;
+		} else if (!searchYearStartModal && !searchMonthStartModal) {
+			// 開始年：未入力　開始月：未入力　の場合は、searchStartModal = null をセット
+			searchStartModal = null;
+		} else if (searchYearStartModal && !searchMonthStartModal) {
+			// 開始年：入力　開始月：未入力　の場合は、searchMonthStartModal = '01' をセット
+			searchStartModal = searchYearStartModal + '01';
+		} else {
+			// 開始年：未入力　開始月：入力　の場合は、searchYearEndModal により分岐
+			if(searchYearEndModal) {
+				// searchYearEndModal：入力　の場合は、searchYearStartModal = searchYearEndModal
+				searchStartModal = searchYearEndModal + searchMonthStartModal;
+			} else {
+				// searchYearEndModal：未入力　の場合は、searchYearStartModal = now
+				searchYearStartModal = new Date().getFullYear().toString();
+				searchStartModal = searchYearStartModal + searchMonthStartModal;
+			}
+		}
+		if (searchYearEndModal && searchMonthEndModal) {
+			// 終了年：入力　終了月：入力　の場合は、searchEndModalをセット
+			searchEndModal = searchYearEndModal + searchMonthEndModal;
+		} else if (!searchYearEndModal && !searchMonthEndModal) {
+			// 終了年：未入力　終了月：未入力　の場合は、searchEndModal = null をセット
+			searchEndModal = null;
+		} else if (searchYearEndModal && !searchMonthEndModal) {
+			// 終了年：入力　終了月：未入力　の場合は、searchMonthEndModal = '12' をセット
+			searchEndModal = searchYearEndModal + '12';
+		} else {
+			// 終了年：未入力　終了月：入力　の場合は、searchYearStartModal により分岐
+			if(searchYearStartModal) {
+				// searchYearEndModal：入力　の場合は、searchYearEndModal = searchYearEndModal
+				searchEndModal = searchYearStartModal + searchMonthEndModal;
+			} else {
+				// searchYearStartModal：未入力　の場合は、searchYearEndModal = now
+				searchYearEndModal = new Date().getFullYear().toString();
+				searchEndModal = searchYearEndModal + searchMonthEndModal;
+			}
+		}
+		if (searchStartModal) {
+			paramName = 'date-min';
+			paramValue = searchStartModal;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (searchEndModal) {
+			paramName = 'date-max';
+			paramValue = searchEndModal;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if(url.endsWith(".0")) {
+			url += '/';
+		}
+		// query_string生成
+		url += makeQueryString(arrQuery);
+		window.location.href = url;
+	}
+});
+
+function makeQueryString(arrQuery) {
+	// query_string生成
+	if (arrQuery.length > 0) {
+		var queryString = $.map(arrQuery, function(param) {
+			return encodeURIComponent(param.name) + '=' + encodeURIComponent(param.value);
+		}).join('&');
+		return '?' + queryString;
+	} else {
+		return '';
+	}
+}
+
+// リセット
+$('#search_reset_btn').on('click', function() {
+	$('.search_form').val('');
+	$('.search_check').prop('checked', false);
+});
+
+$('#search_reset_btn_modal').on('click', function() {
+	$('.search_form').val('');
+	$('.search_check').prop('checked', false);
+});
+
+// 表示切り替え
+$("#display_change_list").on("click", function () {
+	display_change_list();
+	sessionStorage.setItem('display_change', 'list');
+});
+
+$("#display_change_grid").on("click", function () {
+	display_change_grid();
+	sessionStorage.setItem('display_change', 'grid');
+});
+
+$(document).ready(function() {
+	var display_change = sessionStorage.getItem('display_change');
+	if (display_change == 'list') {
+		display_change_list();
+	} else if (display_change == 'grid') {
+		display_change_grid();
+	}
+	// セットカテゴリリンクへのquery_string追加
+	var arrSetQuery = [];
+	var setSortKey = sessionStorage.getItem('listoption_setsortkey');
+	var setPageCount = sessionStorage.getItem('listoption_pagecount');
+	if (setSortKey !== null && setSortKey !== '90') {
+		paramName = 'sort';
+		paramValue = setSortKey;
+		arrSetQuery.push( { name: paramName, value: paramValue } );
+	}
+	if (setPageCount !== null && setPageCount !== '30') {
+		paramName = 'per-page';
+		paramValue = setPageCount;
+		arrSetQuery.push( { name: paramName, value: paramValue } );
+	}
+
+	var setLinkUrl = '/set/search/keyword/9784813705185';
+	setLinkUrl += makeQueryString(arrSetQuery);
+	$('.categorySetLink').attr('href', setLinkUrl);
+});
+
+function display_change_list() {
+	if ($("#items_field").hasClass("-grid")) {
+		$("#items_field").removeClass("-grid");
+		$("#display_change_list").addClass("-active");
+		$("#display_change_grid").removeClass("-active");
+	}
+}
+
+function display_change_grid() {
+	if (!$("#items_field").hasClass("-grid")) {
+		$("#items_field").addClass("-grid");
+		$("#display_change_list").removeClass("-active");
+		$("#display_change_grid").addClass("-active");
+	}
+}
+
+// 並び順
+$(document).on('click', function (e) {
+	if (!$(e.target).closest('#sort_modal').length) {
+		$('#sort_modal').removeClass("-selected");
+		$('#sort_modal_list').removeClass("-selected");
+	}
+});
+
+$('#sort_modal').on('click', function () {
+	if($('#sort_modal').hasClass("-selected")) {
+		$('#sort_modal').removeClass("-selected");
+		$('#sort_modal_list').removeClass("-selected");
+	} else {
+		$('#sort_modal').addClass("-selected");
+		$('#sort_modal_list').addClass("-selected");
+	}
+});
+
+// 表示件数
+$(document).on('click', function (e) {
+	if (!$(e.target).closest('#display_number_modal').length) {
+		$('#display_number_modal').removeClass("-selected");
+		$('#display_number_modal_list').removeClass("-selected");
+	}
+});
+
+$('#display_number_modal').on('click', function () {
+	if($('#display_number_modal').hasClass("-selected")) {
+		$('#display_number_modal').removeClass("-selected");
+		$('#display_number_modal_list').removeClass("-selected");
+	} else {
+		$('#display_number_modal').addClass("-selected");
+		$('#display_number_modal_list').addClass("-selected");
+	}
+});
+
+// 並び順・表示件数の保持
+$('.listDropDown__link').on('click', function () {
+	saveParam = $(this).data('listoption-param');
+	if($(this).data('listoption') == 'sortkey') {
+		sessionStorage.setItem('listoption_sortkey', saveParam);
+	} else if($(this).data('listoption') == 'pagecount') {
+		sessionStorage.setItem('listoption_pagecount', saveParam);
+	}
+});
+
+// 文字制限
+// PC
+$('#search_keyword').on('blur', function() {
+	convertLimitStr(this, 100);
+});
+$('#search_exclusion_keyword').on('blur', function() {
+	convertLimitStr(this, 80);
+});
+$('#search_author').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+$('#search_publisher').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+// SP
+$('#search_keyword_modal').on('blur', function() {
+	convertLimitStr(this, 100);
+});
+$('#search_exclusion_keyword_modal').on('blur', function() {
+	convertLimitStr(this, 80);
+});
+$('#search_author_modal').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+$('#search_publisher_modal').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+
+function convertLimitStr(current, num) {
+	if ($(current).val().length > num) {
+		var convertVal = $(current).val().substr(0, num);
+		$(current).val(convertVal);
+	}
+}
+
+// 中古価格　全角→半角
+// PC
+$('#search_used_price_min').on('blur', function() {
+	convertFullToHalf(this);
+});
+$('#search_used_price_max').on('blur', function() {
+	convertFullToHalf(this);
+});
+// SP
+$('#search_used_price_min_modal').on('blur', function() {
+	convertFullToHalf(this);
+});
+$('#search_used_price_max_modal').on('blur', function() {
+	convertFullToHalf(this);
+});
+
+function convertFullToHalf(current) {
+	var convertVal = $(current).val().replace(/[０-９]/g, function(s) {
+		return String.fromCharCode(s.charCodeAt(0) - 65248);
+	});
+	convertVal = convertVal.replace(/[^0-9]/g, '');
+	var maxDigit = 10;
+	if (convertVal.length > maxDigit) {
+		convertVal = convertVal.substring(0, maxDigit);
+	}
+	$(current).val(convertVal);
+}
+
+function replacePercent(word) {
+	if (!word || word.indexOf('%') < 0) {
+		return word;
+	}
+	var split = word.split('%');
+	var result = split[0];
+	for (var i = 1; i < split.length; i++) {
+		if (i == split.length - 1 && !split[i]) {
+			result += '%25';
+		} else if (!split[i].match(/^[0-9a-f]2/i)) {
+			result += '%25' + split[i];
+		} else {
+			result += '%' + split[i];
+		}
+	}
+	return result;
+}
+
+function encodeMark(word) {
+	word = replacePercent(word);
+	word = word.replace(/\?/g, '%253F');
+	word = word.replace(/\//g, '%252F');
+	word = word.replace(/\#/g, '%2523');
+	return word;
+}
+
+// ボタンの個数差でのCSS制御
+$(".productItem__btns").each(function(index, element) {
+	if($(element).children().length > 2) {
+		$(this).closest('.productItem').addClass('productItem--btns3col');
+	}
+});
+
+// 複数のセット商品がありますモーダル
+$('.js-modal[data-modal^="modalSetSelect-"]').on('click', function () {
+	$(this).delay(100).queue(function () {
+		adjust();
+		$(window).resize(function () {
+			adjust();
+		})
+		function adjust() {
+			var setModal = $('[id^="modalSetSelect-"]');
+			var h1 = setModal.find('.modal__title').outerHeight(true);
+			if (window.matchMedia("(min-width: 768px)").matches) {
+				//PC
+				var modalh = setModal.height();
+				var paddingTop = setModal.find('.modalContent').css('padding-top').replace('px', '');
+				setModal.find('.modalItems.js-modalInnerContent').css("height", modalh - h1 - paddingTop);
+			} else {
+				//SP
+				var windowh = $(window).height();
+				setModal.css("height", windowh * 0.97);
+				setModal.find('.modalItems.js-modalInnerContent').css("height", windowh * 0.97 - h1);
+			}
+		}
+	});
+});
+
+$('.js-ageverification').on('click', function(){
+	var modalBtn = $('#ageVerification__btns--agree');
+	// 初期化
+	modalBtn.removeClass();
+	modalBtn.addClass('btn js-agree-submit');
+	modalBtn.removeAttr('data-mode');
+	modalBtn.removeAttr('data-item');
+	modalBtn.removeAttr('data-cv-name');
+	modalBtn.removeAttr('data-stock');
+	$('.ageVerificationBlock__txt--error').hide();
+
+	// クリックボタンからパラメータ取得
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+
+	// agreeボタン パラメータ設定
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+$('.js-modalClose').on('click', function(){
+	if ($('#modalAgeVerification').hasClass('-show')) {
+		initializeAgeVerificationModal();
+	}
+});
+$('.modal__overlay').on('click', function(){
+	if ($('#modalAgeVerification').hasClass('-show')) {
+		initializeAgeVerificationModal();
+	}
+});
+function initializeAgeVerificationModal () {
+	var modalBtn = $('#ageVerification__btns--agree');
+	modalBtn.removeClass();
+	modalBtn.addClass('btn js-agree-submit');
+	modalBtn.removeAttr('data-mode');
+	modalBtn.removeAttr('data-item');
+	modalBtn.removeAttr('data-cv-name');
+	modalBtn.removeAttr('data-stock');
+	$('.ageVerificationBlock__txt--error').hide();
+}
+</script>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock717566">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">検索結果の関連商品</h2>
+    </div>
+    <div id="js-recSearchRelation" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="602" data-id="search" data-id-mb="search-mb" data-id-pc="search-pc" data-item-id="searchResult" data-genre="" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+			<div class="itemsContainerWrap itemsContainerWrap--itemViewHistory pbNested pbNestedWrapper "  id="pbBlock714242">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock714243">
+						<section class="itemsContainer itemsContainer--itemViewHistory js-itemViewHistory">
+  <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop -hidden js-displayItemViewHistoryHeader">
+    <h2 class="itemsContainer__header">最近チェックした商品</h2>
+    <div class="itemsContainer__textBox itemsContainer__textBox--deleteHistory js-delItemViewHistoryArea"><button class="link itemsContainer__actionButton js-delItemViewHistory"><span>履歴を消す</span></button></div> 
+  </div>
+  <div class="itemsContainer__wrapper">
+    <div class="itemsContainer__main splide js-displayItemViewHistory" id="ItemViewHistory">
+    </div>
+    <div class="itemsContainer__textBox itemsContainer__textBox--removeHistory js-undoItemViewHistoryArea -hidden">
+      <div class="itemsContainer__text">履歴をすべて削除しました</div>
+      <div class="itemsContainer__actionBox">
+        <button class="itemsContainer__actionButton js-undoItemViewHistory"><span>もとにもどす</span></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div></div><div id="footerArea" class="pbFooterArea">
+	<div id="area4" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10025">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock161678">
+						<footer class="footer" id="footer">
+    <div class="footer__wrap">
+      <div class="footer__inner">
+        <div class="footer__navi">
+          <p class="footer__pageTop">
+            <a href="#" class="footer__pageTopBtn js-pagetop">
+              <img src="/library/common/images/img-footer-arrow.svg" alt="ページトップへ戻る">
+            </a>
+          </p>
+          <ul>
+            <li class="footer__item footer__item--first"><a href="https://support-online.bookoff.co.jp" class="footer__link">ヘルプ・ご質問</a>
+              <ul>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/64363fbd97ebd8c6491e0a07" class="footer__link">配送料について</a></li>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/65852e8cd29784dd07b9bdc7" class="footer__link">支払い方法について</a></li>
+              </ul>
+            </li>
+            <li class="footer__item"><a href="https://shopping.bookoff.co.jp/service/mail" class="footer__link">メールサービス</a></li>
+            <li class="footer__item"><a href="https://regist11.smp.ne.jp/regist/is?SMPFORM=ofn-latbq-651b190782b21aa1eaa0162e484e578c" class="footer__link">ご意見・ご感想</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer__wrap footer__wrap--bottom">
+      <div class="footer__inner">
+        <ul class="footer__sns">
+          <li>
+            <a href="https://www.facebook.com/%E3%83%96%E3%83%83%E3%82%AF%E3%82%AA%E3%83%95%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3bookoffonline-166258740189848/" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-fb.svg" alt="Facebook">
+            </a>
+          </li>
+          <li>
+            <a href="https://x.com/bookoffonline" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-x.svg" alt="X">
+            </a>
+          </li>
+          <li>
+            <a href="https://page.line.me/iau9918q" class="footer__snsBtn">
+              <img src="/library/common/images/img-footer-line.svg" alt="LINE">
+            </a>
+          </li>
+        </ul>
+        <div class="footer__bottomNavi">
+          <ul>
+           <li><a href="https://www.bookoff.co.jp/" class="footer__bottomLlink" target="_blank">BOOKOFF公式サイト</a></li>
+           <li><a href="https://www.bookoffgroup.co.jp/corporate/business.html" class="footer__bottomLlink" target="_blank">企業情報</a></li>
+           <li><a href="https://member.bookoff.co.jp/bo-member-content/contract/" class="footer__bottomLlink" target="_blank">BOOKOFF会員サービス利用規約</a></li>
+           <li><a href="https://shopping.bookoff.co.jp/policies/terms" class="footer__bottomLlink">利用規約</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/privacy.html" class="footer__bottomLlink" target="_blank">個人情報保護方針</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/socialmedia.html" class="footer__bottomLlink" target="_blank">ソーシャルメディアポリシー</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/customerharassment.html" class="footer__bottomLlink" target="_blank">カスタマーハラスメントに対する基本方針</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/regulatory-disclosure" class="footer__bottomLlink">特定商取引法に基づく表示</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/external-transmission" class="footer__bottomLlink">利用者情報の外部送信について</a></li>
+          <li><a href="https://www.bookoffgroup.co.jp/" class="footer__bottomLlink" target="_blank">ブックオフグループホールディングス株式会社</a></li>
+         </ul>
+        </div>
+        <div class="footer__bottom">
+          <div class="footer__text">
+            <p> ブックオフコーポレーション株式会社<br> 古物商許可番号 第452760001146号 神奈川県公安委員会許可 </p>
+          </div>
+          <div class="footer__copyright"> Copyright(C)BOOKOFF CORPORATION LTD.<br class="forSp">All Rights Reserved. </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock209621">
+						
+<link rel="stylesheet" href="/library/common/css/appli/app-hide-common.css">
+
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div>
+<script  src="https://content.bookoff.co.jp/js/roc/csrf_tmp.min.js"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-show.js?rev=20260427"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-item.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-contents.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/core.js"></script>
+<script  src="/library/common/js/sjis_convert.min.js"></script>
+<script  src="/library/common/js/suggest_module.js?d=20240911"></script>
+</body>
+</html>
+<!-- cache datetime:2026/07/23 00:43:43, cache file name:/shopping/search.html --> 

--- a/tests/fixtures/used_book/bookoff_search_empty.html
+++ b/tests/fixtures/used_book/bookoff_search_empty.html
@@ -1,0 +1,2864 @@
+<!DOCTYPE html>
+<html data-csrf-tmp-token="9bb8da1cf607a0aa" data-csrf-tmp-verifier="78fb10acbeb3e91cf66cc23c5377a388d05e7734501ff0a7c144a3eb89876680" xmlsn:og="http://ogp.me/ns#" xmlns:fb="http://ogp.me/ns/fb#" lang="ja">
+<head>
+<meta charset="UTF-8">
+
+<link rel="shortcut icon" href="/favicon.ico?dummy=1674087367" />
+<link rel="stylesheet" type="text/css" href="/css/shopping/search.css" charset="UTF-8" />
+<link rel="stylesheet" type="text/css" href="/publis.css" /><meta name="keywords" content="ブックオフ公式オンラインストアの検索ページです。有名書籍から人気コミックまで幅広いジャンルでお気に入りの作品が見つかるかも？　本(書籍)、漫画(コミック)、CD、DVD・ブルーレイ、ゲームなど中古・新品の通販ならブックオフ公式オンラインストア" />
+<meta name="description" content="" />
+<title>検索一覧  | ブックオフ公式オンラインストア</title>
+<script >
+<!--
+	var pbGlobalAliasBase = '/';
+//-->
+</script>
+<script  src="/public.js"></script>
+<meta name="viewport" content="width=device-width">
+<!--link rel="shortcut icon" href="https://content.bookoffonline.co.jp/favicon.ico"-->
+<link rel="apple-touch-icon" sizes="180x180" href="/library/common/images/apple_touch_icon.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/library/common/images/webclip_android.png">
+<link rel="stylesheet" href="/library/common/css/common.css?d=20250416">
+<link rel="stylesheet" href="/library/common/css/headerFooter.css">
+<script src="https://content.bookoff.co.jp/files/common/js/jquery-2.2.4.min.js"></script>
+<script src="/library/common/js/vendor.bundle.js"></script>
+<script src="/library/common/js/common.js"></script>
+<script src="/library/common/js/headerFooter.js"></script>
+<!--<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>-->
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/items-container.css?rev=20260612" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/plugin/splide.min.js"></script>
+
+<script  src="https://content.bookoff.co.jp/files/common/js/jquery-1.12.4.min.js"></script>
+<script>
+
+	var class_name = 'BocSearchResult';
+
+$(document).on('click', '.js-ageverification', function(){
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+	var modalBtn = $('#ageVerification__btns--agree');
+
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+
+	// カートに追加、在庫有りのみカートに追加、巻数を指定してカートに追加する
+	$(document).on('click', '.jsBtn-cart', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if (mode == 'disabled') {
+			return false;
+		}
+		if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+			// 在庫有りのみカートに追加の場合、複数回クリック不許可
+			$(this).attr('data-mode', 'disabled');
+		}
+		var ex_param = {};
+		if (mode == 'Add') {
+			ex_param['stockType'] = $(this).attr('data-stock') ?? '';
+		}
+		if (mode == 'AddSelectedItems') {
+			var selectItemIds = {};
+			$('input[type="checkbox"].js-allCheckTarget:checked').each(function(index){
+				selectItemIds[index] = $(this).closest('.productSetItem__checkbox').find('input.item_id').val() ?? '';
+			});
+			ex_param['selectItemIds'] = selectItemIds;
+		}
+		if(age_limit == 1) {
+			ageVerification('cart', mode, item_id, ex_param);
+		} else {
+			ajaxConfig('cart', mode, item_id, ex_param);
+		}
+	});
+	// お気に入り追加・削除
+	$(document).on('click', '.jsBtn-favorite', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('favorite', mode, item_id);
+		} else {
+			ajaxConfig('favorite', mode, item_id);
+		}
+	});
+	// 入荷お知らせ追加・削除、全巻入荷お知らせ追加・削除
+	$(document).on('click', '.jsBtn-arrival', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var age_limit = $(this).attr('data-agelimit') ?? '';
+		if(age_limit == 1) {
+			ageVerification('arrival', mode, item_id);
+		} else {
+			ajaxConfig('arrival', mode, item_id);
+		}
+	});
+	// 値下げのお知らせ追加・削除
+	$(document).on('click', '.jsBtn-discount', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		var ex_param = {};
+		ex_param['price'] = $(this).attr('data-price') ?? 0;
+
+		if (mode == 'Add_PriceChange' || mode == 'PriceChange'){
+		    ex_param['targetPrice'] = $('#modal #discountAlert input[name="discountAlert"]').val() ?? 0;
+			if (ex_param['targetPrice'] == 0 || ex_param['targetPrice'] == '') {
+				discountModalError('1円以上で入力してください');
+			} else if (parseInt(ex_param['targetPrice']) >=  parseInt(ex_param['price'])) {
+				if (item_id.slice(0, 2) == '88') {
+					discountModalError('定価合計価格より小さい金額を入力してください');
+				} else {
+					discountModalError('中古価格より小さい金額を入力してください');
+				}
+			} else if (!ex_param['targetPrice'].match(/^[0-9]+$/)) {
+				discountModalError('半角数字で入力してください');
+			} else {
+				// 「0」埋めの入力は頭削除して登録
+				if (ex_param['targetPrice'].match(/^0+/)) {
+					ex_param['targetPrice'] = new Intl.NumberFormat('ja-JP').format(ex_param['targetPrice']);
+				}
+				ajaxConfig('discount', mode, item_id, ex_param);
+			}
+		} else if(mode == 'Add') {
+		    ex_param['targetPrice'] = $(this).attr('data-target-price') ?? 0;
+			ajaxConfig('discount', mode, item_id, ex_param);
+		} else if(mode == 'Delete') {
+			ajaxConfig('discount', mode, item_id);
+		}
+	});
+	// 最新刊のお知らせ追加・削除
+	$(document).on('click', '.jsBtn-latests', function(event){
+		event.preventDefault();
+		var mode = $(this).attr('data-mode') ?? '';
+		var item_id = $(this).attr('data-item') ?? '';
+		ajaxConfig('latests', mode, item_id);
+	});
+
+	// 在庫ない商品一覧表示確認モーダル
+	$(document).on('click', '.jsBtn-cart-modal', function(event){
+		event.preventDefault();
+		$('#modalSetAddCart ul.modalSetAddCart__list').empty();
+		var item_id = $(this).attr('data-item');
+		ajaxConfig('cart', 'RewriteSetModal', item_id);
+	});
+
+	// 値下げのお知らせ価格設定変更モーダル
+	$(document).on('click', '.jsBtn-discount-modal', function(event){
+		event.preventDefault();
+		var item_id = $(this).attr('data-item') ?? '';
+		var price = $(this).attr('data-price') ?? '';
+		var target_price = $(this).attr('data-target-price') ?? '';
+		var modal = $(this).attr('data-modal') ?? '';
+
+		if (modal = 'discountAlert') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-price', price);
+				$('#modal #discountAlert .jsBtn-discount').attr('data-target-price', target_price);
+
+				if (item_id.slice(0, 2) == '88') {
+					$('.modalConfirm__regularPrice').show();
+				}else {
+					$('.modalConfirm__regularPrice').hide();
+				}
+
+				$('#modal #discountAlert #discount-market-price').text(price.toLocaleString());
+				$('#modal #discountAlert #discount-target-price').text(target_price.toLocaleString());
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlert').addClass('-show');
+
+		} else if (modal = 'discountAlertCancel') {
+			if (class_name == 'BocAlertMailList') {
+				$('#modal #discountAlert .jsBtn-discount').attr('data-item', item_id);
+			}
+			$('#modal').addClass('-show -visible');
+			$('#modal #discountAlertCancel').addClass('-show');
+		}
+	});
+
+	$(document).on('click', '.js-modalClose', function(event){
+		event.preventDefault();
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+	$(document).on('click', '.modal__overlay', function(event){
+		if ($('#modal #discountAlert').hasClass('-show')) {
+			initializeDiscountModal();
+		}
+	});
+
+	function initializeDiscountModal () {
+		$('#modal #discountAlert input[name="discountAlert"]').removeClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").hide();
+		$("#modal #discountAlert .modalConfirm__error").text('');
+		$('#modal').removeClass('-show -visible');
+		$('#modal #discountAlert').removeClass('-show');
+		$('#modal #discountAlert input[name="discountAlert"]').val('');
+	}
+
+	function discountModalError (str) {
+		$('#modal #discountAlert input[name="discountAlert"]').addClass('-error');
+		$("#modal #discountAlert .modalConfirm__error").show();
+		$("#modal #discountAlert .modalConfirm__error").text(str);
+	}
+</script><script>
+	function ageVerification(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 728352
+						, 'pageId': 1316
+						, 'revision': 0
+						, 'type': 'ageVerification'
+						, 'mode': 'Agree'
+						, 'itemId': item_id
+					};
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+			// 検索一覧内のボタンをすべて書き換え
+				$('.js-ageverification').each(function() {
+					elmType = $(this).attr('data-type');
+					if (elmType == 'cart') {
+						var btnClass = 'jsBtn-cart';
+					} else if (elmType == 'favorite') {
+						var btnClass = 'jsBtn-favorite';
+					} else if (elmType == 'arrival') {
+						var btnClass = 'jsBtn-arrival';
+					}
+					$(this).addClass(btnClass);
+				});
+				$('.js-ageverification').addClass('ac-click-cv');
+				$('.js-ageverification').removeAttr('data-type');
+				$('.js-ageverification').removeAttr('data-modal');
+				$('.js-ageverification').removeClass('js-modal js-ageverification');
+
+				// モーダルを閉じる
+				$('.modal__inner').removeClass('-show');
+				$('#modal').removeClass('-visible -show');
+				$('body').removeClass('-modalOpen');
+				$('html').removeAttr('data-whatelement data-whatclasses');
+				// モーダルのDOM要素を削除
+				$('[id^="modalAgeVerification"]').remove();
+				// ajaxConfig 実行
+				ajaxConfig(type, mode, item_id, ex_param);
+			} else if (data.status == 'FAILED_AGE_VERIFICATION') {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			} else {
+				var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+				$('.ageVerificationBlock__txt--error').text(errMsg);
+				$('.ageVerificationBlock__txt--error').show();
+				return false;
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			var errMsg = 'エラーにより年齢認証が完了出来ませんでした。';
+			$('.ageVerificationBlock__txt--error').text(errMsg);
+			$('.ageVerificationBlock__txt--error').show();
+			return false;
+		});
+	}
+
+	function ajaxConfig(type, mode, item_id, ex_param={}){
+		var send_data = {
+						'className': class_name
+						, 'blockId': 728352
+						, 'pageId': 1316
+						, 'revision': 0
+						, 'type': type
+						, 'mode': mode
+						, 'itemId': item_id
+						, 'exParam' : ex_param
+					};
+
+		ajax_jquery({
+			url: "/view_interface.php",
+			type : "POST",
+			data : send_data,
+			dataType : "json"
+		})
+		.done(function(data, textStatus, jqXHR){
+			if (data.status == 'OK') {
+				// カートに追加
+				if (type == 'cart') {
+					thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-cart-modal[data-item="' + item_id + '"]';
+
+					if (mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocProductSet') {
+							var checkNum = 0;
+							$('.js-allCheckTarget').each(function(){
+								if ($(this).prop('checked')) {
+									checkNum++;
+								}
+							});
+							if (checkNum == 0) {
+								window.location.href = '/cart/';
+							}
+						}
+					}
+
+					if (mode == 'Add' || mode == 'AddSet' || mode == 'AddSelectedItems') {
+						if (class_name == 'BocRankingOfWeekList' || class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSearchResult') {
+							// カートを見るボタンに変更
+							sourceObj = $(thisId);
+							targetObj = $('<a>');
+							sourceObj.removeClass('jsBtn-cart');
+							sourceObj.addClass('-added');
+							targetObj.attr('href', '/cart/');
+							targetObj.text(' カートを見る ');
+							$.each(sourceObj[0].attributes, function() {
+								targetObj.attr(this.name, this.value);
+							});
+							sourceObj.replaceWith(targetObj);
+						} else {
+							$(thisId).attr('href', '/cart/');
+							$(thisId).addClass('-added');
+							$(thisId).text(' カートを見る ');
+							$(thisId).removeClass('jsBtn-cart');
+						}
+					} else if (mode == 'AddSetInStock') {
+						if (class_name == 'BocRankingOfWeekList') {
+							window.location.href = '/cart/';
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisItemBtnId).addClass('-added');
+							$(thisItemBtnId).text(' カートを見る ');
+							$(thisItemBtnId).attr('data-modal', '');
+							$(thisItemBtnId).attr('data-mode', '');
+							$(thisItemBtnId).off('click');
+							$(thisItemBtnId).attr('href', '/cart/');
+							$(thisItemBtnId).removeClass('jsBtn-cart-modal btn--2l js-modal');
+							// モーダルを閉じる
+							$('.modal__overlay').trigger('click');
+						}
+					} else if (mode == 'RewriteSetModal') {
+						$('#modalSetAddCart .jsBtn-cart').attr('data-item', item_id).attr('data-mode', 'AddSetInStock');
+						$('#modalSetAddCart .modal__title span').text(data.stock_count);
+						for (var i in data.no_stock_items) {
+							var liText = '<li class="modalSetAddCart__item">' + data.no_stock_items[i].item_name + '</li>';
+							$('#modalSetAddCart ul.modalSetAddCart__list').append(liText);
+						}
+						$('#modalSetAddCart .js-modalInnerContent').css('height','500px');
+					}
+				}
+				// お気に入り
+				if (type == 'favorite') {
+					thisId = '.jsBtn-favorite[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $(thisId);
+							displayTooltip(click_ele, type, data.message);
+						}
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite icon-favorite-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite-on icon-favorite-on-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite icon-favorite-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite-on icon-favorite-on-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加済');
+						$(thisId).attr('data-mode', 'Delete');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'delSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'delBookmark_Detail');
+						}
+					}
+					if (mode == 'Delete') {
+						$(thisId + ' span:first-of-type').removeClass('icon-favorite-on icon-favorite-on-dims');
+						$(thisId + ' span:first-of-type').addClass('icon-favorite icon-favorite-dims');
+						if (class_name == 'BocProduct') { // SPのみ
+							$('.forSp > ' + thisId).removeClass('icon-favorite-on icon-favorite-on-dims');
+							$('.forSp > ' + thisId).addClass('icon-favorite icon-favorite-dims');
+						}
+						$(thisId + ' span:nth-of-type(2)').text('お気に入り追加');
+						$(thisId).attr('data-mode', 'Add');
+						if (class_name == 'BocSearchResult') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Search');
+						} else if (class_name == 'BocSetSearchResult') {
+							$(thisId).attr('data-cv-name', 'addSetMail_Search');
+						} else if (class_name == 'BocProduct') {
+							$(thisId).attr('data-cv-name', 'addBookmark_Detail');
+						}
+					}
+				}
+				// 入荷お知らせ
+				if (type == 'arrival') {
+					thisId = '.jsBtn-arrival[data-item="' + item_id + '"]';
+					if (mode == 'Add' || mode == 'AddSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							if (data.message) {
+								click_ele = $(thisId);
+								displayTooltip(click_ele, type, data.message);
+							}
+							$(thisId).addClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷お知らせを解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							} else if (mode == 'AddSet') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'DeleteSet');
+							} else if (mode == 'Add') {
+								$(thisId).text('登録を解除する');
+								$(thisId).attr('data-mode', 'Delete');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'delAlertMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'delAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'delSetMail_Ranking');
+							}
+						}
+					} else if (mode == 'Delete' || mode == 'DeleteSet') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId).removeClass('-added');
+							if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+								$(thisId).text('入荷のお知らせを受け取る');
+								$(thisId).attr('data-mode', 'Add');
+							} else if (mode == 'DeleteSet') {
+								$(thisId).text('全巻入荷お知らせ');
+								$(thisId).attr('data-mode', 'AddSet');
+							} else if (mode == 'Delete') {
+								$(thisId).text('入荷お知らせ');
+								$(thisId).attr('data-mode', 'Add');
+							}
+							if (class_name == 'BocSearchResult') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Search');
+							} else if (class_name == 'BocSetSearchResult') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Search');
+							} else if (class_name == 'BocProduct') {
+								$(thisId).attr('data-cv-name', 'addAlertlMail_Detail');
+							} else if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Detail');
+							} else if (class_name == 'BocRankingOfWeekList') {
+								$(thisId).attr('data-cv-name', 'addSetMail_Ranking');
+							}
+						}
+					}
+				}
+				// 値下げお知らせ
+				if (type == 'discount') {
+					thisId = '.jsBtn-discount[data-item="' + item_id + '"]';
+					thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						}
+					}
+					if (mode == 'PriceChange') {
+						if (class_name == 'BocAlertMailList') {
+							initializeDiscountModal();
+							$('#modal #discountAlert .jsBtn-discount').attr('data-item', '');
+							$('#modal #discountAlert .jsBtn-discount').attr('data-price', '');
+							var thisItemBtnId = '.jsBtn-discount-modal[data-item="' + item_id + '"]';
+							var targetPrice = ex_param['targetPrice'];
+							$(thisItemBtnId).attr('data-target-price', targetPrice);
+							$('#discount-target-price-' + item_id).text(targetPrice.toLocaleString());
+						}
+					}
+					if (mode == 'Add_PriceChange') {
+						if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを登録済');
+							$(thisItemBtnId).attr('data-modal','discountAlertCancel');
+							$(thisItemBtnId).attr('data-mode', 'Delete');
+							// モーダルを閉じる
+							initializeDiscountModal();
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'delSetMailPriceDown_Detail');
+							}
+						}
+					}
+					if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else if (class_name == 'BocProduct' || class_name == 'BocProductSet') {
+							$(thisItemBtnId + ' span:nth-of-type(2)').text('値下げのお知らせを受け取る');
+							$(thisItemBtnId).attr('data-modal','discountAlert');
+							$(thisItemBtnId).attr('data-mode', 'Add');
+							// モーダルを閉じる
+							$('#modal').removeClass('-show -visible');
+							$('#modal #discountAlertCancel').removeClass('-show');
+							if (class_name == 'BocProductSet') {
+								$(thisItemBtnId).attr('data-cv-name', 'addSetMailPriceDown_Detail');
+							}
+						}
+					}
+				}
+				// 最新刊お知らせ
+				if (type == 'latests') {
+					thisId = '.jsBtn-latests[data-item="' + item_id + '"]';
+					if (mode == 'Add') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--gray');
+							$(thisId).addClass('btn--blue');
+							$(thisId).text(' 解除する ');
+							$(thisId).attr('data-mode', 'Delete');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを登録済');
+							$(thisId).attr('data-mode', 'Delete');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'delNewAlertMail_Detail');
+							}
+						}
+					} else if (mode == 'Delete') {
+						if (class_name == 'BocAlertMailList') {
+							$(thisId).removeClass('btn--blue');
+							$(thisId).addClass('btn--gray');
+							$(thisId).text(' 再設定 ');
+							$(thisId).attr('data-mode', 'Add');
+						} else {
+							$(thisId + ' span:nth-of-type(2)').text('最新刊のお知らせを受け取る');
+							$(thisId).attr('data-mode', 'Add');
+							if (class_name == 'BocProductSet') {
+								$(thisId).attr('data-cv-name', 'addNewAlertMail_Detail');
+							}
+						}
+					}
+				}
+			// 在庫なし、もしくは、何らかの原因でカート未追加
+			} else if (data.status == 'NO_STOCK' || data.status == 'FAILED_TO_CART') {
+				if (type == 'cart') {
+					// 他のモーダル開いてたら閉じる
+					if ($('.js-modalInner').hasClass('-show')) {
+						$('#modal').removeClass('-show -visible');
+						$('.js-modalInner').removeClass('-show');
+					}
+					// カートに追加できませんでしたモーダルを開く
+					if($('#modalCartAddStock0').length){
+						if (data.status == 'NO_STOCK' || data.error_code == 'OC456') {
+							$('#modalCartAddStock0 .js-cart-alert').text('在庫がなくなったため、商品をカートに追加できませんでした。再読み込みしてページを更新します');
+						} else {
+							$('#modalCartAddStock0 .js-cart-alert').text('現在お取り扱いのない商品が含まれるため、カートに追加できませんでした。再読み込みしてページを更新します');
+						}
+						$('[data-modal="modalCartAddStock0"]').trigger("click");
+					}
+					// disabledにしたカートボタンを元に戻す
+					if ((mode == 'Add') || (mode == 'AddSet') || (mode == 'AddSetInStock')) {
+						thisId = '.jsBtn-cart[data-item="' + item_id + '"]';
+						if($(thisId).attr('data-mode') == 'disabled') {
+							$(thisId).attr('data-mode', mode);
+						}
+					}
+				}
+			// 何らかの原因で処理未完了
+			} else if (data.status == 'NG') {
+				if (type == 'favorite') {
+					if (mode == 'Add') {
+						if (data.message) {
+							click_ele = $('.jsBtn-favorite[data-item="' + item_id + '"]');
+							displayTooltip(click_ele, type, data.message);
+						}
+					}
+				}
+			// 未ログインもしくはAPIエラー
+			} else if (data.status == 'NO_LOGIN' || data.status == 'API_ERROR') {
+				window.location.href = data.url;
+			} else {
+				alert("エラーが発生しました。もう一度設定してください。");
+			}
+		})
+		.fail(function(jqXHR, textStatus, errorThrown){
+			alert("エラーが発生しました。");
+		});
+	}
+
+	function displayTooltip(click_ele_selector, btnType, message) {
+		var display_time = 2500;
+		var click_ele = $(click_ele_selector);
+		var original_width = click_ele.outerWidth();
+		// wrap
+		if(!click_ele.parent().hasClass('tipsBalloonArea')){
+			click_ele.each(function() {
+				var self = jQuery(this);
+				var area = jQuery('<div class="tipsBalloonArea"></div>').css({
+					'width': '100%',
+					'margin': self.css('margin'),
+					'margin-bottom': '0'
+				});
+				self.wrap(area);
+			});
+		}
+		// ツールチップHTML
+		var html = '';
+		var isProductPage = !click_ele.hasClass('productItem__favorite');
+		if (isProductPage) {
+			click_ele.parent().addClass('tipsBalloonAreaProductPage');
+			html = '<div class="tipsBalloon tipsBalloon--favorite tipsBalloonFavoriteProductPage"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if (btnType === 'favorite'){
+			html = '<div class="tipsBalloon tipsBalloon--favorite"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		} else if(btnType === 'arrival') {
+			html = '<div class="tipsBalloon tipsBalloon--tail-center"><span class="tipsBalloonTxt">' + message + '</span></div>';
+		}
+		// ツールチップ生成・幅設定・表示
+		var tooltip_ele = $(html).insertBefore(click_ele).hide();
+		if(btnType == 'arrival'){
+			// 入荷お知らせの時のみ調整
+			click_ele.closest('.tipsBalloonArea').each(function() {
+				var self = $(this);
+				if (self.parent().hasClass('cartFloat__btn')) {
+					self.css('position', 'unset');
+				}
+				self.children('.tipsBalloon').css({
+					'min-width': self.children('.jsBtn-arrival').outerWidth(),
+					'bottom': self.children('.jsBtn-arrival').outerHeight() * 1.5,
+					'right': 'unset'
+				});
+			});
+		}
+		tooltip_ele.show();
+		setTimeout(function() {
+			tooltip_ele.fadeOut(200);
+			tooltip_ele.remove();
+			// unwrap
+			if(click_ele.parent().hasClass('tipsBalloonArea')){
+				click_ele.unwrap();
+			}
+		}, display_time);
+	}
+</script>
+<script >
+window.headerMenuInfo = window.headerMenuInfo || {
+	pageId: "1316",
+	blockId: "751263"
+};
+</script>
+<script type="text/javascript">
+const _boud={};
+</script>
+<meta property="og:site_name" content="ブックオフ公式オンラインストア" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://shopping.bookoff.co.jp/library/common/images/ogp.webp" />
+<meta property="og:title" content="検索一覧  | ブックオフ公式オンラインストア" />
+<meta property="og:description" content="" />
+<meta property="og:url" content="https://shopping.bookoff.co.jp/search/keyword/9784000000000" />
+<link rel="canonical" href="https://shopping.bookoff.co.jp/search/keyword/9784000000000">
+
+<script>const _isLogin = false;const _isApp=(function(){const uaList='BookoffApp';const userAgent=navigator.userAgent;return userAgent.includes(uaList)})();</script>
+<link rel="stylesheet" type="text/css" href="/library/init/css/publis4-default.css" />
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__product.css" />
+<script  src="/library/common/js/modal-adjust.js"></script>
+<link rel="stylesheet" type="text/css" href="/library/common/css/mainContent__search.css" />
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/search/parts.css?rev=20240516" />
+<script  src="https://content.bookoff.co.jp/assets/js/common/search.js?rev=20250603"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/parts.js"></script>
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/common/search.css?rev=20260604" />
+<link rel="stylesheet" type="text/css" href="" />
+<link rel="stylesheet" type="text/css" href="https://content.bookoff.co.jp/assets/css/search/normal/parts.css?rev=20260602" />
+<script  src="https://content.bookoff.co.jp/assets/js/search/normal/parts.js?rev=20260707"></script>
+</head>
+<body>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-T8MGMLD');</script>
+<!-- End Google Tag Manager -->
+<script src="https://d.adlpo.com/687/2212/js/smartadlpo.js"></script>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8MGMLD" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<script  src="https://content.bookoff.co.jp/assets/js/common/components.js"></script>
+<noscript><p>このページではjavascriptを使用しています。</p></noscript>
+<div id="page" class="pbPage">
+<div id="headerArea" class="pbHeaderArea">
+	<div id="area1" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10023">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162219">
+						
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock162220">
+						<style type="text/css">
+/* 宅配買取ボタン */
+/* common.css */
+.header__menuSell.sellBtn {
+  display: block;
+  padding: 3px 20px;
+  background-color: #fff000;
+  border: 1px solid #fff000;
+  border-radius: 99px;
+  color: #003894;
+  font-weight: bold;
+  font-size: 16px;
+}
+.header__menuSell {
+  margin-left: 8px;
+}
+/* headerFooter.css */
+.header__menu ul {
+  align-items: center;
+}
+</style>
+<div class="header js-header" id="header">
+  <div class="header__wrap js-headerFixed" style="">
+    <div class="header__inner">
+      <div class="header__logoWrap js-headerLogo">
+
+        <div class="header__logo">
+          <a href="/" class="header__logo__img">
+            <img src="/library/common/images/img-logo.png" alt="BOOKOFF">
+          </a>
+          <div class="header__logo__more">
+            <a class="js-headerLogoBtn" href="/"></a>
+          </div>
+        </div>
+        <div class="header__logoContent js-headerLogoContent">
+          <div class="header__logoContentUserGuide">
+            <a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a>
+          </div>
+          <div class="header__logoContentHeader">
+            <a href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+          </div>
+          <ul>
+            <li>
+              <a href="https://www.bookoff.co.jp/shop/" class="header__linkStore">店舗検索</a>
+            </li>
+            <li>
+              <a href="https://sell.bookoff.co.jp/" class="header__linkPurchase">買取はこちら</a>
+            </li>
+          </ul>
+        </div>
+
+      </div>
+      <nav class="header__navi">
+        <div class="header__naviTop">
+          <div class="header__search js-headerSearch">
+            <div class="header__searchInner">
+              <form name="zsForm" id="zsSearchForm" class="header__searchForm">
+                <input id="zsSearchFormInput" type="search" enterkeyhint="search" name="kw_sn" placeholder="キーワード・品番で検索" autocomplete="off" class="zs-search-input" id="zsSearchFormInput">
+                <span class="header__searchIcon">
+                  <img src="/library/common/svg/search-gray.svg" alt="">
+                </span>
+                <span class="header__searchFormClear">
+                  <img src="/library/common/svg/search-clear.svg" alt="" id="zsSearchClearButton">
+                </span>
+              </form>
+              <div class="header__searchHistory" id="zsHistoryArea">
+                <div class="header__searchHistoryHeading">検索履歴</div>
+                <ul class="js-searchHistory" id="zsSearchHistoryAreaUl">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchHistory -->
+              <div class="header__searchSuggest" id="zsSuggestDiv">
+                <ul class="js-searchSuggest">
+                  <li>
+                  </li>
+                </ul>
+              </div>
+              <!-- /header__searchSuggest -->
+            </div>
+          </div>
+          <div class="header__menu">
+                        <ul>
+                <li>
+                  <a class="header__menuSell sellBtn" href="https://sell.bookoff.co.jp/">宅配買取</a>
+                </li>
+                <li>
+                    <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+                </li>
+                <li>
+                    <div class="header__menuAccount js-headerAccount">
+                        <a href="" class=" js-headerAccountBtn"><img src="/library/common/svg/account.svg" alt=""></a>
+                        <div class="header__menuAccountContent js-headerAccountContent">
+                                                            <div class="header__loginBtn">
+                                    <ul>
+                                        <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+                                        <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+                                    </ul>
+                                </div>
+                                                    </div>
+                    </div>
+                </li>
+                <li>
+                    <a href="/cart" ><img src="/library/common/svg/cart.svg" alt="Cart"></a>
+                </li>
+            </ul>
+                      </div>
+        </div>
+        <div class="header__category js-headerCategory">
+          <ul>
+            <li><a href="/book">書籍</a></li>
+            <li><a href="/comic">コミック</a></li>
+            <li><a href="/cd">CD</a></li>
+            <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+            <li><a href="/game">ゲーム</a></li>
+            <li><a href="/set">セット・まとめ買い</a></li>
+          </ul>
+        </div>
+      </nav>
+
+            <div class="header__naviSp">
+        <div class="header__naviTopSp">
+          <div class="header__menuBtnSp js-spMenuBtn">
+            <img src="/library/common/svg/menu.svg" alt="メニュー">
+          </div>
+          <div class="header__menuSp">
+            <a href="https://my.bookoff.co.jp/wishlist"><img src="/library/common/svg/favorite-blue.svg" alt=""></a>
+            <a href="/cart" ><img src="/library/common/svg/cart.svg" alt=""></a>
+          </div>
+        </div>
+      </div>
+      
+    </div><!-- /header__inner -->
+  </div><!-- /header__wrap -->
+</div><!-- /header js-header -->
+
+<div class="spHeaderMenu js-spHeaderMenu">
+  <div class="spHeaderMenu__close">
+    <span class="js-spHeaderMenuClose" tabindex="0">
+      <img src="/library/common/svg/close.svg" alt="close">
+    </span>
+  </div>
+  <div class="spHeaderMenu__inner">
+
+        <div class="spHeaderMenu__loginBtn">
+        <ul>
+            <li><a class="btn btn--blue" href="https://my.bookoff.co.jp/login">ログイン</a></li>
+            <li><a class="btn btn--orange" href="https://my.bookoff.co.jp/register/entry">新規会員登録</a></li>
+        </ul>
+    </div>
+    
+    <div class="spHeaderMenu__heading">カテゴリ</div>
+    <div class="spHeaderMenu__list">
+      <ul>
+        <li><a href="/book">書籍</a></li>
+        <li><a href="/comic">コミック</a></li>
+        <li><a href="/cd">CD</a></li>
+        <li><a href="/dvdbd">DVD・ブルーレイ</a></li>
+        <li><a href="/game">ゲーム</a></li>
+        <li><a href="/set">セット・まとめ買い</a></li>
+      </ul>
+    </div>
+    <div class="spHeaderMenu__list">
+      <ul class="spHeaderMenu__listUserGuide">
+      <li><a href="https://support-online.bookoff.co.jp">ヘルプ・ご質問</a></li>
+      </ul>
+    </div>
+    <a class="spHeaderMenu__linkStore" href="https://www.bookoff.co.jp/">BOOKOFF公式サイト</a>
+    <a class="spHeaderMenu__linkSearch" href="https://www.bookoff.co.jp/shop/">店舗検索</a>
+    <a class="spHeaderMenu__linkPurchase" href="https://sell.bookoff.co.jp/">買取はこちら</a>
+  </div>
+</div>
+<div class="spHeaderMenuOverlay js-spHeaderMenuClose">&nbsp;</div>
+<script type="text/javascript">
+$(document).ready(function () {
+	$('.logout-link').on('click', function() {
+		const logoutUrl="https://my.bookoff.co.jp/logout";
+		ajax_jquery(logoutUrl)
+		.done(function() {
+			const loginUrl="https://my.bookoff.co.jp/login";
+			window.location.href=loginUrl;
+		})
+		.fail(function(e) {
+			let errUrl="/err/404";
+			switch(true){
+				case e.status==502:
+					errUrl="/err/408";
+					break;
+				case e.status>=500:
+					errUrl="/err/500";
+					break;
+			}
+			window.location.href=errUrl;
+		});
+	});
+});
+
+  // point
+  window.loadPoint = function() {
+    const send_data = {
+      "className": "BocHeaderMenu",
+      "blockId": window.headerMenuInfo.blockId,
+      "pageId": window.headerMenuInfo.pageId,
+      "revision": 0,
+      "type": "loadPoint"
+    };
+    ajax_jquery({
+      url: "/view_interface.php",
+      type: "POST",
+      data: send_data,
+      dataType: "json"
+    })
+    .done(function(data, textStatus, jqXHR) {
+      document.querySelectorAll("div.js-headerAccountContent .header__point,div.js-spHeaderMenu .spHeaderMenu__point")
+        .forEach(el => {
+          el.innerHTML = (data.point || "-") + "<span>P</span>";
+        });
+    });
+  }
+</script>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock162458">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock145581">
+						<div class="headerMessage">
+    	<div class="headerMessage__text">1,800円以上の注文で<span class="headerMessage__textDecoration">送料無料</span></div>
+  </div>
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div><div id="areaWrapper1" class="pbAreaWrapper1"><div id="areaWrapper2" class="pbAreaWrapper2"><div id="mainArea" class="pbMainArea">
+	<div id="area0" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock259613">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock435867">
+						<div class="commonBnr">
+  <div class="commonBnr__inner">
+          <a href="https://shopping.bookoff.co.jp/campaign/19th"  class="commonBnr__link ">
+      <figure class="commonBnr__fig">
+                    <img src="https://content.bookoff.co.jp/assets/images/1200x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="2400" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forPc">
+                            <img src="https://content.bookoff.co.jp/assets/images/375x60/campaign/19th.webp" alt="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" width="750" height="120" title="オンラインストア19周年記念キャンペーン お得なクーポンプレゼント！8月1日(土)まで" class="forSp">
+              </figure>
+    </a>
+        </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10018">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock314591">
+						<div class="campaign campaign--for2col forPc">
+  <div class="campaign__inner">
+          <a class="campaign__items" href="https://shopping.bookoff.co.jp/campaign/20260710-sale">
+      <div class="campaign__item">
+                  <span class="campaign__item__tag infoicon-sale">セール</span>
+              </div>
+      <div class="campaign__item">
+        <span class="campaign__item__ttl"> CD&DVD・ブルーレイSALE 2026/07/23(木)23:59まで</span>
+              </div>
+    </a>
+                                                                                                                                                  </div>
+</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="mainContent pbNested pbNestedWrapper "  id="pbBlock10011">
+								<div class="pbNested " >
+			<div class="mainContent__inner pbNested pbNestedWrapper "  id="pbBlock10012">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock10027">
+						<div class="mainContent__search">
+  <div class="mainContent__col">
+    <div class="productSearch">
+      <h1 class="productSearch__ttl">
+        <span class="productSearch__ttlInner">検索結果<span class="productSearch__word">9784000000000</span></span>
+      </h1>
+      <div class="productSearch__inner">
+        <div class="productSearch__control">
+          <div class="productSearch__refinement">
+            <div class="productSearch__item productSearch__item--refinement forSp">
+              <a class="productInformation__list__link js-modal ac-click-cv" data-cv-name="filterOpen_Search" data-modal="modalSearchRefinement" data-mode="full">
+                <span class="icon-refinement icon-refinement-dims"></span>
+                <span>条件を追加</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="productSearch__null">
+        <p class="productSearch__null__lead">
+          ご指定いただいた検索条件に該当する商品が見つかりませんでした
+        </p>
+        <section class="productSearch__enclosure">
+          <h2 class="productSearch__enclosure__ttl">
+            <span class="icon-help-gray icon-help-gray-dims"></span>
+            <span>お探しの商品が見つかりませんか？</span>
+          </h2>
+          <h3 class="productSearch__enclosure__heading">
+            ｢在庫ありのみ｣をチェックして検索の場合
+          </h3>
+          <p class="productSearch__enclosure__txt">
+            検索ヒットした商品がすべて品切れの場合はこのページが表示されます｡在庫の有無に関わらず商品を表示する場合､｢在庫ありのみ｣のチェックマークを外して検索をしてください｡在庫がない商品は､入荷お知らせメールへの登録がおすすめです
+          </p>
+          <h3 class="productSearch__enclosure__heading">
+            キーワードに誤字がある場合
+          </h3>
+          <p class="productSearch__enclosure__txt">
+            漢字の変換ミスなどがあると表示されないことがあります｡できるだけ正確に入力しなおしてみてください
+          </p>
+          <h3 class="productSearch__enclosure__heading">
+            それでも見つからない場合
+          </h3>
+          <p class="productSearch__enclosure__txt">
+            <a href="https://regist11.smp.ne.jp/regist/is?SMPFORM=ofn-latbq-651b190782b21aa1eaa0162e484e578c" class="productSearch__enclosure__link">
+              ご意見フォーム
+            </a>
+            からご指摘いただけますようお願いいたします
+          </p>
+        </section>
+        <div class="linkButton">
+          <div class="linkButton__inner">
+            <span class="btn linkButton__item js-returnToPreviousPage">ひとつ前のページに戻る</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- /productSearch -->
+  </div>
+  <!--mainContent__col-->
+  <div class="mainContent__col forPc">
+    <section class="refinement js-refinement">
+        <h4 class="refinement__head">
+          <span class="refinement__ttl">絞り込み</span>
+        </h4>
+        <ul class="refinement__list">
+          <li class="refinement__item">
+            <label class="checkbox">
+                <input id='exist_used_check' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+              <span class="checkbox__item"><span class="checkbox__txt">中古のみ</span></span>
+            </label>
+          </li>
+          <li class="refinement__item">
+            <label class="checkbox">
+                <input id='exist_stock_check' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+              <span class="checkbox__item"><span class="checkbox__txt">在庫ありのみ</span></span>
+            </label>
+          </li>
+          <li class="refinement__item">
+            <label class="checkbox">
+                            <input id='exist_store_trans_check' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+                            <span class="checkbox__item"><span class="checkbox__txt">店舗受取可</span></span>
+            </label>
+          </li>
+        </ul>
+        <section>
+          <h5 class="refinement__heading">カテゴリ</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <a href="/search" class="refinement__link">                <span class="refinement__linkTxt">すべてのカテゴリ</span>
+                <span class="refinement__hit">(5,724,178)</span>
+              </a>
+            </li>
+              <li class="refinement__item">
+                <a href="/search/genre/12" class="refinement__link">
+                  <span class="refinement__linkTxt">書籍</span>
+                  <span class="refinement__hit">(2,871,429)</span>
+                </a>
+              </li>
+              <li class="refinement__item">
+                <a href="/search/genre/11" class="refinement__link">
+                  <span class="refinement__linkTxt">コミック</span>
+                  <span class="refinement__hit">(417,695)</span>
+                </a>
+              </li>
+              <li class="refinement__item">
+                <a href="/search/genre/13" class="refinement__link">
+                  <span class="refinement__linkTxt">雑誌</span>
+                  <span class="refinement__hit">(116,927)</span>
+                </a>
+              </li>
+              <li class="refinement__item">
+                <a href="/search/genre/31" class="refinement__link">
+                  <span class="refinement__linkTxt">CD</span>
+                  <span class="refinement__hit">(1,943,264)</span>
+                </a>
+              </li>
+              <li class="refinement__item">
+                <a href="/search/genre/71" class="refinement__link">
+                  <span class="refinement__linkTxt">DVD・ブルーレイ</span>
+                  <span class="refinement__hit">(329,691)</span>
+                </a>
+              </li>
+              <li class="refinement__item">
+                <a href="/search/genre/51" class="refinement__link">
+                  <span class="refinement__linkTxt">ゲーム</span>
+                  <span class="refinement__hit">(45,172)</span>
+                </a>
+              </li>
+            <li class="refinement__item">
+              <a href="/set/search/keyword/9784000000000" class="refinement__link categorySetLink">
+                <span class="refinement__linkTxt">セット</span>
+                <span class="modalSearchRefinement__hit"></span>
+              </a>
+            </li>
+          </ul>
+        </section>
+        <section class="refinement__form">
+          <h5 class="refinement__heading">キーワード</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <span class="refinement__keywordBox">
+                  <input id='search_keyword' type="text" class="refinement__text search_form" placeholder="〜を含む" name="or" value="9784000000000" />
+                </span>
+                <span class="refinement__keywordTxt">を含む</span>
+              </p>
+            </li>
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <span class="refinement__keywordBox">
+                  <input id='search_exclusion_keyword' type="text" class="refinement__text search_form" placeholder="〜を含まない" name="not" value="" />
+                </span>
+                <span class="refinement__keywordTxt">を除く</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">著者・作者</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <input id='search_author' type="text" class="refinement__text search_form" placeholder="入力してください" name="author" value="" />
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">販売会社/出版社（メーカー）</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__keyword">
+                <input id='search_publisher' type="text" class="refinement__text search_form" placeholder="入力してください" name="maker" value="" />
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">中古価格</h5>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__price">
+                <span class="refinement__priceBox">
+                  <input id='search_used_price_min' type="text" class="refinement__text search_form" placeholder="0" name="price1" value="" />
+                </span>
+                <span class="refinement__priceRange">〜</span>
+                <span class="refinement__priceBox">
+                  <input id='search_used_price_max' type="text" class="refinement__text search_form" placeholder="上限なし" name="price2" value="" />
+                </span>
+                <span class="refinement__priceYen">円</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5 class="refinement__heading">発売年月</h5>
+          <p class="refinement__note">セットは対象外となります</p>
+          <ul class="refinement__list">
+            <li class="refinement__item">
+              <p class="refinement__date">
+
+                <span class="refinement__dateYearBox">
+                  <span class="refinement__select">
+                    <select id='search_sys' name="year1" class="refinement__selectTag -empty year_select1 search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="2026">2026</option>
+                      <option value="2025">2025</option>
+                      <option value="2024">2024</option>
+                      <option value="2023">2023</option>
+                      <option value="2022">2022</option>
+                      <option value="2021">2021</option>
+                      <option value="2020">2020</option>
+                      <option value="2019">2019</option>
+                      <option value="2018">2018</option>
+                      <option value="2017">2017</option>
+                      <option value="2016">2016</option>
+                      <option value="2015">2015</option>
+                      <option value="2014">2014</option>
+                      <option value="2013">2013</option>
+                      <option value="2012">2012</option>
+                      <option value="2011">2011</option>
+                      <option value="2010">2010</option>
+                      <option value="2009">2009</option>
+                      <option value="2008">2008</option>
+                      <option value="2007">2007</option>
+                      <option value="2006">2006</option>
+                      <option value="2005">2005</option>
+                      <option value="2004">2004</option>
+                      <option value="2003">2003</option>
+                      <option value="2002">2002</option>
+                      <option value="2001">2001</option>
+                      <option value="2000">2000</option>
+                      <option value="1999">1999</option>
+                      <option value="1998">1998</option>
+                      <option value="1997">1997</option>
+                      <option value="1996">1996</option>
+                      <option value="1995">1995</option>
+                      <option value="1994">1994</option>
+                      <option value="1993">1993</option>
+                      <option value="1992">1992</option>
+                      <option value="1991">1991</option>
+                      <option value="1990">1990</option>
+                      <option value="1989">1989</option>
+                      <option value="1988">1988</option>
+                      <option value="1987">1987</option>
+                      <option value="1986">1986</option>
+                      <option value="1985">1985</option>
+                      <option value="1984">1984</option>
+                      <option value="1983">1983</option>
+                      <option value="1982">1982</option>
+                      <option value="1981">1981</option>
+                      <option value="1980">1980</option>
+                      <option value="1979">1979</option>
+                      <option value="1978">1978</option>
+                      <option value="1977">1977</option>
+                      <option value="1976">1976</option>
+                      <option value="1975">1975</option>
+                      <option value="1974">1974</option>
+                      <option value="1973">1973</option>
+                      <option value="1972">1972</option>
+                      <option value="1971">1971</option>
+                      <option value="1970">1970</option>
+                      <option value="1969">1969</option>
+                      <option value="1968">1968</option>
+                      <option value="1967">1967</option>
+                      <option value="1966">1966</option>
+                      <option value="1965">1965</option>
+                      <option value="1964">1964</option>
+                      <option value="1963">1963</option>
+                      <option value="1962">1962</option>
+                      <option value="1961">1961</option>
+                      <option value="1960">1960</option>
+                      <option value="1959">1959</option>
+                      <option value="1958">1958</option>
+                      <option value="1957">1957</option>
+                      <option value="1956">1956</option>
+                      <option value="1955">1955</option>
+                      <option value="1954">1954</option>
+                      <option value="1953">1953</option>
+                      <option value="1952">1952</option>
+                      <option value="1951">1951</option>
+                      <option value="1950">1950</option>
+                      <option value="1949">1949</option>
+                      <option value="1948">1948</option>
+                      <option value="1947">1947</option>
+                      <option value="1946">1946</option>
+                      <option value="1945">1945</option>
+                      <option value="1944">1944</option>
+                      <option value="1943">1943</option>
+                      <option value="1942">1942</option>
+                      <option value="1941">1941</option>
+                      <option value="1940">1940</option>
+                      <option value="1939">1939</option>
+                      <option value="1938">1938</option>
+                      <option value="1937">1937</option>
+                      <option value="1936">1936</option>
+                      <option value="1935">1935</option>
+                      <option value="1934">1934</option>
+                      <option value="1933">1933</option>
+                      <option value="1932">1932</option>
+                      <option value="1931">1931</option>
+                      <option value="1930">1930</option>
+                      <option value="1929">1929</option>
+                      <option value="1928">1928</option>
+                      <option value="1927">1927</option>
+                      <option value="1926">1926</option>
+                      <option value="1925">1925</option>
+                      <option value="1924">1924</option>
+                      <option value="1923">1923</option>
+                      <option value="1922">1922</option>
+                      <option value="1921">1921</option>
+                      <option value="1920">1920</option>
+                      <option value="1919">1919</option>
+                      <option value="1918">1918</option>
+                      <option value="1917">1917</option>
+                      <option value="1916">1916</option>
+                      <option value="1915">1915</option>
+                      <option value="1914">1914</option>
+                      <option value="1913">1913</option>
+                      <option value="1912">1912</option>
+                      <option value="1911">1911</option>
+                      <option value="1910">1910</option>
+                      <option value="1909">1909</option>
+                      <option value="1908">1908</option>
+                      <option value="1907">1907</option>
+                      <option value="1906">1906</option>
+                      <option value="1905">1905</option>
+                      <option value="1904">1904</option>
+                      <option value="1903">1903</option>
+                      <option value="1902">1902</option>
+                      <option value="1901">1901</option>
+                      <option value="1900">1900</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateYear">年</span>
+
+                <span class="refinement__dateMonthBox">
+                  <span class="refinement__select">
+                    <select id='search_sms' name="month1" class="refinement__selectTag -empty search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="01">01</option>
+                      <option value="02">02</option>
+                      <option value="03">03</option>
+                      <option value="04">04</option>
+                      <option value="05">05</option>
+                      <option value="06">06</option>
+                      <option value="07">07</option>
+                      <option value="08">08</option>
+                      <option value="09">09</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateMonth">月〜</span>
+              </p>
+            </li>
+
+            <li class="refinement__item">
+              <p class="refinement__date">
+                <span class="refinement__dateYearBox">
+                  <span class="refinement__select">
+                    <select id='search_sye' name="year2" class="refinement__selectTag -empty year_select2 search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="2026">2026</option>
+                      <option value="2025">2025</option>
+                      <option value="2024">2024</option>
+                      <option value="2023">2023</option>
+                      <option value="2022">2022</option>
+                      <option value="2021">2021</option>
+                      <option value="2020">2020</option>
+                      <option value="2019">2019</option>
+                      <option value="2018">2018</option>
+                      <option value="2017">2017</option>
+                      <option value="2016">2016</option>
+                      <option value="2015">2015</option>
+                      <option value="2014">2014</option>
+                      <option value="2013">2013</option>
+                      <option value="2012">2012</option>
+                      <option value="2011">2011</option>
+                      <option value="2010">2010</option>
+                      <option value="2009">2009</option>
+                      <option value="2008">2008</option>
+                      <option value="2007">2007</option>
+                      <option value="2006">2006</option>
+                      <option value="2005">2005</option>
+                      <option value="2004">2004</option>
+                      <option value="2003">2003</option>
+                      <option value="2002">2002</option>
+                      <option value="2001">2001</option>
+                      <option value="2000">2000</option>
+                      <option value="1999">1999</option>
+                      <option value="1998">1998</option>
+                      <option value="1997">1997</option>
+                      <option value="1996">1996</option>
+                      <option value="1995">1995</option>
+                      <option value="1994">1994</option>
+                      <option value="1993">1993</option>
+                      <option value="1992">1992</option>
+                      <option value="1991">1991</option>
+                      <option value="1990">1990</option>
+                      <option value="1989">1989</option>
+                      <option value="1988">1988</option>
+                      <option value="1987">1987</option>
+                      <option value="1986">1986</option>
+                      <option value="1985">1985</option>
+                      <option value="1984">1984</option>
+                      <option value="1983">1983</option>
+                      <option value="1982">1982</option>
+                      <option value="1981">1981</option>
+                      <option value="1980">1980</option>
+                      <option value="1979">1979</option>
+                      <option value="1978">1978</option>
+                      <option value="1977">1977</option>
+                      <option value="1976">1976</option>
+                      <option value="1975">1975</option>
+                      <option value="1974">1974</option>
+                      <option value="1973">1973</option>
+                      <option value="1972">1972</option>
+                      <option value="1971">1971</option>
+                      <option value="1970">1970</option>
+                      <option value="1969">1969</option>
+                      <option value="1968">1968</option>
+                      <option value="1967">1967</option>
+                      <option value="1966">1966</option>
+                      <option value="1965">1965</option>
+                      <option value="1964">1964</option>
+                      <option value="1963">1963</option>
+                      <option value="1962">1962</option>
+                      <option value="1961">1961</option>
+                      <option value="1960">1960</option>
+                      <option value="1959">1959</option>
+                      <option value="1958">1958</option>
+                      <option value="1957">1957</option>
+                      <option value="1956">1956</option>
+                      <option value="1955">1955</option>
+                      <option value="1954">1954</option>
+                      <option value="1953">1953</option>
+                      <option value="1952">1952</option>
+                      <option value="1951">1951</option>
+                      <option value="1950">1950</option>
+                      <option value="1949">1949</option>
+                      <option value="1948">1948</option>
+                      <option value="1947">1947</option>
+                      <option value="1946">1946</option>
+                      <option value="1945">1945</option>
+                      <option value="1944">1944</option>
+                      <option value="1943">1943</option>
+                      <option value="1942">1942</option>
+                      <option value="1941">1941</option>
+                      <option value="1940">1940</option>
+                      <option value="1939">1939</option>
+                      <option value="1938">1938</option>
+                      <option value="1937">1937</option>
+                      <option value="1936">1936</option>
+                      <option value="1935">1935</option>
+                      <option value="1934">1934</option>
+                      <option value="1933">1933</option>
+                      <option value="1932">1932</option>
+                      <option value="1931">1931</option>
+                      <option value="1930">1930</option>
+                      <option value="1929">1929</option>
+                      <option value="1928">1928</option>
+                      <option value="1927">1927</option>
+                      <option value="1926">1926</option>
+                      <option value="1925">1925</option>
+                      <option value="1924">1924</option>
+                      <option value="1923">1923</option>
+                      <option value="1922">1922</option>
+                      <option value="1921">1921</option>
+                      <option value="1920">1920</option>
+                      <option value="1919">1919</option>
+                      <option value="1918">1918</option>
+                      <option value="1917">1917</option>
+                      <option value="1916">1916</option>
+                      <option value="1915">1915</option>
+                      <option value="1914">1914</option>
+                      <option value="1913">1913</option>
+                      <option value="1912">1912</option>
+                      <option value="1911">1911</option>
+                      <option value="1910">1910</option>
+                      <option value="1909">1909</option>
+                      <option value="1908">1908</option>
+                      <option value="1907">1907</option>
+                      <option value="1906">1906</option>
+                      <option value="1905">1905</option>
+                      <option value="1904">1904</option>
+                      <option value="1903">1903</option>
+                      <option value="1902">1902</option>
+                      <option value="1901">1901</option>
+                      <option value="1900">1900</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateYear">年</span>
+
+                <span class="refinement__dateMonthBox">
+                  <span class="refinement__select">
+                    <select id='search_sme' name="month2" class="refinement__selectTag -empty search_form">
+                      <option value="" selected="selected">ー</option>
+                      <option value="01">01</option>
+                      <option value="02">02</option>
+                      <option value="03">03</option>
+                      <option value="04">04</option>
+                      <option value="05">05</option>
+                      <option value="06">06</option>
+                      <option value="07">07</option>
+                      <option value="08">08</option>
+                      <option value="09">09</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                    </select>
+                  </span>
+                </span>
+                <span class="refinement__dateMonth">月まで</span>
+              </p>
+            </li>
+          </ul>
+        </section>
+        <a href="" id="search_btn" class="btn btn--blue ac-click-cv" data-cv-name="sortOn_Search">検索する</a>
+        <a href="" id='search_reset_btn' class="link link--center js-refinementReset">条件をリセット</a>
+    </section>
+    <!-- /.refinement -->
+  </div>
+  <!--mainContent__col forPc-->
+</div>
+<!-- /mainContent__search -->
+<input type="hidden" class="js-modal" data-modal="modalCartAddStock0">
+
+<div id="modal" class="modal">
+    <div class="modal__overlay"></div>
+    <div id="modalSearchRefinement" class="modal__inner js-modalInner forSp" tabindex="0">
+      <div class="modalContent">
+        <!-- /modalRefinementWrap -->
+        <div class="modalRefinementWrap js-modalRefinementWrap" data-level="0" data-id="0">
+          <p class="modal__title">しぼりこみ</p>
+          <div class="modalSearchRefinement js-modalInnerContent js-modalRefinementInnerContent" style="height: 744px;">
+            <div class="modalSearchRefinement__inner">
+              <div class="modalSearchRefinement__content">
+                <ul class="modalSearchRefinement__list modalSearchRefinement__list--checkbox">
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                        <input id='exist_used_check_modal' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+                      <span class="checkbox__item"><span class="checkbox__txt">中古のみ</span></span>
+                    </label>
+                  </li>
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                        <input id='exist_stock_check_modal' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+                    <span class="checkbox__item"><span class="checkbox__txt">在庫ありのみ</span></span>
+                    </label>
+                  </li>
+                  <li class="modalSearchRefinement__item">
+                    <label class="checkbox">
+                          <input id='exist_store_trans_check_modal' type="checkbox" class="js-cartSetItemCheckbox" value="" disabled="disabled"/>
+                      <span class="checkbox__item"><span class="checkbox__txt">店舗受取可</span></span>
+                    </label>
+                  </li>
+                </ul>
+                <p class="modalSearchRefinement__heading">カテゴリ</p>
+                <ul class="modalSearchRefinement__list">
+                  <li class="modalSearchRefinement__item">
+                    <a href="" class="modalSearchRefinement__category js-modalRefinementSp" data-level="1" data-id="0" data-direction="bottom">
+                        すべてのカテゴリ
+                    </a>
+                  </li>
+                </ul>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_keyword_modal">キーワード</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <span class="modalSearchRefinement__keywordBox">
+                          <input id='search_keyword_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="〜を含む" name="or"
+                          value="9784000000000">
+                        </span>
+                        <span class="modalSearchRefinement__keywordTxt">を含む</span>
+                      </p>
+                    </li>
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <span class="modalSearchRefinement__keywordBox">
+                          <input id='search_exclusion_keyword_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="〜を含まない" name="not" value="">
+                        </span>
+                        <span class="modalSearchRefinement__keywordTxt">を除く</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_author_modal">著者・作者</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <input id='search_author_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="入力してください" name="author" value="">
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_publisher_modal">販売会社/出版社（メーカー）</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__keyword">
+                        <input id='search_publisher_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="入力してください" name="maker" value="">
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_used_price_min_modal">中古価格</label>
+                  <ul class="modalSearchRefinement__list">
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__price">
+                        <span class="modalSearchRefinement__priceBox">
+                          <input id='search_used_price_min_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="0" name="price1" value="">
+                        </span>
+                        <span class="modalSearchRefinement__priceRange">〜</span>
+                        <span class="modalSearchRefinement__priceBox">
+                          <input id='search_used_price_max_modal' type="text" class="modalSearchRefinement__text search_form" placeholder="上限なし" name="price2" value="">
+                        </span>
+                        <span class="modalSearchRefinement__priceYen">円</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <div class="modalSearchRefinement__searchBox">
+                  <label class="modalSearchRefinement__heading" for="search_sys_modal">発売</label>
+                  <ul class="modalSearchRefinement__list">
+
+                      <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__date">
+
+                        <span class="modalSearchRefinement__dateYearBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sys_modal' name="year1" class="modalSearchRefinement__selectTag -empty year_select1 search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="2026">2026</option>
+                                <option value="2025">2025</option>
+                                <option value="2024">2024</option>
+                                <option value="2023">2023</option>
+                                <option value="2022">2022</option>
+                                <option value="2021">2021</option>
+                                <option value="2020">2020</option>
+                                <option value="2019">2019</option>
+                                <option value="2018">2018</option>
+                                <option value="2017">2017</option>
+                                <option value="2016">2016</option>
+                                <option value="2015">2015</option>
+                                <option value="2014">2014</option>
+                                <option value="2013">2013</option>
+                                <option value="2012">2012</option>
+                                <option value="2011">2011</option>
+                                <option value="2010">2010</option>
+                                <option value="2009">2009</option>
+                                <option value="2008">2008</option>
+                                <option value="2007">2007</option>
+                                <option value="2006">2006</option>
+                                <option value="2005">2005</option>
+                                <option value="2004">2004</option>
+                                <option value="2003">2003</option>
+                                <option value="2002">2002</option>
+                                <option value="2001">2001</option>
+                                <option value="2000">2000</option>
+                                <option value="1999">1999</option>
+                                <option value="1998">1998</option>
+                                <option value="1997">1997</option>
+                                <option value="1996">1996</option>
+                                <option value="1995">1995</option>
+                                <option value="1994">1994</option>
+                                <option value="1993">1993</option>
+                                <option value="1992">1992</option>
+                                <option value="1991">1991</option>
+                                <option value="1990">1990</option>
+                                <option value="1989">1989</option>
+                                <option value="1988">1988</option>
+                                <option value="1987">1987</option>
+                                <option value="1986">1986</option>
+                                <option value="1985">1985</option>
+                                <option value="1984">1984</option>
+                                <option value="1983">1983</option>
+                                <option value="1982">1982</option>
+                                <option value="1981">1981</option>
+                                <option value="1980">1980</option>
+                                <option value="1979">1979</option>
+                                <option value="1978">1978</option>
+                                <option value="1977">1977</option>
+                                <option value="1976">1976</option>
+                                <option value="1975">1975</option>
+                                <option value="1974">1974</option>
+                                <option value="1973">1973</option>
+                                <option value="1972">1972</option>
+                                <option value="1971">1971</option>
+                                <option value="1970">1970</option>
+                                <option value="1969">1969</option>
+                                <option value="1968">1968</option>
+                                <option value="1967">1967</option>
+                                <option value="1966">1966</option>
+                                <option value="1965">1965</option>
+                                <option value="1964">1964</option>
+                                <option value="1963">1963</option>
+                                <option value="1962">1962</option>
+                                <option value="1961">1961</option>
+                                <option value="1960">1960</option>
+                                <option value="1959">1959</option>
+                                <option value="1958">1958</option>
+                                <option value="1957">1957</option>
+                                <option value="1956">1956</option>
+                                <option value="1955">1955</option>
+                                <option value="1954">1954</option>
+                                <option value="1953">1953</option>
+                                <option value="1952">1952</option>
+                                <option value="1951">1951</option>
+                                <option value="1950">1950</option>
+                                <option value="1949">1949</option>
+                                <option value="1948">1948</option>
+                                <option value="1947">1947</option>
+                                <option value="1946">1946</option>
+                                <option value="1945">1945</option>
+                                <option value="1944">1944</option>
+                                <option value="1943">1943</option>
+                                <option value="1942">1942</option>
+                                <option value="1941">1941</option>
+                                <option value="1940">1940</option>
+                                <option value="1939">1939</option>
+                                <option value="1938">1938</option>
+                                <option value="1937">1937</option>
+                                <option value="1936">1936</option>
+                                <option value="1935">1935</option>
+                                <option value="1934">1934</option>
+                                <option value="1933">1933</option>
+                                <option value="1932">1932</option>
+                                <option value="1931">1931</option>
+                                <option value="1930">1930</option>
+                                <option value="1929">1929</option>
+                                <option value="1928">1928</option>
+                                <option value="1927">1927</option>
+                                <option value="1926">1926</option>
+                                <option value="1925">1925</option>
+                                <option value="1924">1924</option>
+                                <option value="1923">1923</option>
+                                <option value="1922">1922</option>
+                                <option value="1921">1921</option>
+                                <option value="1920">1920</option>
+                                <option value="1919">1919</option>
+                                <option value="1918">1918</option>
+                                <option value="1917">1917</option>
+                                <option value="1916">1916</option>
+                                <option value="1915">1915</option>
+                                <option value="1914">1914</option>
+                                <option value="1913">1913</option>
+                                <option value="1912">1912</option>
+                                <option value="1911">1911</option>
+                                <option value="1910">1910</option>
+                                <option value="1909">1909</option>
+                                <option value="1908">1908</option>
+                                <option value="1907">1907</option>
+                                <option value="1906">1906</option>
+                                <option value="1905">1905</option>
+                                <option value="1904">1904</option>
+                                <option value="1903">1903</option>
+                                <option value="1902">1902</option>
+                                <option value="1901">1901</option>
+                                <option value="1900">1900</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateYear">年</span>
+
+                        <span class="modalSearchRefinement__dateMonthBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sms_modal' name="month1" class="modalSearchRefinement__selectTag -empty search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="01">01</option>
+                                <option value="02">02</option>
+                                <option value="03">03</option>
+                                <option value="04">04</option>
+                                <option value="05">05</option>
+                                <option value="06">06</option>
+                                <option value="07">07</option>
+                                <option value="08">08</option>
+                                <option value="09">09</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateMonth">月〜</span>
+                      </p>
+                    </li>
+
+                    <li class="modalSearchRefinement__item">
+                      <p class="modalSearchRefinement__date">
+
+                        <span class="modalSearchRefinement__dateYearBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sye_modal' name="year2" class="modalSearchRefinement__selectTag -empty year_select2 search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="2026">2026</option>
+                                <option value="2025">2025</option>
+                                <option value="2024">2024</option>
+                                <option value="2023">2023</option>
+                                <option value="2022">2022</option>
+                                <option value="2021">2021</option>
+                                <option value="2020">2020</option>
+                                <option value="2019">2019</option>
+                                <option value="2018">2018</option>
+                                <option value="2017">2017</option>
+                                <option value="2016">2016</option>
+                                <option value="2015">2015</option>
+                                <option value="2014">2014</option>
+                                <option value="2013">2013</option>
+                                <option value="2012">2012</option>
+                                <option value="2011">2011</option>
+                                <option value="2010">2010</option>
+                                <option value="2009">2009</option>
+                                <option value="2008">2008</option>
+                                <option value="2007">2007</option>
+                                <option value="2006">2006</option>
+                                <option value="2005">2005</option>
+                                <option value="2004">2004</option>
+                                <option value="2003">2003</option>
+                                <option value="2002">2002</option>
+                                <option value="2001">2001</option>
+                                <option value="2000">2000</option>
+                                <option value="1999">1999</option>
+                                <option value="1998">1998</option>
+                                <option value="1997">1997</option>
+                                <option value="1996">1996</option>
+                                <option value="1995">1995</option>
+                                <option value="1994">1994</option>
+                                <option value="1993">1993</option>
+                                <option value="1992">1992</option>
+                                <option value="1991">1991</option>
+                                <option value="1990">1990</option>
+                                <option value="1989">1989</option>
+                                <option value="1988">1988</option>
+                                <option value="1987">1987</option>
+                                <option value="1986">1986</option>
+                                <option value="1985">1985</option>
+                                <option value="1984">1984</option>
+                                <option value="1983">1983</option>
+                                <option value="1982">1982</option>
+                                <option value="1981">1981</option>
+                                <option value="1980">1980</option>
+                                <option value="1979">1979</option>
+                                <option value="1978">1978</option>
+                                <option value="1977">1977</option>
+                                <option value="1976">1976</option>
+                                <option value="1975">1975</option>
+                                <option value="1974">1974</option>
+                                <option value="1973">1973</option>
+                                <option value="1972">1972</option>
+                                <option value="1971">1971</option>
+                                <option value="1970">1970</option>
+                                <option value="1969">1969</option>
+                                <option value="1968">1968</option>
+                                <option value="1967">1967</option>
+                                <option value="1966">1966</option>
+                                <option value="1965">1965</option>
+                                <option value="1964">1964</option>
+                                <option value="1963">1963</option>
+                                <option value="1962">1962</option>
+                                <option value="1961">1961</option>
+                                <option value="1960">1960</option>
+                                <option value="1959">1959</option>
+                                <option value="1958">1958</option>
+                                <option value="1957">1957</option>
+                                <option value="1956">1956</option>
+                                <option value="1955">1955</option>
+                                <option value="1954">1954</option>
+                                <option value="1953">1953</option>
+                                <option value="1952">1952</option>
+                                <option value="1951">1951</option>
+                                <option value="1950">1950</option>
+                                <option value="1949">1949</option>
+                                <option value="1948">1948</option>
+                                <option value="1947">1947</option>
+                                <option value="1946">1946</option>
+                                <option value="1945">1945</option>
+                                <option value="1944">1944</option>
+                                <option value="1943">1943</option>
+                                <option value="1942">1942</option>
+                                <option value="1941">1941</option>
+                                <option value="1940">1940</option>
+                                <option value="1939">1939</option>
+                                <option value="1938">1938</option>
+                                <option value="1937">1937</option>
+                                <option value="1936">1936</option>
+                                <option value="1935">1935</option>
+                                <option value="1934">1934</option>
+                                <option value="1933">1933</option>
+                                <option value="1932">1932</option>
+                                <option value="1931">1931</option>
+                                <option value="1930">1930</option>
+                                <option value="1929">1929</option>
+                                <option value="1928">1928</option>
+                                <option value="1927">1927</option>
+                                <option value="1926">1926</option>
+                                <option value="1925">1925</option>
+                                <option value="1924">1924</option>
+                                <option value="1923">1923</option>
+                                <option value="1922">1922</option>
+                                <option value="1921">1921</option>
+                                <option value="1920">1920</option>
+                                <option value="1919">1919</option>
+                                <option value="1918">1918</option>
+                                <option value="1917">1917</option>
+                                <option value="1916">1916</option>
+                                <option value="1915">1915</option>
+                                <option value="1914">1914</option>
+                                <option value="1913">1913</option>
+                                <option value="1912">1912</option>
+                                <option value="1911">1911</option>
+                                <option value="1910">1910</option>
+                                <option value="1909">1909</option>
+                                <option value="1908">1908</option>
+                                <option value="1907">1907</option>
+                                <option value="1906">1906</option>
+                                <option value="1905">1905</option>
+                                <option value="1904">1904</option>
+                                <option value="1903">1903</option>
+                                <option value="1902">1902</option>
+                                <option value="1901">1901</option>
+                                <option value="1900">1900</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateYear">年</span>
+
+                        <span class="modalSearchRefinement__dateMonthBox">
+                          <span class="modalSearchRefinement__select">
+                            <select id='search_sme_modal' name="month2" class="modalSearchRefinement__selectTag -empty search_form">
+                              <option value="" selected="selected">ー</option>
+                                <option value="01">01</option>
+                                <option value="02">02</option>
+                                <option value="03">03</option>
+                                <option value="04">04</option>
+                                <option value="05">05</option>
+                                <option value="06">06</option>
+                                <option value="07">07</option>
+                                <option value="08">08</option>
+                                <option value="09">09</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                              </select>
+                          </span>
+                        </span>
+                        <span class="modalSearchRefinement__dateMonth">月まで</span>
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+                <p class="modalSearchRefinement__note">セットは対象外となります</p>
+                <a id='search_btn_modal' class="btn btn--blue ac-click-cv" data-cv-name="sortOn_Search">検索する</a>
+                <a id='search_reset_btn_modal' class="link link--center js-modalRefinementReset">条件をリセット</a>
+              </div><!-- /.modalSearchRefinement__content -->
+            </div>
+          </div>
+        </div>
+        <!-- /modalRefinementWrap -->
+
+        <div class="modalRefinementWrap js-modalRefinementWrap -hide" data-level="1" data-id="0">
+          <p class="modal__title">
+            <span>カテゴリ</span>
+          </p>
+          <div class="modalSearchRefinement js-modalRefinementInnerContent">
+            <div class="modalSearchRefinement__inner">
+              <div class="modalSearchRefinement__content">
+                <ul class="modalSearchRefinement__categoryList">
+                  <li class="modalSearchRefinement__categoryItem">
+                    <a href="/search" class="modalSearchRefinement__categoryLink">                      <span>すべてのカテゴリ</span>
+                      <span class="modalSearchRefinement__hit">(5,724,178)</span>
+                    </a>
+                  </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/12" class="modalSearchRefinement__categoryLink">
+                        <span>書籍</span>
+                        <span class="refinement__hit">(2,871,429)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/11" class="modalSearchRefinement__categoryLink">
+                        <span>コミック</span>
+                        <span class="refinement__hit">(417,695)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/13" class="modalSearchRefinement__categoryLink">
+                        <span>雑誌</span>
+                        <span class="refinement__hit">(116,927)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/31" class="modalSearchRefinement__categoryLink">
+                        <span>CD</span>
+                        <span class="refinement__hit">(1,943,264)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/71" class="modalSearchRefinement__categoryLink">
+                        <span>DVD・ブルーレイ</span>
+                        <span class="refinement__hit">(329,691)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/search/genre/51" class="modalSearchRefinement__categoryLink">
+                        <span>ゲーム</span>
+                        <span class="refinement__hit">(45,172)</span>
+                      </a>
+                    </li>
+                    <li class="modalSearchRefinement__categoryItem">
+                      <a href="/set/search/keyword/9784000000000" class="modalSearchRefinement__categoryLink categorySetLink">
+                        <span>セット</span>
+                      </a>
+                    </li>
+                </ul>
+              </div><!-- /.modalSearchRefinement__content -->
+            </div>
+          </div>
+          <div class="modal__closeRefineSp js-modalRefinementSp" data-level="0" data-id="0" data-direction="top">
+            <img src="/library/common/svg/close.svg" alt="close" title="close">
+          </div>
+        </div>
+        <!-- /modalRefinementWrap -->
+
+        <div class="modal__close js-modalClose" tabindex="0">
+          <img src="/library/common/svg/close.svg" alt="close" title="close">
+        </div>
+      </div>
+      <!-- /modalContent -->
+      <div class="modal__closeSp js-modalCloseSp">
+        <span></span>
+      </div>
+    </div>
+    <!-- /modal__inner -->
+
+  <div id="modalCartAddStock0" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="modalContent__inner">
+        <div class="modal__headingBlock">
+          <p class="modal__title">カートに追加できませんでした</p>
+        </div>
+        <div class="modalItems">
+          <p class="modalItems__note">
+            <span class="icon-info icon-info-dims"></span>
+            <span class="js-cart-alert"></span>
+          </p>
+        </div>
+      </div>
+      <ul class="modal__confirm modal__confirm--box-shadow-none">
+        <li class="modal__confirmBtn">
+          <a href="" class="modal__no js-modalClose" tabindex="0">キャンセル</a>
+        </li>
+        <li class="modal__confirmBtn">
+          <a href="" class="modal__yes js-refreshPage">OK</a>
+        </li>
+      </ul>
+      <div class="modal__close js-modalClose" tabindex="0">
+        <img src="/library/common/svg/close.svg" alt="close">
+      </div>
+    </div>
+    <div class="modal__closeSp js-modalCloseSp">
+      <span></span>
+    </div>
+  </div>
+
+  <div id="modalAgeVerification" class="modal__inner js-modalInner" tabindex="0">
+    <div class="modalContent">
+      <div class="pageTitle">年齢確認</div>
+      <div class="ageVerificationBlock js-modalInnerContent">
+        <div class="ageVerificationBlock__inner">
+          <div class="ageVerificationBlock__txt--error ageVerificationBlock__txt--bold modalConfirm__error" style="display:none;">エラーにより年齢認証が完了出来ませんでした。</div>
+          <div class="ageVerificationBlock__txt">これより先は18歳未満の方には不適切な表現内容が含まれる商品を取り扱う画面です</div>
+          <div class="ageVerificationBlock__txt">18歳未満の方のアクセスは、固くお断りいたします</div>
+          <div class="ageVerificationBlock__txt--check ageVerificationBlock__txt--bold">あなたは18歳以上ですか？</div>
+          <div class="ageVerification__btns">
+            <div id="ageVerification__btns--agree" class="btn js-agree-submit" data-agelimit="1">はい</div>
+            <div class="btn js-cancel-submit js-modalClose">いいえ</div>
+          </div>
+        </div><!-- /ageVerificationBlock__inner -->
+      </div><!-- /ageVerificationBlock -->
+      <div class="modal__close js-modalClose" tabindex="1"><img src="https://content.bookoff.co.jp/common/images/close.svg" width="24" height="24" alt="close"></div>
+    </div><!--modalContent-->
+    <div class="modal__closeSp js-modalCloseSp"><span></span></div>
+  </div><!-- modalAgeVerification -->
+</div>
+<!-- /modal -->
+
+<script>
+var arrQuery = [];
+var paramName = '';
+var paramValue = '';
+var genreCode = '';
+
+  // 絞り込み（「中古のみ」「在庫ありのみ」）
+$('#exist_stock_check, #exist_used_check, #exist_store_trans_check').on('change', function () {
+	$('.js-cartSetItemCheckbox').prop('disabled', true);
+	let url = '/search/keyword/9784000000000';
+	let destUrl = '';
+	let pattern = '';
+	let replacement = '';
+
+	if($('#exist_used_check').prop('checked')) {
+		if($('#exist_stock_check').prop('checked')) {
+			replacement = '/stock/u';
+		} else {
+			replacement = '/stock/used';
+		}
+	} else {
+		if($('#exist_stock_check').prop('checked')) {
+			replacement = '/stock/z';
+		} else {
+			replacement = '';
+		}
+	}
+	if($('#exist_store_trans_check').prop('checked')) {
+		replacement += '/store-receive/y';
+	}
+	if('a' == 'a' && 'all' == 'all') {
+		pattern = '/search';
+		replacement = '/search' + replacement;
+		destUrl = url.replace(pattern, replacement);
+	} else if('a' != 'a' && 'all' == 'all') {
+		pattern = '/stock/a';
+		destUrl = url.replace(pattern, replacement);
+	} else if('a' == 'a' && 'all' != 'all') {
+		pattern = '/store-receive/all';
+		destUrl = url.replace(pattern, replacement);
+	} else {
+		pattern = '/stock/a/store-receive/all';
+		destUrl = url.replace(pattern, replacement);
+	}
+	window.location.href = destUrl;
+});
+
+let isSubmitting = false;
+// 検索
+$('#search_btn').on('click', function(e) {
+	if (isSubmitting) {
+		e.preventDefault();
+	} else {
+		isSubmitting = true;
+		e.preventDefault();
+		let url = '/search';
+		if($('#exist_used_check').prop('checked')) {
+			if($('#exist_stock_check').prop('checked')) {
+				url += '/stock/u';
+			} else {
+				url += '/stock/used';
+			}
+		} else {
+			if($('#exist_stock_check').prop('checked')) {
+				url += '/stock/z';
+			}
+		}
+		if($('#exist_store_trans_check').prop('checked')) {
+			url += '/store-receive/y';
+		}
+		if (genreCode) {
+			url += '/genre/' + genreCode;
+		}
+		if ($('#search_keyword').val()) {
+			let keyword = $('#search_keyword').val();
+			keyword = encodeMark(keyword);
+			url += '/keyword/' + keyword;
+		}
+		if ($('#search_exclusion_keyword').val()) {
+			let exclusion_keyword = $('#search_exclusion_keyword').val();
+			exclusion_keyword = encodeMark(exclusion_keyword);
+			url += '/not/' + exclusion_keyword;
+		}
+		if ($('#search_author').val()) {
+			let author = $('#search_author').val();
+			author = encodeMark(author);
+			url += '/author/' + author;
+		}
+		if ($('#search_publisher').val()) {
+			let publisher = $('#search_publisher').val();
+			publisher = encodeMark(publisher);
+			url += '/publisher/' + publisher;
+		}
+		if ($('#search_hashtag').text()) {
+			let hashtag = $('#search_hashtag').text();
+			hashtag = encodeMark(hashtag);
+			url += '/hashtag/' + hashtag;
+		}
+
+		// query_string 生成
+		arrQuery.splice(0);
+		if ($('#search_used_price_min').val() || $('#search_used_price_max').val()) {
+			paramName = 'price';
+			paramValue = $('#search_used_price_min').val() + '-' + $('#search_used_price_max').val();
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		// 発売年月 未入力補完
+		var searchYearStart = $('#search_sys').val();
+		var searchMonthStart = $('#search_sms').val();
+		var searchYearEnd = $('#search_sye').val();
+		var searchMonthEnd = $('#search_sme').val();
+		var searchStart = null;
+		var searchEnd = null;
+		if (searchYearStart && searchMonthStart) {
+			// 開始年：入力　開始月：入力　の場合は、searchStartをセット
+			searchStart = searchYearStart + searchMonthStart;
+		} else if (!searchYearStart && !searchMonthStart) {
+			// 開始年：未入力　開始月：未入力　の場合は、searchStart = null をセット
+			searchStart = null;
+		} else if (searchYearStart && !searchMonthStart) {
+			// 開始年：入力　開始月：未入力　の場合は、searchMonthStart = '01' をセット
+			searchStart = searchYearStart + '01';
+		} else {
+			// 開始年：未入力　開始月：入力　の場合は、searchYearEnd により分岐
+			if(searchYearEnd) {
+				// searchYearEnd：入力　の場合は、searchYearStart = searchYearEnd
+				searchStart = searchYearEnd + searchMonthStart;
+			} else {
+				// searchYearEnd：未入力　の場合は、searchYearStart = now
+				searchYearStart = new Date().getFullYear().toString();
+				searchStart = searchYearStart + searchMonthStart;
+			}
+		}
+		if (searchYearEnd && searchMonthEnd) {
+			// 終了年：入力　終了月：入力　の場合は、searchEndをセット
+			searchEnd = searchYearEnd + searchMonthEnd;
+		} else if (!searchYearEnd && !searchMonthEnd) {
+			// 終了年：未入力　終了月：未入力　の場合は、searchEnd = null をセット
+			searchEnd = null;
+		} else if (searchYearEnd && !searchMonthEnd) {
+			// 終了年：入力　終了月：未入力　の場合は、searchMonthEnd = '12' をセット
+			searchEnd = searchYearEnd + '12';
+		} else {
+			// 終了年：未入力　終了月：入力　の場合は、searchYearStart により分岐
+			if(searchYearStart) {
+				// searchYearEnd：入力　の場合は、searchYearEnd = searchYearEnd
+				searchEnd = searchYearStart + searchMonthEnd;
+			} else {
+				// searchYearStart：未入力　の場合は、searchYearEnd = now
+				searchYearEnd = new Date().getFullYear().toString();
+				searchEnd = searchYearEnd + searchMonthEnd;
+			}
+		}
+		if (searchStart) {
+			paramName = 'date-min';
+			paramValue = searchStart;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (searchEnd) {
+			paramName = 'date-max';
+			paramValue = searchEnd;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if(url.endsWith(".0")) {
+			url += '/';
+		}
+		// query_string生成
+		url += makeQueryString(arrQuery);
+		window.location.href = url;
+	}
+});
+
+// 検索（モーダル）
+$('#search_btn_modal').on('click', function(e) {
+	if (isSubmitting) {
+		e.preventDefault();
+	} else {
+		isSubmitting = true;
+		e.preventDefault();
+		let url = '/search';
+		if($('#exist_used_check_modal').prop('checked')) {
+			if($('#exist_stock_check_modal').prop('checked')) {
+				url += '/stock/u';
+			} else {
+				url += '/stock/used';
+			}
+		} else {
+			if($('#exist_stock_check_modal').prop('checked')) {
+				url += '/stock/z';
+			}
+		}
+		if($('#exist_store_trans_check_modal').prop('checked')) {
+			url += '/store-receive/y';
+		}
+		if (genreCode) {
+			url += '/genre/' + genreCode;
+		}
+		if ($('#search_keyword_modal').val()) {
+			let keyword = $('#search_keyword_modal').val();
+			keyword = encodeMark(keyword);
+			url += '/keyword/' + keyword;
+		}
+		if ($('#search_exclusion_keyword_modal').val()) {
+			let exclusion_keyword = $('#search_exclusion_keyword_modal').val();
+			exclusion_keyword = encodeMark(exclusion_keyword);
+			url += '/not/' + exclusion_keyword;
+		}
+		if ($('#search_author_modal').val()) {
+			let author = $('#search_author_modal').val();
+			author = encodeMark(author);
+			url += '/author/' + author;
+		}
+		if ($('#search_publisher_modal').val()) {
+			let publisher = $('#search_publisher_modal').val();
+			publisher = encodeMark(publisher);
+			url += '/publisher/' + publisher;
+		}
+		if ($('#search_hashtag_modal').text()) {
+			let hashtag = $('#search_hashtag_modal').text();
+			hashtag = encodeMark(hashtag);
+			url += '/hashtag/' + hashtag;
+		}
+
+		// query_string 生成
+		arrQuery.splice(0);
+		if ($('#search_used_price_min_modal').val() || $('#search_used_price_max_modal').val()) {
+			paramName = 'price';
+			paramValue = $('#search_used_price_min_modal').val() + '-' + $('#search_used_price_max_modal').val();
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+			// 発売年月 未入力補完
+		var searchYearStartModal = $('#search_sys_modal').val();
+		var searchMonthStartModal = $('#search_sms_modal').val();
+		var searchYearEndModal = $('#search_sye_modal').val();
+		var searchMonthEndModal = $('#search_sme_modal').val();
+		var searchStartModal = null;
+		var searchEndModal = null;
+		if (searchYearStartModal && searchMonthStartModal) {
+			// 開始年：入力　開始月：入力　の場合は、searchStartModalをセット
+			searchStartModal = searchYearStartModal + searchMonthStartModal;
+		} else if (!searchYearStartModal && !searchMonthStartModal) {
+			// 開始年：未入力　開始月：未入力　の場合は、searchStartModal = null をセット
+			searchStartModal = null;
+		} else if (searchYearStartModal && !searchMonthStartModal) {
+			// 開始年：入力　開始月：未入力　の場合は、searchMonthStartModal = '01' をセット
+			searchStartModal = searchYearStartModal + '01';
+		} else {
+			// 開始年：未入力　開始月：入力　の場合は、searchYearEndModal により分岐
+			if(searchYearEndModal) {
+				// searchYearEndModal：入力　の場合は、searchYearStartModal = searchYearEndModal
+				searchStartModal = searchYearEndModal + searchMonthStartModal;
+			} else {
+				// searchYearEndModal：未入力　の場合は、searchYearStartModal = now
+				searchYearStartModal = new Date().getFullYear().toString();
+				searchStartModal = searchYearStartModal + searchMonthStartModal;
+			}
+		}
+		if (searchYearEndModal && searchMonthEndModal) {
+			// 終了年：入力　終了月：入力　の場合は、searchEndModalをセット
+			searchEndModal = searchYearEndModal + searchMonthEndModal;
+		} else if (!searchYearEndModal && !searchMonthEndModal) {
+			// 終了年：未入力　終了月：未入力　の場合は、searchEndModal = null をセット
+			searchEndModal = null;
+		} else if (searchYearEndModal && !searchMonthEndModal) {
+			// 終了年：入力　終了月：未入力　の場合は、searchMonthEndModal = '12' をセット
+			searchEndModal = searchYearEndModal + '12';
+		} else {
+			// 終了年：未入力　終了月：入力　の場合は、searchYearStartModal により分岐
+			if(searchYearStartModal) {
+				// searchYearEndModal：入力　の場合は、searchYearEndModal = searchYearEndModal
+				searchEndModal = searchYearStartModal + searchMonthEndModal;
+			} else {
+				// searchYearStartModal：未入力　の場合は、searchYearEndModal = now
+				searchYearEndModal = new Date().getFullYear().toString();
+				searchEndModal = searchYearEndModal + searchMonthEndModal;
+			}
+		}
+		if (searchStartModal) {
+			paramName = 'date-min';
+			paramValue = searchStartModal;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if (searchEndModal) {
+			paramName = 'date-max';
+			paramValue = searchEndModal;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var sortKey = sessionStorage.getItem('listoption_sortkey');
+		if (sortKey !== null && sortKey !== '00') {
+			paramName = 'sort';
+			paramValue = sortKey;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+
+		var pageCount = sessionStorage.getItem('listoption_pagecount');
+		if (pageCount !== null && pageCount !== '30') {
+			paramName = 'per-page';
+			paramValue = pageCount;
+			arrQuery.push( { name: paramName, value: paramValue } );
+		}
+		if(url.endsWith(".0")) {
+			url += '/';
+		}
+		// query_string生成
+		url += makeQueryString(arrQuery);
+		window.location.href = url;
+	}
+});
+
+function makeQueryString(arrQuery) {
+	// query_string生成
+	if (arrQuery.length > 0) {
+		var queryString = $.map(arrQuery, function(param) {
+			return encodeURIComponent(param.name) + '=' + encodeURIComponent(param.value);
+		}).join('&');
+		return '?' + queryString;
+	} else {
+		return '';
+	}
+}
+
+// リセット
+$('#search_reset_btn').on('click', function() {
+	$('.search_form').val('');
+	$('.search_check').prop('checked', false);
+});
+
+$('#search_reset_btn_modal').on('click', function() {
+	$('.search_form').val('');
+	$('.search_check').prop('checked', false);
+});
+
+// 表示切り替え
+$("#display_change_list").on("click", function () {
+	display_change_list();
+	sessionStorage.setItem('display_change', 'list');
+});
+
+$("#display_change_grid").on("click", function () {
+	display_change_grid();
+	sessionStorage.setItem('display_change', 'grid');
+});
+
+$(document).ready(function() {
+	var display_change = sessionStorage.getItem('display_change');
+	if (display_change == 'list') {
+		display_change_list();
+	} else if (display_change == 'grid') {
+		display_change_grid();
+	}
+	// セットカテゴリリンクへのquery_string追加
+	var arrSetQuery = [];
+	var setSortKey = sessionStorage.getItem('listoption_setsortkey');
+	var setPageCount = sessionStorage.getItem('listoption_pagecount');
+	if (setSortKey !== null && setSortKey !== '90') {
+		paramName = 'sort';
+		paramValue = setSortKey;
+		arrSetQuery.push( { name: paramName, value: paramValue } );
+	}
+	if (setPageCount !== null && setPageCount !== '30') {
+		paramName = 'per-page';
+		paramValue = setPageCount;
+		arrSetQuery.push( { name: paramName, value: paramValue } );
+	}
+
+	var setLinkUrl = '/set/search/keyword/9784000000000';
+	setLinkUrl += makeQueryString(arrSetQuery);
+	$('.categorySetLink').attr('href', setLinkUrl);
+});
+
+function display_change_list() {
+	if ($("#items_field").hasClass("-grid")) {
+		$("#items_field").removeClass("-grid");
+		$("#display_change_list").addClass("-active");
+		$("#display_change_grid").removeClass("-active");
+	}
+}
+
+function display_change_grid() {
+	if (!$("#items_field").hasClass("-grid")) {
+		$("#items_field").addClass("-grid");
+		$("#display_change_list").removeClass("-active");
+		$("#display_change_grid").addClass("-active");
+	}
+}
+
+// 並び順
+$(document).on('click', function (e) {
+	if (!$(e.target).closest('#sort_modal').length) {
+		$('#sort_modal').removeClass("-selected");
+		$('#sort_modal_list').removeClass("-selected");
+	}
+});
+
+$('#sort_modal').on('click', function () {
+	if($('#sort_modal').hasClass("-selected")) {
+		$('#sort_modal').removeClass("-selected");
+		$('#sort_modal_list').removeClass("-selected");
+	} else {
+		$('#sort_modal').addClass("-selected");
+		$('#sort_modal_list').addClass("-selected");
+	}
+});
+
+// 表示件数
+$(document).on('click', function (e) {
+	if (!$(e.target).closest('#display_number_modal').length) {
+		$('#display_number_modal').removeClass("-selected");
+		$('#display_number_modal_list').removeClass("-selected");
+	}
+});
+
+$('#display_number_modal').on('click', function () {
+	if($('#display_number_modal').hasClass("-selected")) {
+		$('#display_number_modal').removeClass("-selected");
+		$('#display_number_modal_list').removeClass("-selected");
+	} else {
+		$('#display_number_modal').addClass("-selected");
+		$('#display_number_modal_list').addClass("-selected");
+	}
+});
+
+// 並び順・表示件数の保持
+$('.listDropDown__link').on('click', function () {
+	saveParam = $(this).data('listoption-param');
+	if($(this).data('listoption') == 'sortkey') {
+		sessionStorage.setItem('listoption_sortkey', saveParam);
+	} else if($(this).data('listoption') == 'pagecount') {
+		sessionStorage.setItem('listoption_pagecount', saveParam);
+	}
+});
+
+// 文字制限
+// PC
+$('#search_keyword').on('blur', function() {
+	convertLimitStr(this, 100);
+});
+$('#search_exclusion_keyword').on('blur', function() {
+	convertLimitStr(this, 80);
+});
+$('#search_author').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+$('#search_publisher').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+// SP
+$('#search_keyword_modal').on('blur', function() {
+	convertLimitStr(this, 100);
+});
+$('#search_exclusion_keyword_modal').on('blur', function() {
+	convertLimitStr(this, 80);
+});
+$('#search_author_modal').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+$('#search_publisher_modal').on('blur', function() {
+	convertLimitStr(this, 78);
+});
+
+function convertLimitStr(current, num) {
+	if ($(current).val().length > num) {
+		var convertVal = $(current).val().substr(0, num);
+		$(current).val(convertVal);
+	}
+}
+
+// 中古価格　全角→半角
+// PC
+$('#search_used_price_min').on('blur', function() {
+	convertFullToHalf(this);
+});
+$('#search_used_price_max').on('blur', function() {
+	convertFullToHalf(this);
+});
+// SP
+$('#search_used_price_min_modal').on('blur', function() {
+	convertFullToHalf(this);
+});
+$('#search_used_price_max_modal').on('blur', function() {
+	convertFullToHalf(this);
+});
+
+function convertFullToHalf(current) {
+	var convertVal = $(current).val().replace(/[０-９]/g, function(s) {
+		return String.fromCharCode(s.charCodeAt(0) - 65248);
+	});
+	convertVal = convertVal.replace(/[^0-9]/g, '');
+	var maxDigit = 10;
+	if (convertVal.length > maxDigit) {
+		convertVal = convertVal.substring(0, maxDigit);
+	}
+	$(current).val(convertVal);
+}
+
+function replacePercent(word) {
+	if (!word || word.indexOf('%') < 0) {
+		return word;
+	}
+	var split = word.split('%');
+	var result = split[0];
+	for (var i = 1; i < split.length; i++) {
+		if (i == split.length - 1 && !split[i]) {
+			result += '%25';
+		} else if (!split[i].match(/^[0-9a-f]2/i)) {
+			result += '%25' + split[i];
+		} else {
+			result += '%' + split[i];
+		}
+	}
+	return result;
+}
+
+function encodeMark(word) {
+	word = replacePercent(word);
+	word = word.replace(/\?/g, '%253F');
+	word = word.replace(/\//g, '%252F');
+	word = word.replace(/\#/g, '%2523');
+	return word;
+}
+
+// ボタンの個数差でのCSS制御
+$(".productItem__btns").each(function(index, element) {
+	if($(element).children().length > 2) {
+		$(this).closest('.productItem').addClass('productItem--btns3col');
+	}
+});
+
+// 複数のセット商品がありますモーダル
+$('.js-modal[data-modal^="modalSetSelect-"]').on('click', function () {
+	$(this).delay(100).queue(function () {
+		adjust();
+		$(window).resize(function () {
+			adjust();
+		})
+		function adjust() {
+			var setModal = $('[id^="modalSetSelect-"]');
+			var h1 = setModal.find('.modal__title').outerHeight(true);
+			if (window.matchMedia("(min-width: 768px)").matches) {
+				//PC
+				var modalh = setModal.height();
+				var paddingTop = setModal.find('.modalContent').css('padding-top').replace('px', '');
+				setModal.find('.modalItems.js-modalInnerContent').css("height", modalh - h1 - paddingTop);
+			} else {
+				//SP
+				var windowh = $(window).height();
+				setModal.css("height", windowh * 0.97);
+				setModal.find('.modalItems.js-modalInnerContent').css("height", windowh * 0.97 - h1);
+			}
+		}
+	});
+});
+
+$('.js-ageverification').on('click', function(){
+	var modalBtn = $('#ageVerification__btns--agree');
+	// 初期化
+	modalBtn.removeClass();
+	modalBtn.addClass('btn js-agree-submit');
+	modalBtn.removeAttr('data-mode');
+	modalBtn.removeAttr('data-item');
+	modalBtn.removeAttr('data-cv-name');
+	modalBtn.removeAttr('data-stock');
+	$('.ageVerificationBlock__txt--error').hide();
+
+	// クリックボタンからパラメータ取得
+	var type = $(this).attr('data-type') ?? '';
+	var mode = $(this).attr('data-mode') ?? '';
+	var item_id = $(this).attr('data-item') ?? '';
+	var cvName = $(this).attr('data-cv-name') ?? '';
+
+	// agreeボタン パラメータ設定
+	if(type == 'cart' || type == 'arrival' || type == 'favorite') {
+		modalBtn.attr('data-mode', mode);
+		modalBtn.attr('data-item', item_id);
+		modalBtn.attr('data-cv-name', cvName);
+
+		if(type == 'cart') {
+			var stockType = $(this).attr('data-stock') ?? '';
+			modalBtn.attr('data-stock', stockType);
+		}
+
+		modalBtn.addClass('jsBtn-' + type);
+		modalBtn.addClass('ac-click-cv');
+	} else {
+		$('#modalAgeVerification > modalContent > js-modalClose').trigger('click');
+	}
+});
+$('.js-modalClose').on('click', function(){
+	if ($('#modalAgeVerification').hasClass('-show')) {
+		initializeAgeVerificationModal();
+	}
+});
+$('.modal__overlay').on('click', function(){
+	if ($('#modalAgeVerification').hasClass('-show')) {
+		initializeAgeVerificationModal();
+	}
+});
+function initializeAgeVerificationModal () {
+	var modalBtn = $('#ageVerification__btns--agree');
+	modalBtn.removeClass();
+	modalBtn.addClass('btn js-agree-submit');
+	modalBtn.removeAttr('data-mode');
+	modalBtn.removeAttr('data-item');
+	modalBtn.removeAttr('data-cv-name');
+	modalBtn.removeAttr('data-stock');
+	$('.ageVerificationBlock__txt--error').hide();
+}
+</script>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock717566">
+						<section class="itemsContainer">
+    <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop">
+        <h2 class="itemsContainer__header">検索結果の関連商品</h2>
+    </div>
+    <div id="js-recSearchRelation" class="js-recommend itemsContainer__outer" data-item-number="20" data-model-id="602" data-id="search" data-id-mb="search-mb" data-id-pc="search-pc" data-item-id="searchResult" data-genre="" data-price="" data-item-type="">
+        <!-- レコメンド出力箇所 -->
+    </div>
+</section>
+			</div>
+			<div class="itemsContainerWrap itemsContainerWrap--itemViewHistory pbNested pbNestedWrapper "  id="pbBlock714242">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock714243">
+						<section class="itemsContainer itemsContainer--itemViewHistory js-itemViewHistory">
+  <div class="itemsContainer__headerArea itemsContainer__headerArea--spacedTop -hidden js-displayItemViewHistoryHeader">
+    <h2 class="itemsContainer__header">最近チェックした商品</h2>
+    <div class="itemsContainer__textBox itemsContainer__textBox--deleteHistory js-delItemViewHistoryArea"><button class="link itemsContainer__actionButton js-delItemViewHistory"><span>履歴を消す</span></button></div> 
+  </div>
+  <div class="itemsContainer__wrapper">
+    <div class="itemsContainer__main splide js-displayItemViewHistory" id="ItemViewHistory">
+    </div>
+    <div class="itemsContainer__textBox itemsContainer__textBox--removeHistory js-undoItemViewHistoryArea -hidden">
+      <div class="itemsContainer__text">履歴をすべて削除しました</div>
+      <div class="itemsContainer__actionBox">
+        <button class="itemsContainer__actionButton js-undoItemViewHistory"><span>もとにもどす</span></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div></div><div id="footerArea" class="pbFooterArea">
+	<div id="area4" class="pbArea ">
+		<div class="pbNested " >
+			<div class="  pbNested pbNestedWrapper "  id="pbBlock10025">
+								<div class="pbNested " >
+			<div class="pbNested pbNestedWrapper "  id="pbBlock161678">
+						<footer class="footer" id="footer">
+    <div class="footer__wrap">
+      <div class="footer__inner">
+        <div class="footer__navi">
+          <p class="footer__pageTop">
+            <a href="#" class="footer__pageTopBtn js-pagetop">
+              <img src="/library/common/images/img-footer-arrow.svg" alt="ページトップへ戻る">
+            </a>
+          </p>
+          <ul>
+            <li class="footer__item footer__item--first"><a href="https://support-online.bookoff.co.jp" class="footer__link">ヘルプ・ご質問</a>
+              <ul>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/64363fbd97ebd8c6491e0a07" class="footer__link">配送料について</a></li>
+                <li class="footer__item"><a href="https://support-online.bookoff.co.jp/answer/65852e8cd29784dd07b9bdc7" class="footer__link">支払い方法について</a></li>
+              </ul>
+            </li>
+            <li class="footer__item"><a href="https://shopping.bookoff.co.jp/service/mail" class="footer__link">メールサービス</a></li>
+            <li class="footer__item"><a href="https://regist11.smp.ne.jp/regist/is?SMPFORM=ofn-latbq-651b190782b21aa1eaa0162e484e578c" class="footer__link">ご意見・ご感想</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer__wrap footer__wrap--bottom">
+      <div class="footer__inner">
+        <ul class="footer__sns">
+          <li>
+            <a href="https://www.facebook.com/%E3%83%96%E3%83%83%E3%82%AF%E3%82%AA%E3%83%95%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3bookoffonline-166258740189848/" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-fb.svg" alt="Facebook">
+            </a>
+          </li>
+          <li>
+            <a href="https://x.com/bookoffonline" class="footer__snsBtn" target="_blank">
+              <img src="/library/common/images/img-footer-x.svg" alt="X">
+            </a>
+          </li>
+          <li>
+            <a href="https://page.line.me/iau9918q" class="footer__snsBtn">
+              <img src="/library/common/images/img-footer-line.svg" alt="LINE">
+            </a>
+          </li>
+        </ul>
+        <div class="footer__bottomNavi">
+          <ul>
+           <li><a href="https://www.bookoff.co.jp/" class="footer__bottomLlink" target="_blank">BOOKOFF公式サイト</a></li>
+           <li><a href="https://www.bookoffgroup.co.jp/corporate/business.html" class="footer__bottomLlink" target="_blank">企業情報</a></li>
+           <li><a href="https://member.bookoff.co.jp/bo-member-content/contract/" class="footer__bottomLlink" target="_blank">BOOKOFF会員サービス利用規約</a></li>
+           <li><a href="https://shopping.bookoff.co.jp/policies/terms" class="footer__bottomLlink">利用規約</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/privacy.html" class="footer__bottomLlink" target="_blank">個人情報保護方針</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/socialmedia.html" class="footer__bottomLlink" target="_blank">ソーシャルメディアポリシー</a></li>
+          <li><a href="https://www.bookoff.co.jp/site/customerharassment.html" class="footer__bottomLlink" target="_blank">カスタマーハラスメントに対する基本方針</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/regulatory-disclosure" class="footer__bottomLlink">特定商取引法に基づく表示</a></li>
+          <li><a href="https://shopping.bookoff.co.jp/policies/external-transmission" class="footer__bottomLlink">利用者情報の外部送信について</a></li>
+          <li><a href="https://www.bookoffgroup.co.jp/" class="footer__bottomLlink" target="_blank">ブックオフグループホールディングス株式会社</a></li>
+         </ul>
+        </div>
+        <div class="footer__bottom">
+          <div class="footer__text">
+            <p> ブックオフコーポレーション株式会社<br> 古物商許可番号 第452760001146号 神奈川県公安委員会許可 </p>
+          </div>
+          <div class="footer__copyright"> Copyright(C)BOOKOFF CORPORATION LTD.<br class="forSp">All Rights Reserved. </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+			</div>
+			<div class="pbNested pbNestedWrapper "  id="pbBlock209621">
+						
+<link rel="stylesheet" href="/library/common/css/appli/app-hide-common.css">
+
+
+			</div>
+		</div>
+
+			</div>
+		</div>
+	</div>
+
+</div></div>
+<script  src="https://content.bookoff.co.jp/js/roc/csrf_tmp.min.js"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/common/item-view-history-show.js?rev=20260427"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-item.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/build-contents.js?rev=20260527"></script>
+<script  src="https://content.bookoff.co.jp/assets/js/recommend/zeta/core.js"></script>
+<script  src="/library/common/js/sjis_convert.min.js"></script>
+<script  src="/library/common/js/suggest_module.js?d=20240911"></script>
+</body>
+</html>
+<!-- cache datetime:2026/07/23 01:06:43, cache file name:/shopping/search.html --> 

--- a/tests/fixtures/used_book/netoff_product.html
+++ b/tests/fixtures/used_book/netoff_product.html
@@ -1,0 +1,4288 @@
+<!doctype html>
+<html lang="ja">
+  <head><script>(function(w,i,g){w[g]=w[g]||[];if(typeof w[g].push=='function')w[g].push(i)})(window,'GTM-NPLRPRC','google_tags_first_party');</script><script>(function(w,d,s,l){w[l]=w[l]||[];(function(){w[l].push(arguments);})('set','developer_id.dYzZiYj',true);var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='/27ns5f/';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>
+    <meta charset="UTF-8" />
+    <meta name="_csrf" content="b1fc02dc-957b-459a-a7a6-de5a016d402e" />
+    <meta name="_csrf_header" content="X-XSRF-TOKEN" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    
+      <title>海に願いを風に祈りをそして君に誓いを(文庫): 中古 | 汐見夏衛 | 古本の通販ならネットオフ</title>
+      <link rel="canonical" href="https://www.netoff.co.jp/detail/0012822282/" />
+      
+        <meta name="description" content="「海に願いを風に祈りをそして君に誓いを(文庫): 中古 | 汐見夏衛」の購入はネットオフ！楽天ポイント・Vポイントが貯まる・使える！" />
+      
+      <meta name="robots" content="index,follow" />
+      <meta property="og:locale" content="ja_JP" />
+      <meta property="og:title" content="海に願いを風に祈りをそして君に誓いを(文庫): 中古 | 汐見夏衛 | 古本の通販ならネットオフ" />
+      <meta property="og:site_name" content="ネット中古書店 ネットオフ (本・CD・DVD・ゲームソフトの買取・販売)" />
+      <meta property="og:url" content="https://www.netoff.co.jp/detail/0012822282/" />
+      <meta property="og:type" content="article" />
+      <meta property="og:image" content="https://www.netoff.co.jp/images/logo_fb.gif" />
+      <meta property="og:description" content="「海に願いを風に祈りをそして君に誓いを(文庫): 中古 | 汐見夏衛」の購入はネットオフ！楽天ポイント・Vポイントが貯まる・使える！" />
+      <meta property="fb:app_id" content="193098350747639" />
+    
+
+    
+      
+        <script type="application/ld+json">
+          /*<![CDATA[*/
+          {
+            "@context": "http://schema.org",
+            "@type": "Product",
+            "name": "海に願いを風に祈りをそして君に誓いを",
+            "image": "/ebimage/cmdty/0012822282.jpg",
+            "sku": "0012822282",
+            "gtin13": "9784813705185",
+            "url": "https://www.netoff.co.jp/detail/0012822282/",
+            "brand": {
+              "@type": "Brand",
+              "name": "汐見夏衛"
+            },
+            "offers": {
+              "@type": "Offer",
+              "price": "220",
+              "priceCurrency": "JPY",
+              "url": "https://www.netoff.co.jp/detail/0012822282/"
+            }
+          }
+          /*]]>*/
+        </script>
+      
+    
+    <link rel="shortcut icon" href="/netoff.ico" />
+    <link rel="apple-touch-icon" href="/netoff.png" />
+    <link href="/css/style.css" rel="stylesheet" />
+    <script src="/js/googleTag.js" defer></script>
+    
+      
+        
+          
+  
+    
+      
+        
+          <script>
+            /*<![CDATA[*/
+            const user = {
+              zeta_id: "",
+              zeta_gender: "",
+              zeta_age: "",
+            };
+            /*]]>*/
+            const zetaParam = {};
+            const zetaScriptUrl = "https:\/\/renet.search.zetacx.net\/static\/zd\/zd_register_prd.js";
+          </script>
+          <script src="/js/zetatags.js" defer></script>
+        
+      
+    
+  
+
+        
+      
+    
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NPLRPRC" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header>
+      <div id="js-headerContainer" class="l-header__container is-fixed">
+        <div class="l-header-common" id="js-header">
+  <!-- <div class="l-header-common__info">
+    <p>古本・CD・DVD・ゲームの買取・中古通販ならネットオフ！！</p>
+    <nav class="l-header-common__info-nav">
+      <ul>
+        <li class="l-header-common__info-nav-list">
+          <a href="/sell/">段ボール無料</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="forfirsttime = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FORFIRSTTIMEUSER_URL}" th:href="${forfirsttime}">はじめての方へ</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="faq = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FAQ_URL}" th:href="${faq}">よくある質問</a>
+        </li>
+      </ul>
+    </nav>
+  </div> -->
+  <div class="l-header">
+    <button type="button" class="l-header__nav-button js-toggle" data-target="js-headerSideNav">
+      <span></span>
+    </button>
+    <div class="l-header__logo">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <a href="/sell/" class="l-header__purchase-button">買取</a>
+    
+  </div>
+  <div class="l-header-common__inner js-topNavigation">
+    <div class="l-header__logo is-sp-hidden">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <form class="c-search-input__form l-header-common__search" id="js-searchList" name="search_form">
+      <input type="hidden" name="cat" value="" />
+      <div class="l-header-common__search-select">
+        <div class="c-select c-select--black js-select" data-target="js-headerSelect" tabindex="0">
+          <div
+            class="c-select__label js-selectLabel js-init-category"
+            data-target="js-headerSelect"
+            data-value="すべてのカテゴリー"
+          ></div>
+          <div class="c-select__option-container" id="js-headerSelect">
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="すべてのカテゴリー"
+                data-value=""
+                id="headerSearchCategory1"
+                class="js-selectOption js-searchSelect" checked="checked"
+              />
+              <label class="c-select__options" for="headerSearchCategory1">すべてのカテゴリー</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="古本・中古本"
+                data-value="1002"
+                id="headerSearchCategory4"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory4">古本・中古本</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミック"
+                data-value="1001"
+                id="headerSearchCategory2"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory2">コミック</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミックセット"
+                data-value="1011"
+                id="headerSearchCategory3"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory3">コミックセット</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="ゲーム"
+                data-value="5001"
+                id="headerSearchCategory7"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory7">ゲーム</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="DVD・Blu-ray"
+                data-value="7001"
+                id="headerSearchCategory6"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory6">DVD・Blu-ray</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="CD"
+                data-value="3001"
+                id="headerSearchCategory5"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory5">CD</label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-header-common__search-input">
+        <button type="submit" formaction="/cmdtyallsearch/" class="l-header-common__search-button">
+          <img src="/img/search_black_icon.svg" width="20px" alt="検索" />
+        </button>
+        <div class="c-search-input">
+          <div class="c-search-input__input-container">
+            <input
+              type="text"
+              placeholder="キーワードを入力"
+              class="c-search-input__input js-searchForm"
+              name="word"
+              data-target="js-searchList"
+              value=""
+              autocomplete="off"
+            />
+            <button type="button" class="c-search-input__delete-input js-searchInputDelete">
+              <img src="/img/close_gray_icon.svg" alt="削除" />
+            </button>
+          </div>
+          <button type="submit" formaction="/cmdtyallsearch/" class="c-search-input__button">
+            <img src="/img/search_icon.svg" alt="検索" />
+          </button>
+          <button type="button" class="c-search-input__cancel js-toggle" data-target="js-searchList">キャンセル</button>
+        </div>
+        <!-- <input type="text" placeholder="キーワードを入力" class="js-searchForm" data-target="js-searchList" /> -->
+        <div class="c-search-input__list-inner js-searchResult">
+          <div class="c-search-input__list-top">
+            <span class="c-search-input__history-text">検索履歴</span>
+            <span class="c-search-input__result-text">検索候補</span>
+            <button type="button" class="c-search-input__delete-all-button js-suggest-delete-all">全件削除</button>
+          </div>
+          <ul class="js-suggestList">
+            <!--
+            <li class="c-search-input__list">
+              <a th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}" th:href="@{__${url}__}">
+                <span class="c-search-input__list-text js-searchHistory">鬼滅の刃</span>
+              </a>
+              <button type="button" class="c-search-input__delete-button">
+                <img th:src="@{/img/close_gray_icon.svg}" alt="削除" />
+              </button>
+            </li>
+            -->
+          </ul>
+        </div>
+      </div>
+
+      <div class="c-search-input__list-container">
+        <div class="c-search-input__background"></div>
+      </div>
+    </form>
+    <script>
+      document.querySelectorAll('.js-searchSelect').forEach((option) => {
+        option.addEventListener('change', function () {
+          if (this.checked) {
+            const selectedValue = this.getAttribute('data-value');
+            document.querySelector('input[type="hidden"][name="cat"]').value = selectedValue;
+          }
+        });
+      });
+    </script>
+    <nav
+      class="l-header-common__nav-container"
+    >
+      <ul class="l-header-common__nav">
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/mypagetop/">
+            
+            ログイン
+          </a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/incomingmaillist/">入荷メール</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/reservation/reservationlist/">予約履歴</a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/myfavorite/">お気に入り</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/browsinghistory/">閲覧履歴</a>
+        </li>
+        <li class="l-header-common__nav-list js-cartcontainer">
+          <a href="/purchase/cart/">カート</a>
+          
+        </li>
+        <li style="display: block" class="l-header-common__nav-list l-header-common__nav-list--purchase">
+          <a href="/sell/">買取</a>
+        </li>
+        <li style="display: none" class="l-header-common__nav-list l-header-common__nav-list--cards">
+          <a href="/moetaku/tcg/pokemon_card/">トレカ<br />買取</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="l-header__nav" id="js-headerSideNav">
+    <div class="l-header__nav-back js-toggle" data-target="js-headerSideNav"></div>
+    <nav class="l-header__nav-container">
+      <!-- 未ログイン -->
+      <div>
+        <div class="l-header__login-container">
+          <div class="l-header__login-buttons">
+            <!--  
+            <a class="c-button--main" href="{$root}login/login">ログイン</a>
+            <a class="c-button--outline" th:href="@{/registration/enterinformation}">新規会員登録</a>
+          -->
+            <a class="c-button--main" href="/login/">ログイン</a>
+            <a class="c-button--outline" href="/registration/enterinformation/"
+              >新規会員登録</a
+            >
+          </div>
+          <div>
+            <!--
+            <a class="c-link--icon l-header__guide-link" href="">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" th:href="/login/resetpassword">パスワードを忘れた方はこちら</a>
+            -->
+            <a class="c-link--icon l-header__guide-link" href="/guide/beginner.jsp">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" href="/resetpassword/"
+              >パスワードを忘れた方はこちら</a
+            >
+          </div>
+        </div>
+      </div>
+      <!-- ログイン済み -->
+      
+      <ul>
+        <li class="l-header__nav-title">カテゴリ</li>
+        <li class="l-header__nav-list">
+          <a href="/book/">古本・中古本</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comic/">コミック</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comicset/">コミックセット</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/game/">ゲーム</a>
+        </li>
+        <!-- <li class="l-header__nav-list">
+          <a href="">トレカ</a>
+        </li> -->
+        <li class="l-header__nav-list">
+          <a href="/dvd/">DVD・Blu-ray</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/cd/">CD</a>
+        </li>
+      </ul>
+      <ul>
+        <li class="l-header__nav-title">買取</li>
+        <li class="l-header__nav-list">
+          <a href="/sell/">ネットオフ宅配買取TOP</a>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav1">本＆ゲーム買取</button>
+          <ul id="js-headerNav1">
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">本＆ゲーム買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/comic/">コミック・漫画</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">古本・中古本</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/campaign/game/">ゲームソフト</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/game/body.jsp">ゲーム機本体</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/dvd/">DVD・Blu-ray</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/cd/">CD</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav2">トレカ買取</button>
+          <ul id="js-headerNav2">
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/">トレカ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/pokemon_card/">ポケモンカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/onepiece/">ワンピースカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/yugioh/">遊戯王カード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/shadowverse-evolve/">シャドウバース エボルヴ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav4">フィギュア買取</button>
+          <ul id="js-headerNav4">
+            <li class="l-header__nav-list">
+              <a href="/figure/">フィギュア買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/kuji_prize/">プライズフィギュア</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/plamodel/">プラモデル</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gunpla/">ガンプラ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav3">スマホ買取</button>
+          <ul id="js-headerNav3">
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/">スマホ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/iphone/">iPhone</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/xperia/">Xperia</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/tablet/ipad/">iPad</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/galaxy/">Galaxy</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/googlepixel/">Google Pixel</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav5">家電買取</button>
+          <ul id="js-headerNav5">
+            <li class="l-header__nav-list">
+              <a href="/kaden/">家電買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/camera/">カメラ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/headphone/">ヘッドホン</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/gamingpc/">ゲーミングPC</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/wellness/">美容家電</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/deditalstationery/pentablet/">ペンタブレット</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/smartwatch/">スマートウォッチ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav6">ブランド総合買取</button>
+          <ul id="js-headerNav6">
+            <li class="l-header__nav-list">
+              <a href="/sell/general/">ブランド総合買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/brand/">ブランド品</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/clothes/">洋服・古着</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/jewelry/">金・プラチナ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gakki/">楽器</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/hikkigu/">万年筆</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <!-- <div class="c-modal" id="js-logout">
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="button" class="c-button--black-outline" onClick="window.location.href='/'">ログアウト</button>
+      </div>
+    </div>
+  </div> -->
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="b1fc02dc-957b-459a-a7a6-de5a016d402e"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+</div>
+        <nav class="c-top-nav is-fixed js-topNavigation">
+  <ul class="c-top-nav__list">
+    <li class="is-active">
+      <a href="/book/" class="c-top-nav__link">古本・中古本</a>
+    </li>
+    <li>
+      <a href="/comic/" class="c-top-nav__link">コミック</a>
+    </li>
+    <li>
+      <a href="/comicset/" class="c-top-nav__link">コミックセット</a>
+    </li>
+    <li>
+      <a href="/game/" class="c-top-nav__link">ゲーム</a>
+    </li>
+    <!-- <li>
+      <a href="" class="c-top-nav__link">トレカ</a>
+    </li> -->
+    <li>
+      <a href="/dvd/" class="c-top-nav__link">DVD・Blu-ray</a>
+    </li>
+    <li>
+      <a href="/cd/" class="c-top-nav__link">CD</a>
+    </li>
+  </ul>
+</nav>
+      </div>
+    </header>
+
+    <main class="l-product l-common__header--tab l-common__footer">
+      <!-- パンくず -->
+      
+        <div
+        >
+          <ol class="c-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem" data-breadcrumb="home">
+    <a href="/" class="c-link--blue c-breadcrumbs__label" itemprop="item"><span itemprop="name">ネットオフTOP</span></a>
+    <meta itemprop="position" content="1" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    <a href="/book/" class="c-link--blue c-breadcrumbs__label" itemprop="item">
+      <span itemprop="name">古本・中古本</span>
+    </a>
+    
+    <meta itemprop="position" content="2" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    <a href="/book/10" class="c-link--blue c-breadcrumbs__label" itemprop="item">
+      <span itemprop="name">文芸</span>
+    </a>
+    
+    <meta itemprop="position" content="3" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    
+    <span class="c-breadcrumbs__label" itemprop="name">海に願いを風に祈りをそして君に誓いを/文庫</span>
+    <meta itemprop="position" content="4" />
+  </li>
+</ol>
+        </div>
+      
+
+      <div class="l-product__container">
+        <div class="l-product__main">
+          <section class="l-product__main--flex product-inner" id="js-cartTarget">
+            <div class="l-product__main-image sp-none">
+              <div class="l-product__image">
+                
+                  <img src="/ebimage/cmdty/0012822282.jpg" alt="" class="l-product__image-book" />
+                
+              </div>
+              
+            </div>
+            <div class="l-product__main-textwrap">
+              <div class="">
+                
+                <div class="l-product__category-wrap">
+                  
+                    <span class="c-category --green">古本・中古本</span>
+                  
+                  
+                    <span class="c-category">メール便対象</span>
+                  
+                  
+                  
+                  
+                </div>
+                <h1
+                  class="l-product__main-title"
+                >海に願いを風に祈りをそして君に誓いを/文庫</h1>
+                <div class="l-product__author-wrap">
+                  <span class="l-product__author">作家</span>
+                  <span class="l-product__author-mark">：</span>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;word=%E6%B1%90%E8%A6%8B%E5%A4%8F%E8%A1%9B"
+                  >
+                    <span class="l-product__author-name">汐見夏衛</span>
+                  </a>
+                </div>
+              </div>
+              <div class="l-product__main-image pc-none">
+                <div class="l-product__image">
+                  
+                    <img src="/ebimage/cmdty/0012822282.jpg" alt="" class="l-product__image-book" />
+                  
+                </div>
+              </div>
+              
+              
+              
+              
+              
+              
+                <div class="l-product__price product-price">
+                  
+                  
+                    <label for="normal_price" class="product-price__normal c-product-price__btn js-changeColor selected">
+                      <input type="radio" id="normal_price" name="price_option" checked />
+                      <div class="product-price__normal-left">
+                        <p>通常価格</p>
+                        <div class="product-price__normal-text-wrap">
+                          <span class="product-price__normal-num">220</span>
+                          <span class="product-price__normal-mark">円</span>
+                          <span class="product-price__normal-tax">（税込）</span>
+                        </div>
+                      </div>
+                      
+                        <div class="product-price__normal-right">
+                          <span>定価より</span><span><span class="--red">440円</span>おトク！</span>
+                        </div>
+                      
+                    </label>
+                  
+                  
+                  
+                  
+                  
+                    <label for="premium_price" class="product-price__premium c-product-price__btn js-changeColor js-textChange" data-target="js-priceContainer">
+                      <input type="radio" id="premium_price" name="price_option" />
+                      <div class="product-price__premium-origin" id="js-textReturn1">
+                        <div class="product-price__premium-left">
+                          <img src="/img/premium.png" alt="Premium会員" />
+                          <p>なら</p>
+                        </div>
+                        <div class="product-price__premium-right">
+                          <div class="product-price__premium-text-wrap">
+                            <span class="product-price__premium-text">実質</span>
+                            <span
+                              class="product-price__premium-num"
+                            >44</span>
+                            <span class="product-price__premium-mark">円</span>
+                            <span class="product-price__premium-text">（税込）</span>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="product-price__premium-change" id="js-textChange1" style="visibility: hidden">
+                        <div class="product-price__premium-left">
+                          <img src="/img/premium.png" alt="Premium会員" />
+                          <p>なら</p>
+                        </div>
+                        <div class="product-price__premium-right">
+                          <div class="product-price__premium-text-wrap">
+                            <span class="product-price__premium-text">最大買取価格</span>
+                            <span
+                              class="product-price__premium-num"
+                            >176</span>
+                            <span class="product-price__premium-mark">円</span>
+                            <span class="product-price__premium-text">（税込）</span>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="product-price__premium-list-inner" id="js-priceContainer">
+                        <ul class="product-price__premium-list">
+                          <li class="product-price__premium-list-item">
+                            <p class="product-price__premium-list-text">
+                              販売価格
+                              <span
+                                class="--em"
+                              >220円</span>
+                            </p>
+                            －
+                            <p class="product-price__premium-list-text">
+                              買取価格
+                              <span
+                                class="--em"
+                              >176円</span>
+                            </p>
+                          </li>
+                          <li class="product-price__premium-list-item">
+                            <span>＝</span>
+                            <span>差引</span>
+                            <div class="product-price__premium-list-price">
+                              <span
+                              >44</span>
+                              <span>円</span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </label>
+                    <div class="product-price__comments">
+                      <a href="/PremiumMemberLp/">
+                        <span>プレミアム会員とは</span>
+                      </a>
+                    </div>
+                  
+                </div>
+              
+              <div class="l-product__coupon product-coupon sp-none">
+                <a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+
+
+<!--
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大10倍！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大500ポイントプレゼント！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント100ポイントプレゼント！</span>
+</a>
+</div>
+
+<a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+-->
+
+              </div>
+            </div>
+          </section>
+          <section class="product-inner pc-none">
+            <div class="l-product__cart --bg">
+              <div
+              ><button class="l-product__cart-btn product-btn --cart addCart" value=0012822282 data-target="js-addcart" data-cartinfo="true"><span>カートに入れる</span></button></div>
+              <div class="c-favorite__button--wrap">
+                <button class="c-favorite__button js-favorite-button" value="0012822282" data-target="js-addfav"></button>
+              </div>
+            </div>
+            <div class="l-product__cart --bg --fixed" id="js-cartSticky">
+              <div
+              ><button class="l-product__cart-btn product-btn --cart addCart" value=0012822282 data-target="js-addcart" data-cartinfo="true"><span>カートに入れる</span></button></div>
+              <div class="c-favorite__button--wrap">
+                <button class="c-favorite__button js-favorite-button" value="0012822282" data-target="js-addfav"></button>
+              </div>
+            </div>
+
+            <div class="l-product__stock">
+              <div class="l-product__stock--flex">
+                
+                  <p class="l-product__stock-text">在庫あと1点！</p>
+                
+                
+                  <div class="l-product__stock-note">
+                    <span class="c-stock-icon">在庫あり</span>
+                    <span class="l-product__icon-text">1&#65374;2日以内に発送</span>
+                  </div>
+                
+              </div>
+              <div class="l-product__stock-bottom">
+                
+                  <div class="l-product__condition">
+                    <span class="l-product__condition-text">状態：中古品</span>
+                    <a
+                      href="/guide/goods.jsp?dtl=GoodsPolicy"
+                      class="l-product__condition-link"
+                      target="_blank"
+                      >販売基準について
+                    </a>
+                  </div>
+                
+                <a href="/price_down/" class="l-product__condition-mail">
+                  値下げしたらメールでお知らせ！
+                </a>
+              </div>
+            </div>
+          </section>
+          <div class="l-product__coupon product-coupon pc-none">
+            <a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+
+
+<!--
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大10倍！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大500ポイントプレゼント！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント100ポイントプレゼント！</span>
+</a>
+</div>
+
+<a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+-->
+
+          </div>
+          
+          
+
+          
+          
+
+          <section class="l-product__section l-product__detail">
+            <h2 class="c-heading--gray l-product__heading--cursor js-pullDown" data-target="js-newDetailContainer">この商品の詳細</h2>
+            <div class="l-product__detail-inner" id="js-newDetailContainer">
+              <dl class="l-product__detail-list detail-list">
+                <dt>出版社</dt>
+                <dd>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;maker=%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88"
+                    class="detail-list__link"
+                  >スターツ出版</a>
+                </dd>
+                <dt>出版社シリーズ</dt>
+                <dd>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;word=%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB"
+                    class="detail-list__link"
+                  >スターツ出版文庫</a>
+                </dd>
+                <dt>ISBN</dt>
+                <dd>4813705185</dd>
+                <dt>サイズ</dt>
+                <dd>文庫</dd>
+                <dt>発売年月日</dt>
+                <dd
+                >2018年08月01日</dd>
+              </dl>
+            </div>
+            <section class="l-product__section l-product__detail"></section>
+          </section>
+          
+            <section class="l-product__section">
+              <h2 class="c-heading--gray l-product__heading--cursor js-pullDown" data-target="js-newIntroContainer">この商品の紹介</h2>
+              <div class="l-product__intro-inner is-active" id="js-newIntroContainer">
+                <p class="l-product__intro-container l-product__intro-container--more" id="js-newIntroText">優等生で天の邪鬼な凪沙と、おバカで素直な優海は幼馴染で恋人同士。ところがある日を境に、凪沙は優海への態度を一変させる。甘えを許さず、厳しく優海を鍛える日々。そこには悲しすぎる秘密が隠されていて…。</p>
+                <button type="button" class="l-product__intro-more js-doublePullDownCommon" data-target="js-newIntroText" data-height="106">
+                  <span>詳しく見る＋</span>
+                  <span>閉じる－</span>
+                </button>
+              </div>
+            </section>
+            <section class="l-product__section"></section>
+          
+          
+            <article class="l-top__section">
+              <h2 class="c-heading--gray c-heading--gray--tag l-product__heading--cursor js-pullDown" data-target="js-newTagContainer">この商品の関連タグ</h2>
+              <div class="l-product__tag-list-container is-active" id="js-newTagContainer">
+                <ul class="l-product__tag-list" id="js-newTagList">
+                  
+                    <li>
+                      <a href="/tag?tagid=1041" class="c-tag">泣けるライトノベル</a>
+                    </li>
+                  
+                    <li>
+                      <a href="/tag?tagid=2024" class="c-tag">切ないライトノベル</a>
+                    </li>
+                  
+                    <li>
+                      <a href="/tag?tagid=1142" class="c-tag">恋愛・ラブコメライトノベル</a>
+                    </li>
+                  
+                </ul>
+                <button type="button" class="l-product__intro-more js-doublePullDownCommon" data-target="js-newTagList" data-height="106">
+                  <span>詳しく見る＋</span>
+                  <span>閉じる－</span>
+                </button>
+              </div>
+            </article>
+          
+          
+          <div class="l-product__purchase product-purchase pc-none">
+            <div class="product-purchase__container">
+              <p
+                class="product-purchase__title"
+              >海に願いを風に祈りをそして君に誓いを/文庫</p>
+              
+              <div class="">
+                <p class="product-purchase__present-text">
+                  買取金額50%UP<br />
+                  ＋お買物クーポン500円分プレゼント！
+                </p>
+                <div class="product-purchase__present-img">
+                  <img src="/img/dummy/coupon.png" alt="ネットオフで使えるクーポン" />
+                </div>
+              </div>
+              <div class="product-purchase__btn">
+                <a href="/campaign/2250" class="product-btn">
+                  <span>買取を申し込む</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <article class="l-product__section">
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--faq"
+                href="/qa/"
+              >
+                よくある質問
+                <span class="c-heading__link"> もっと見る </span>
+              </a>
+            </h2>
+            <div class="l-product__faq-inner">
+              <ul class="l-product__faq-container">
+                <li>
+                  <a href="/guide/goods.jsp#01" class="c-tag--faq"> 品質 </a>
+                </li>
+                <li>
+                  <a href="/guide/qa.jsp#q1_29" class="c-tag--faq"> 送料 </a>
+                </li>
+                <li>
+                  <a
+                    href="/guide/delivery.jsp#01"
+                    class="c-tag--faq"
+                  >
+                    お届け日数
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="/guide/qa.jsp#q1_36"
+                    class="c-tag--faq"
+                  >
+                    返品・交換
+                  </a>
+                </li>
+                <li>
+                  <a href="/qa/#q1_5" class="c-tag--faq">
+                    サイズ
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </article>
+          <article class="l-top__section"></article>
+        </div>
+
+        <div class="l-product__cta sp-none">
+          <section class="l-product__cta-inner">
+            <div class="l-product__cart-wrap">
+              <div class="l-product__cart" id="cart-button">
+                
+                  <div
+                  ><button class="l-product__cart-btn product-btn --cart addCart" value=0012822282 data-target="js-addcart" data-cartinfo="true"><span>カートに入れる</span></button></div>
+                  <div class="l-product__cart-favorite">
+                    <button class="c-favorite__button js-favorite-button" value="0012822282" data-target="js-addfav">お気に入り</button>
+                  </div>
+                
+              </div>
+            </div>
+            <div class="l-product__stock">
+              
+                <p class="l-product__stock-text">在庫あと1点！</p>
+              
+              
+                <div class="l-product__stock-note">
+                  <span class="c-stock-icon">在庫あり</span>
+                  <span class="l-product__icon-text">1&#65374;2日以内に発送</span>
+                </div>
+              
+              <div class="l-product__stock-bottom">
+                <!-- <a
+                  th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}"
+                  th:href="@{__${url}__(__(${bookDetail.getCtgrycode() != null ? 'cat=${bookDetail.getCtgrycode()}':','})__,__(${bookDetail.getTitle() != null ? 'word=${bookDetail.getTitle()}':','})__,__(${ebCmdtyDetail.getAuthor() != null ? 'author=${ebCmdtyDetail.getAuthor()}':','})__,__(${bookDetail.getBooksize() != null ? 'size=${bookDetail.getBooksize()}':','})__,__(${bookDetail.getPublisher() != null ? 'maker=${bookDetail.getPublisher()}':','})__)}"
+                  class="c-arrow-link"
+                >
+                  <span class="c-arrow-link__icon"></span>
+                  <span class="c-arrow-link__text">︎他の巻を探す</span>
+                </a> -->
+                
+                  <div class="l-product__condition">
+                    <span class="l-product__condition-text">状態：中古品</span>
+                    <a
+                      href="/guide/goods.jsp?dtl=GoodsPolicy"
+                      class="l-product__condition-link"
+                      target="_blank"
+                      >販売基準について
+                    </a>
+                  </div>
+                
+                <a href="/price_down/" class="l-product__condition-mail">
+                  値下げしたらメールでお知らせ！
+                </a>
+              </div>
+            </div>
+            <div class="l-product__purchase product-purchase">
+              <div class="product-purchase__container">
+                <p
+                  class="product-purchase__title"
+                >海に願いを風に祈りをそして君に誓いを/文庫</p>
+                
+                <div class="product-purchase__present-wrap">
+                  <p class="product-purchase__present-text">
+                    買取金額50%UP<br />
+                    ＋お買物クーポン500円分<br class="sp-none" />プレゼント！
+                  </p>
+                  <div class="product-purchase__present-img">
+                    <img src="/img/dummy/coupon.png" alt="ネットオフで使えるクーポン" />
+                  </div>
+                </div>
+                <div class="product-purchase__btn">
+                  <a href="/campaign/2250" class="product-btn">
+                    <span>買取を申し込む</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          
+          <div class="l-product__small-cta" id="floatingCartContainer">
+            <div class="l-product__small-cta-inner">
+              <p
+                class="l-product__small-cta-title"
+              >海に願いを風に祈りをそして君に誓いを/文庫</p>
+              
+              
+                <div class="l-product__small-cta-price">
+                  <span class="l-product__small-cta-price--em">220</span>
+                  <span>円</span>(税込)
+                </div>
+              
+              
+              
+              <div class="l-product__stock-note">
+                
+                  <span class="c-stock-icon --small">在庫あり</span>
+                  <span class="l-product__icon-text --small">1&#65374;2日以内に発送</span>
+                
+              </div>
+              <div class="l-product__small-cta-cart l-product__cart">
+                <div
+                ><button class="l-product__cart-btn product-btn --cart addCart" value=0012822282 data-target="js-addcart" data-cartinfo="true"><span>カートに入れる</span></button></div>
+                <div class="l-product__cart-favorite">
+                  <button class="c-favorite__button js-favorite-button" value="0012822282" data-target="js-addfav">お気に入り</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-product__container-bottom">
+        
+        
+          
+            <article class="l-top__section">
+              <h2>
+                <a
+                  class="c-heading--gray c-heading--gray--recommend"
+                  href="/cmdtyallsearch/?stock=1&amp;used=0&amp;cat=1002&amp;author=%E6%B1%90%E8%A6%8B%E5%A4%8F%E8%A1%9B"
+                >
+                  <span>同じ作家の商品</span>
+                  <span class="c-heading__link">もっと見る </span>
+                </a>
+              </h2>
+              <div class="splide c-splide__products js-productListSlideLarge">
+                <div class="splide__arrows">
+                  <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                  </button>
+                  <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                  </button>
+                </div>
+                <div class="splide__track c-splide__track-small">
+                  <ul class="splide__list">
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0014091869/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0014091869.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">わたしを変えた夏 ひと夏の出会いと別れ</span>
+                          
+                          <span class="c-splide__products-price">400円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0014054938/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0014054938.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">卒業 桜舞う春に、また君と</span>
+                          
+                          <span class="c-splide__products-price">1,150円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013833387/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013833387.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">傷だらけの僕らは、それでもいつか光をみつける</span>
+                          
+                          <span class="c-splide__products-price">400円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013845832/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013845832.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ないものねだりの君に光の花束を</span>
+                          
+                          <span class="c-splide__products-price">400円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013773710/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013773710.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">夜が明けたら、いちばんに君に会いにいく Another Stories</span>
+                          
+                          <span class="c-splide__products-price">330円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013608243/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013608243.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">君の傷痕が知りたい</span>
+                          
+                          <span class="c-splide__products-price">275円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013487425/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013487425.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">君はきっとまだ知らない</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013448774/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013448774.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">卒業 桜舞う春に、また君と</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013398268/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013398268.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">臆病な僕らは今日も震えながら</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013358920/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013358920.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">明日の世界が君に優しくありますように</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013239381/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013239381.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">さよなら嘘つき人魚姫</span>
+                          
+                          <span class="c-splide__products-price">330円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013228460/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013228460.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">あの星が降る丘で、君とまた出会いたい。</span>
+                          
+                          <span class="c-splide__products-price">550円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013213031/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013213031.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">だから私は、明日のきみを描く</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0013049783/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0013049783.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">君はきっとまだ知らない</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012964768/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012964768.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">明日の世界が君に優しくありますように</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012919767/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">僕の永遠を全部あげる</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012902822/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012902822.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">まだ見ぬ春も、君のとなりで笑っていたい</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012822282/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012822282.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">海に願いを風に祈りをそして君に誓いを</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012710583/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012710583.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">だから私は、明日のきみを描く</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  </ul>
+                </div>
+              </div>
+            </article>
+          
+        
+        
+
+        
+        
+          
+            <article class="l-top__section">
+              <h2>
+                <a
+                  class="c-heading--gray c-heading--gray--recommend"
+                  href="/recommend/?req_model=700&amp;req_device=pc&amp;showMore=on&amp;htextno=1000&amp;cat=1002&amp;cmdtycode=0012822282"
+                >
+                  <span>良く一緒に買われている商品</span>
+                  <span class="c-heading__link">もっと見る</span>
+                </a>
+              </h2>
+              <div class="splide c-splide__products js-productListSlideLarge">
+                <div class="splide__arrows">
+                  <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                  </button>
+                  <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                  </button>
+                </div>
+                <div class="splide__track c-splide__track-small">
+                  <ul class="splide__list">
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000496954/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000496954.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">【CD付】ビートマニアゴッタミックス公式ガイド</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000250070/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000250070.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">Official guide of Dungeon Master  II  Skullkeep</span>
+                            
+                            <span class="c-splide__products-price">1,260円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000952456/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000952456.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">tsugunai～つぐない～公式攻略ガイド</span>
+                            
+                            <span class="c-splide__products-price">165円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000462818/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/noimage_book_01.gif" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ザ・キング・オブ・ファイターズ&#39;98－最大多数の最大幸福－</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000776174/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000776174.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">姉妹物語 PRETTY5－安藤有里・水野さやか・水沢早紀・高原みゆき・かとう由梨写真集</span>
+                            
+                            <span class="c-splide__products-price">447円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000778234/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000778234.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ホースブレーカーマスターブック</span>
+                            
+                            <span class="c-splide__products-price">275円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0010698963/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0010698963.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">エルフレア</span>
+                            
+                            <span class="c-splide__products-price">165円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0001443125/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0001443125.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ポケモンコロシアム公式完全クリアガイド ［バーチャルトレーナーカード付属なし］</span>
+                            
+                            <span class="c-splide__products-price">400円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0010322584/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0010322584.jpg" alt="" />
+                              
+                            </div>
+                            
+                              <span
+                                class="c-splide__products-name"
+                              >『ファイブスター物語』の秘密＜2＞</span>
+                            
+                            
+                            <span class="c-splide__products-price">1,890円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0001465085/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0001465085.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">パワプロスーパー大全 コナミ公式パーフェクトシリーズ</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                  </ul>
+                </div>
+              </div>
+            </article>
+          
+        
+        
+
+        
+        
+          <article class="l-top__section">
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--recommend"
+                href="/recommend/?req_model=400&amp;req_device=pc&amp;showMore=on&amp;htextno=311&amp;cat=1002&amp;cmdtycode=0012822282"
+              >
+                この商品を見た人におすすめ
+                <span class="c-heading__link">もっと見る</span>
+              </a>
+            </h2>
+            <div class="splide c-splide__products js-productListSlideLarge">
+              <div class="splide__arrows">
+                <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                  <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                </button>
+                <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                  <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                </button>
+              </div>
+              <div class="splide__track c-splide__track-small">
+                <ul class="splide__list">
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000496954/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000496954.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">【CD付】ビートマニアゴッタミックス公式ガイド</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000250070/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000250070.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">Official guide of Dungeon Master  II  Skullkeep</span>
+                          
+                          <span class="c-splide__products-price">1,260円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000952456/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000952456.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">tsugunai～つぐない～公式攻略ガイド</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000462818/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ザ・キング・オブ・ファイターズ&#39;98－最大多数の最大幸福－</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000778234/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000778234.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ホースブレーカーマスターブック</span>
+                          
+                          <span class="c-splide__products-price">275円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010698963/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010698963.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">エルフレア</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001443125/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001443125.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ポケモンコロシアム公式完全クリアガイド ［バーチャルトレーナーカード付属なし］</span>
+                          
+                          <span class="c-splide__products-price">400円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010322584/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010322584.jpg" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >『ファイブスター物語』の秘密＜2＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">1,890円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001465085/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001465085.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">パワプロスーパー大全 コナミ公式パーフェクトシリーズ</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011433105/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">完全保存版 ビーストウォーズII 超図鑑</span>
+                          
+                          <span class="c-splide__products-price">630円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012371270/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012371270.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">【限定版 ドラマCD付】おジャ魔女どれみ19</span>
+                          
+                          <span class="c-splide__products-price">2,470円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000393390/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">スターフォックス64最終攻略読本</span>
+                          
+                          <span class="c-splide__products-price">550円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010335551/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >たまごっちカップまるわかりガイド 超ねんじゅーかいさいカードでおーえん！＜2006秋＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000124941/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >魯迅文集＜1＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011002061/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011002061.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">プロティノス「美について」</span>
+                          
+                          <span class="c-splide__products-price">710円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001309270/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">100％リッチー・コッツェン</span>
+                          
+                          <span class="c-splide__products-price">800円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001157814/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001157814.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">スターオーシャン－ブルースフィア－</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011948710/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011948710.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">アニメCGの現場 2014 3DCGを中心とした映像制作技術を徹底取材！</span>
+                          
+                          <span class="c-splide__products-price">550円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011103313/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011103313.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">世界の歴史（5）－ギリシアとローマ－</span>
+                          
+                          <span class="c-splide__products-price">990円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000202537/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">アイドル工学</span>
+                          
+                          <span class="c-splide__products-price">275円</span>
+                        </a>
+                      </li>
+                    
+                  
+                </ul>
+              </div>
+            </div>
+          </article>
+        
+
+        <article class="l-top__section">
+          <h2 class="c-heading--gray c-heading--gray--shipping">
+            
+              <span>
+                送料無料まであと
+                <span
+                  class="c-heading__em"
+                >1,800円</span>
+                ！
+              </span>
+            
+            
+          </h2>
+          <div class="l-product__shipping-inner">
+            <ul class="l-top__shipping-container">
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=1&amp;filter_price_max=110&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >110円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=111&amp;filter_price_max=165&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >165円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=166&amp;filter_price_max=220&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >220円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=221&amp;filter_price_max=275&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >275円</a
+                  >
+                
+              </li>
+              </th:block>
+            </ul>
+          </div>
+        </article>
+        <div class="pc-none">
+          <div id="shohinshosai-1m-banner" class="l-product__banner">
+            <!-- <img th:src="@{/img/dummy/banner_dummy3.png}" alt="タダ本会員バナー" /> -->
+          </div>
+        </div>
+      </div>
+      <div class="c-bottom-nav" id="js-searchModal">
+  <div class="c-bottom-nav__button-container">
+    <div class="c-bottom-nav__buttons">
+      <button type="" class="c-button--outline c-button-nav__clear-button" data-target="js-bottomNavSortForm">条件を解除する</button>
+      <button type="" class="c-button--next-green c-button-nav__search-button" disabled>検索する</button>
+    </div>
+
+    <nav>
+      <ul class="c-bottom-nav__list">
+        <li class="c-bottom-nav__nav">
+          <button type="button" class="c-bottom-nav__link js-toggle" data-target="js-searchModal" id="memory-ajax">
+            <span class="c-button-nav__search">商品を探す</span>
+            <span class="c-button-nav__close">閉じる</span>
+          </button>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/myfavorite/" class="c-bottom-nav__link">
+            
+            
+            お気に入り
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/incomingmaillist/" class="c-bottom-nav__link">
+            
+            
+            入荷・予約
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/browsinghistory/" class="c-bottom-nav__link">閲覧履歴</a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/purchase/cart/" class="c-bottom-nav__link">
+            
+            カート
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="c-bottom-nav__modal">
+    <ul class="c-bottom-nav__tab-list">
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="search-srot" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab2" />
+        <label for="search-srot" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--sort" onclick="handleTabClick('search', null, null)">商品を探す</label>
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="recommend" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab3" />
+        <label for="recommend" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--recommend" onclick="handleTabClick('taglist', null, '1002')"
+          >ネットオフの<br />おすすめ</label
+        >
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="memory" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab1" />
+        <label for="memory" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--memory" onclick="handleTabClick('memory', null, null)">思い出の作品</label>
+      </li>
+    </ul>
+
+    <!-- 思い出の作品 -->
+    <div class="c-bottom-nav__modal-inner">
+      <div class="c-bottom-nav__modal-contents c-bottom-nav__memory js-tabContent" id="js-bottomNavTab1">
+        <ul class="l-bottom-nav__select-container">
+          <!-- ジャンル表示ここから -->
+          <li class="c-bottom-nav__memory-category-list l-bottom-nav__category-list" id="memory-select-container-category">
+            <div class="c-select js-select" data-target="js-bottomNavCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavCategory"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavCategory">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="男性向けコミック" data-value="男性向けコミック" id="bottomNavCategory1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory1">男性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="女性向けコミック" data-value="女性向けコミック" id="bottomNavCategory2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory2">女性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="文庫小説・エッセイ" data-value="文庫小説・エッセイ" id="bottomNavCategory3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory3">文庫小説・エッセイ </label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="単行本小説・エッセイ" data-value="単行本小説・エッセイ" id="bottomNavCategory4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory4">単行本小説・エッセイ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ライトノベル" data-value="ライトノベル" id="bottomNavCategory5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory5">ライトノベル</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ゲーム" data-value="ゲーム" id="bottomNavCategory6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory6">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="映画・ドラマ" data-value="映画・ドラマ" id="bottomNavCategory7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory7">映画・ドラマ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="アニメ" data-value="アニメ" id="bottomNavCategory8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory8">アニメ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="邦楽" data-value="邦楽" id="bottomNavCategory9" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory9">邦楽</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- ジャンル表示ここまで -->
+          <!-- 年表示ここから -->
+          <li class="l-bottom-nav__generation-list" id="memory-select-container-generation">
+            <div class="c-select js-select" data-target="js-bottomNavGeneration" tabindex="0">
+              <div class="c-select__label js-selectLabel js-memory-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavGeneration"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavGeneration">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="2000年" data-value="2000" id="bottomNavGeneration1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration1">2000年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2005年" data-value="2005" id="bottomNavGeneration2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration2">2005年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2010年" data-value="2010" id="bottomNavGeneration3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration3">2010年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2015年" data-value="2015" id="bottomNavGeneration4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration4">2015年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2020年" data-value="2020" id="bottomNavGeneration5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration5">2020年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2021年" data-value="2021" id="bottomNavGeneration6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration6">2021年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2022年" data-value="2022" id="bottomNavGeneration7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration7">2022年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2023年" data-value="2023" id="bottomNavGeneration8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration8">2023年</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- 年表示ここまで -->
+          <li>
+            <div class="l-bottom-nav__btn-wrap">
+              <button type="submit" class="l-bottom-nav__submit-btn" id="memory-submit-btn"></button>
+            </div>
+          </li>
+        </ul>
+        <div class="l-bottom-nav__ranking-container">
+          
+          <ul id="memory-container" class="c-bottom-nav__ranking-list">
+            <li>
+              <p class="l-bottom-nav__ranking-text">
+                作品がありません<br />
+                他の条件で探してみましょう！
+              </p>
+            </li>
+          </ul>
+          
+          <!-- <ul class="c-bottom-nav__ranking-list">
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--1">1</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--2">2</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--3">3</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy3.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--4">4</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy4.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+          </ul> -->
+        </div>
+      </div>
+    </div>
+    <!-- 思い出の作品 -->
+
+    <form id="js-bottomNavSortForm" method="GET" action="/cmdtyallsearch/">
+      <!-- 絞り込み -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab2">
+        <div class="c-bottom-nav__input">
+          <input id="js-bottomNavWord" type="text" name="word" placeholder="キーワードを入力" />
+          <input type="hidden" id="hiddenCat" name="cat" value="" />
+          <input type="hidden" id="hiddenGenre" name="genre" value="" />
+          <button type="button" class="c-bottom_nav__input-button">
+            <img src="/img/search_simple_icon.svg" alt="search" />
+          </button>
+        </div>
+        <ul id="search-category">
+          
+          <!-- <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory1">古本・中古本</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory1">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks1" />
+                    <label for="js-bottomNavSortGenreBooks1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks2" />
+                    <label for="js-bottomNavSortGenreBooks2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks3" />
+                    <label for="js-bottomNavSortGenreBooks3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks4" />
+                    <label for="js-bottomNavSortGenreBooks4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown is-active" data-target="js-bottomNavSortCategory2">コミック</div>
+              <div class="c-bottom-nav__sort-genre-container" id="js-bottomNavSortCategory2">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics1" />
+                    <label for="js-bottomNavSortGenreComics1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics2" />
+                    <label for="js-bottomNavSortGenreComics2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics3" />
+                    <label for="js-bottomNavSortGenreComics3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics4" />
+                    <label for="js-bottomNavSortGenreComics4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory3">コミックセット</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory3">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet1" />
+                    <label for="js-bottomNavSortGenreComicsSet1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet2" />
+                    <label for="js-bottomNavSortGenreComicsSet2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet3" />
+                    <label for="js-bottomNavSortGenreComicsSet3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet4" />
+                    <label for="js-bottomNavSortGenreComicsSet4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet5" />
+                    <label for="js-bottomNavSortGenreComicsSet5">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory4">ゲーム</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory4">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames1" />
+                    <label for="js-bottomNavSortGenreGames1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames2" />
+                    <label for="js-bottomNavSortGenreGames2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames3" />
+                    <label for="js-bottomNavSortGenreGames3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames4" />
+                    <label for="js-bottomNavSortGenreGames4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory5">トレカ</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory5">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards1" />
+                    <label for="js-bottomNavSortGenreCards1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards2" />
+                    <label for="js-bottomNavSortGenreCards2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards3" />
+                    <label for="js-bottomNavSortGenreCards3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards4" />
+                    <label for="js-bottomNavSortGenreCards4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory6">DVD・Blu-ray</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory6">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD1" />
+                    <label for="js-bottomNavSortGenreDVD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD2" />
+                    <label for="js-bottomNavSortGenreDVD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD3" />
+                    <label for="js-bottomNavSortGenreDVD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD4" />
+                    <label for="js-bottomNavSortGenreDVD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory7">CD</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory7">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD1" />
+                    <label for="js-bottomNavSortGenreCD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD2" />
+                    <label for="js-bottomNavSortGenreCD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD3" />
+                    <label for="js-bottomNavSortGenreCD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD4" />
+                    <label for="js-bottomNavSortGenreCD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li> -->
+        </ul>
+      </div>
+      <!-- 絞り込み -->
+      <!-- ネットオフのおすすめ -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab3">
+        <p class="c-bottom-nav__tag-heading">人気タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavPopularCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavPopularCategory">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavPopularCategory">
+                <div>
+                  <input type="radio" name="popular-category" value="古本・中古本" data-value="1002" id="popular-category1" checked class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category1" id="popular-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミック" data-value="1001" id="popular-category2" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category2" id="popular-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミックセット" data-value="1011" id="popular-category3" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="ゲーム" data-value="5001" id="popular-category4" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="DVD・Blu-ray" data-value="7001" id="popular-category5" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="CD" data-value="3001" id="popular-category6" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="popularTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <p class="c-bottom-nav__tag-heading">新着タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavTagNewCategory1" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavTagNewCategory1">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavTagNewCategory1">
+                <div>
+                  <input type="radio" name="new-category" value="古本・中古本" data-value="1002" id="new-category1" checked class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミック" data-value="1001" id="new-category2" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミックセット" data-value="1011" id="new-category3" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="ゲーム" data-value="5001" id="new-category4" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="DVD・Blu-ray" data-value="7001" id="new-category5" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="CD" data-value="3001" id="new-category6" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="newTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+
+          <!-- <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown is-active" data-target="js-bottomNavTagCategory1">コミック</div>
+            <div class="c-bottom-nav__tag-container" id="js-bottomNavTagCategory1">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li>
+          <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown" data-target="js-bottomNavTagCategory2">コミックセット</div>
+            <div class="c-bottom-nav__tag-container c-bottom-nav__tag-container--close" id="js-bottomNavTagCategory2">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li> -->
+        </div>
+        <p class="c-bottom-nav__tag-heading">好きな商品の関連商品を探す</p>
+        <div class="l-bottom-nav__tag-search">
+          <p class="l-bottom-nav__lead-text c-link--blue">お好きな商品を含むタグの一覧を表示します</p>
+          <div class="c-bottom-nav__input" method="GET" action="/cmdtyallsearch/">
+            <input type="text" name="word" id="wordInput" placeholder="キーワードを入力" />
+            <button type="button" class="c-bottom_nav__input-button" onclick="handleButtonClick()">
+              <img src="/img/search_simple_icon.svg" alt="search" />
+            </button>
+          </div>
+          <div class="c-bottom-nav__tag-container">
+            <ul class="c-bottom-nav__tag-list" id="tagSearch">
+              <!-- <li>
+                <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                  <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                    <span>2023年映画化</span>
+                  </label>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+              </li> -->
+            </ul>
+            <div class="c-bottom-nav__tag-link-container">
+              <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+            </div>
+          </div>
+        </div>
+        <p class="c-bottom-nav__tag-heading">おすすめの特集から探す</p>
+        <ul class="l-bottom-nav__campaign-list">
+          <li class="l-bottom-nav__campaign-item">
+            <a href="https://www.netoff.co.jp/special/comicset.jsp">
+  <img src="/images/banner/main/serchmodal-1m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/ranking2023/">
+  <img src="/images/banner/main/serchmodal-2m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/bl_comic.jsp">
+  <img src="/images/banner/main/serchmodal-3m-banner.webp" alt="" />
+</a>
+
+          </li>
+        </ul>
+      </div>
+      <!-- ネットオフのおすすめ -->
+    </form>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/bottom-navigation.js" defer></script>
+  </div>
+</div>
+    </main>
+
+    <!-- /* 商品カセット用モーダル */ -->
+    <div>
+  <!-- /* 入荷メール&予約モーダル */ -->
+  <div class="c-modal" id="js-mailReserve">
+    <div class="c-modal__background js-toggle" data-target="js-mailReserve"></div>
+    <div class="c-modal__inner c-modal__inner--sort">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailReserve">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-search__modal">
+        <div class="l-search__modal__inner l-search__modal__inner--green">
+          <p class="l-search__modal-heading">商品が入荷したらメールでお知らせ</p>
+          <p class="l-search__modal-text">
+            取り置きではありませんので、<br />
+            すぐに売り切れになる場合もございます。
+          </p>
+          <button type="button" class="c-button--mail l-search__modal-button js-incomingMailButton" data-target="js-mailSetting">入荷メールを登録（無料）</button>
+          <p class="l-search__modal-text js-mailregistercount-text"></p>
+        </div>
+        <div class="l-search__modal__inner l-search__modal__inner--red js-reserve-region"></div>
+      </div>
+    </div>
+  </div>
+</div>
+    <div>
+  <!-- /* 商品詳細用カート追加モーダル */ -->
+  <div class="c-modal" id="js-addcart">
+    <div class="c-modal__background js-toggle" data-target="js-addcart"></div>
+    <div class="c-modal__inner">
+      <div class="c-modal__close-container">
+        <button type="button" class="c-modal__close js-toggle" data-target="js-addcart">
+          <img src="/img/close_black_icon.svg" alt="閉じる" />
+        </button>
+      </div>
+      <div class="c-modal__product-container--mx">
+        <p class="c-modal__cart-heading">以下の商品をカートに入れました</p>
+        <div
+          class="c-modal__cart-text"
+        >
+          <p class="c-modal__cart-name">海に願いを風に祈りをそして君に誓いを</p>
+          <p
+            class="c-modal__cart-info"
+          >古本・中古本／文芸／汐見夏衛</p>
+          <!-- /* カートに入っている値段の合計値で送料計算 */ -->
+          <p class="c-modal__cart-shipping">現在の送料：<span class="free js-shippingfee-text"></span></p>
+          <p class="c-modal__cart-shipping-free js-forfreeshipping">あと<span class="bold js-forfreeshipping-text"></span>で送料無料！</p>
+        </div>
+
+        <!-- /* タダ本会員の場合、カート内の対象商品数とあと〇点買えるのか表示する */ -->
+        
+
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addcart">閉じる</button>
+          <a type="button" class="c-button--cart js-toggle" data-target="js-addcart" href="/purchase/cart/">カートに進む</a>
+        </div>
+
+        
+          <p class="c-modal__product-list-heading">この商品を買った人はこちらも</p>
+          <ul class="c-modal__product-list-container">
+            <li>
+              
+                <a href="/detail/0000496954/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000496954.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >【ＣＤ付】ビートマニアゴッタミックス公式ガイド</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000250070/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000250070.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >Ｏｆｆｉｃｉａｌ　ｇｕｉｄｅ　ｏｆ　Ｄｕｎｇｅｏｎ　Ｍａｓｔｅｒ　 ＩＩ 　Ｓｋｕｌｌｋｅｅｐ</span>
+                  <span class="c-modal__product-price">1,260円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000952456/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000952456.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ｔｓｕｇｕｎａｉ～つぐない～公式攻略ガイド</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000462818/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ザ・キング・オブ・ファイターズ’９８－最大多数の最大幸福－</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000778234/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000778234.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ホースブレーカーマスターブック</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010698963/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010698963.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >エルフレア</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001443125/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001443125.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ポケモンコロシアム公式完全クリアガイド　［バーチャルトレーナーカード付属なし］</span>
+                  <span class="c-modal__product-price">400円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010322584/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010322584.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >『ファイブスター物語』の秘密＜２＞</span>
+                  <span class="c-modal__product-price">1,890円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001465085/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001465085.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >パワプロスーパー大全　コナミ公式パーフェクトシリーズ</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011433105/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >完全保存版　ビーストウォーズＩＩ　超図鑑</span>
+                  <span class="c-modal__product-price">630円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0012371270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0012371270.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >【限定版　ドラマＣＤ付】おジャ魔女どれみ１９</span>
+                  <span class="c-modal__product-price">2,470円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000393390/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >スターフォックス６４最終攻略読本</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010335551/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >たまごっちカップまるわかりガイド　超ねんじゅーかいさいカードでおーえん！＜２００６秋＞</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000124941/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >魯迅文集＜1＞</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011002061/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011002061.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >プロティノス「美について」</span>
+                  <span class="c-modal__product-price">710円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001309270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >１００％リッチー・コッツェン</span>
+                  <span class="c-modal__product-price">800円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001157814/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001157814.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >スターオーシャン－ブルースフィア－</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011948710/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011948710.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >アニメＣＧの現場　２０１４　３ＤＣＧを中心とした映像制作技術を徹底取材！</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011103313/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011103313.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >世界の歴史（５）－ギリシアとローマ－</span>
+                  <span class="c-modal__product-price">990円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000202537/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >アイドル工学</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+          </ul>
+        
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品詳細用入荷メールモーダル */ -->
+  <div class="c-modal" id="js-mailSetting">
+    <div class="c-modal__background js-toggle" data-target="js-mailSetting"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailSetting">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品を入荷メールに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-mailSetting">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り登録モーダル */ -->
+  <div class="c-modal" id="js-addfav">
+    <div class="c-modal__background js-toggle" data-target="js-addfav"></div>
+    <div class="c-modal__inner">
+      <div class="c-modal__close-container">
+        <button type="button" class="c-modal__close js-toggle" data-target="js-addfav">
+          <img src="/img/close_black_icon.svg" alt="閉じる" />
+        </button>
+      </div>
+      <div class="c-modal__product-container--mx">
+        <p>商品をお気に入りに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addfav">閉じる</button>
+        </div>
+        
+          <p class="c-modal__product-list-heading">この商品を買った人はこちらも</p>
+          <ul class="c-modal__product-list-container">
+            <li>
+              
+                <a href="/detail/0000496954/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000496954.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">【ＣＤ付】ビートマニアゴッタミックス公式ガイド</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000250070/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000250070.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">Ｏｆｆｉｃｉａｌ　ｇｕｉｄｅ　ｏｆ　Ｄｕｎｇｅｏｎ　Ｍａｓｔｅｒ　 ＩＩ 　Ｓｋｕｌｌｋｅｅｐ</span>
+                  <span class="c-modal__product-price">1,260円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000952456/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000952456.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ｔｓｕｇｕｎａｉ～つぐない～公式攻略ガイド</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000462818/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ザ・キング・オブ・ファイターズ’９８－最大多数の最大幸福－</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000778234/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000778234.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ホースブレーカーマスターブック</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010698963/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010698963.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">エルフレア</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001443125/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001443125.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ポケモンコロシアム公式完全クリアガイド　［バーチャルトレーナーカード付属なし］</span>
+                  <span class="c-modal__product-price">400円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010322584/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010322584.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">『ファイブスター物語』の秘密２</span>
+                  <span class="c-modal__product-price">1,890円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001465085/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001465085.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">パワプロスーパー大全　コナミ公式パーフェクトシリーズ</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011433105/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">完全保存版　ビーストウォーズＩＩ　超図鑑</span>
+                  <span class="c-modal__product-price">630円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0012371270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0012371270.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">【限定版　ドラマＣＤ付】おジャ魔女どれみ１９</span>
+                  <span class="c-modal__product-price">2,470円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000393390/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">スターフォックス６４最終攻略読本</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010335551/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">たまごっちカップまるわかりガイド　超ねんじゅーかいさいカードでおーえん！２００６秋</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000124941/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">魯迅文集1</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011002061/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011002061.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">プロティノス「美について」</span>
+                  <span class="c-modal__product-price">710円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001309270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">１００％リッチー・コッツェン</span>
+                  <span class="c-modal__product-price">800円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001157814/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001157814.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">スターオーシャン－ブルースフィア－</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011948710/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011948710.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">アニメＣＧの現場　２０１４　３ＤＣＧを中心とした映像制作技術を徹底取材！</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011103313/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011103313.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">世界の歴史（５）－ギリシアとローマ－</span>
+                  <span class="c-modal__product-price">990円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000202537/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">アイドル工学</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+          </ul>
+        
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り解除モーダル */ -->
+  <div class="c-modal" id="js-delfav">
+    <div class="c-modal__background js-toggle" data-target="js-delfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-delfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りから登録解除しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-delfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+    
+    <div>
+  
+  <div class="c-snackbar" id="js-addcart-ng">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-addcart-ng">閉じる</button>
+  </div>
+  <div class="c-snackbar" id="js-snack-common">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-snack-common">閉じる</button>
+  </div>
+  
+  
+  
+</div>
+
+    <input id="reserveLimit" type="hidden" value="9" />
+    <input id="reserveAmount" type="hidden" value="0" />
+    <input id="reserveKind" type="hidden" value="11" />
+    <input id="reserveNewFullFlg" type="hidden" value="0" />
+
+    <footer>
+      <div class="l-footer l-footer--sp">
+  <nav>
+    <ul>
+      <li>
+        <div class="l-footer__heading">カテゴリから探す</div>
+        <ul>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav1">古本・中古本</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav1">
+              <li>
+                <a href="/book/" class="l-footer__nav-list l-footer__nav-list--category-link">古本・中古本 TOP</a>
+              </li>
+              <li>
+                <a href="/book/10/" class="l-footer__nav-list l-footer__nav-list--category-link">文芸</a>
+              </li>
+              <li>
+                <a href="/book/11/" class="l-footer__nav-list l-footer__nav-list--category-link">ビジネス</a>
+              </li>
+              <li>
+                <a href="/book/12/" class="l-footer__nav-list l-footer__nav-list--category-link">政治・経済・法律</a>
+              </li>
+              <li>
+                <a href="/book/13/" class="l-footer__nav-list l-footer__nav-list--category-link">料理・趣味・児童</a>
+              </li>
+              <li>
+                <a href="/book/14/" class="l-footer__nav-list l-footer__nav-list--category-link">教育・福祉・資格</a>
+              </li>
+              <li>
+                <a href="/book/15/" class="l-footer__nav-list l-footer__nav-list--category-link">女性・生活・コンピュータ</a>
+              </li>
+              <li>
+                <a href="/book/16/" class="l-footer__nav-list l-footer__nav-list--category-link">産業・学術・歴史</a>
+              </li>
+              <li>
+                <a href="/book/17/" class="l-footer__nav-list l-footer__nav-list--category-link">スポーツ・健康・医療</a>
+              </li>
+              <li>
+                <a href="/book/18/" class="l-footer__nav-list l-footer__nav-list--category-link">写真集</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav2">コミック</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav2">
+              <li>
+                <a href="/comic/" class="l-footer__nav-list l-footer__nav-list--category-link">コミック TOP</a>
+              </li>
+              <li>
+                <a href="/comic/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comic/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comic/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <li>
+                <a href="/comic/26/" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li>
+              <li>
+                <a href="/comic/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav3">コミックセット</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav3">
+              <li>
+                <a href="/comicset/" class="l-footer__nav-list l-footer__nav-list--category-link">コミックセット TOP</a>
+              </li>
+              <li>
+                <a href="/comicset/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comicset/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <!-- <li>
+                <a href="/comicset/26" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li> -->
+              <li>
+                <a href="/comicset/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav4">ゲーム</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav4">
+              <li><a href="/game/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲーム TOP</a></li>
+              <li><a href="/game/80/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch2</a></li>
+              <li><a href="/game/75/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch</a></li>
+              <li><a href="/game/72/" class="l-footer__nav-list l-footer__nav-list--category-link">WiiU</a></li>
+              <li><a href="/game/67/" class="l-footer__nav-list l-footer__nav-list--category-link">Wii</a></li>
+              <li><a href="/game/70/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドー3DS</a></li>
+              <li><a href="/game/56/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドーDS</a></li>
+              <!-- <li><a href="/game/54/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/game/57/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=54&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=57&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li>
+              <li><a href="/game/77/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション5</a></li>
+              <li><a href="/game/73/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション4</a></li>
+              <li><a href="/game/66/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション3</a></li>
+              <li><a href="/game/51/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション2</a></li>
+              <li><a href="/game/52/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション</a></li>
+              <li><a href="/game/71/" class="l-footer__nav-list l-footer__nav-list--category-link">PS Vita</a></li>
+              <li><a href="/game/53/" class="l-footer__nav-list l-footer__nav-list--category-link">PSP</a></li>
+              <!-- <li><a href="/game/74/" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/game/65/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/game/61/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=74&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=65&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=61&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li>
+              <li><a href="/game/78/" class="l-footer__nav-list l-footer__nav-list--category-link">レトロゲーム</a></li>
+              <li><a href="/game/68/" class="l-footer__nav-list l-footer__nav-list--category-link">PCゲーム</a></li>
+            </ul>
+          </li>
+          <!-- <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav5">トレカ</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav5">
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">トレカ TOP</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ポケモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ワンピースカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">シャドウバース エボルブ</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">遊戯王</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">デジモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ヴァンガード</a>
+              </li>
+            </ul>
+          </li> -->
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav6">DVD・Blu-ray</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav6">
+              <li>
+                <a href="/dvd/" class="l-footer__nav-list l-footer__nav-list--category-link">DVD・Blu-ray TOP</a>
+              </li>
+              <li>
+                <a href="/dvd/41/" class="l-footer__nav-list l-footer__nav-list--category-link">洋画</a>
+              </li>
+              <li>
+                <a href="/dvd/42/" class="l-footer__nav-list l-footer__nav-list--category-link">邦画</a>
+              </li>
+              <li>
+                <a href="/dvd/43/" class="l-footer__nav-list l-footer__nav-list--category-link">ミュージック</a>
+              </li>
+              <li>
+                <a href="/dvd/44/" class="l-footer__nav-list l-footer__nav-list--category-link">アニメ</a>
+              </li>
+              <li>
+                <a href="/dvd/45/" class="l-footer__nav-list l-footer__nav-list--category-link">芸能・スポーツ・その他</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav7">CD</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav7">
+              <li>
+                <a href="/cd/" class="l-footer__nav-list l-footer__nav-list--category-link">CD TOP</a>
+              </li>
+              <li>
+                <a href="/cd/31/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャパニーズポップス</a>
+              </li>
+              <li>
+                <a href="/cd/32/" class="l-footer__nav-list l-footer__nav-list--category-link">海外のロック＆ポップス</a>
+              </li>
+              <li>
+                <a href="/cd/33/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャズ＆フュージョン</a>
+              </li>
+              <li>
+                <a href="/cd/34/" class="l-footer__nav-list l-footer__nav-list--category-link">イージーリスニング</a>
+              </li>
+              <li>
+                <a href="/cd/35/" class="l-footer__nav-list l-footer__nav-list--category-link">クラシック</a>
+              </li>
+              <li>
+                <a href="/cd/36/" class="l-footer__nav-list l-footer__nav-list--category-link">サウンドトラック</a>
+              </li>
+              <li>
+                <a href="/cd/37/" class="l-footer__nav-list l-footer__nav-list--category-link">童謡・民謡・その他</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__heading">おすすめから探す</div>
+        <ul>
+          <li><a class="l-footer__nav-list" href="/special/">キャンペーン・特集</a></li>
+          <li><a class="l-footer__nav-list" href="/timesale/">タイムセール</a></li>
+          <!-- <li>
+            <a th:with="result = ${T(www.netoff.co.jp.web.config.UrlConfig).TAG_DETAILS_URL}" th:href="${result + '?tagid=19821&cat=7001'}">110円～！激安人気作ランキング</a>
+          </li>
+          <li>
+            <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}" class="l-footer__nav-list"
+              >あなたにおすすめの商品</a
+            >
+          </li> -->
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__purchase">
+          <span>ラクして売るなら</span>
+          ネットオフ宅配買取
+        </div>
+        <ul>
+          <li>
+            <a href="/sell/book/" class="l-footer__nav-list l-footer__nav-list--accent">本＆ゲーム買取コース</a>
+          </li>
+          <li>
+            <a href="/sell/book/book/" class="l-footer__nav-list">古本・中古本買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/comic/" class="l-footer__nav-list">コミック買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/" class="l-footer__nav-list">ゲームソフト買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/body.jsp" class="l-footer__nav-list">ゲーム機本体買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/dvd/" class="l-footer__nav-list">DVD・Blu-ray買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/cd/" class="l-footer__nav-list">CD買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/moetaku/" class="l-footer__nav-list l-footer__nav-list--accent">ホビー・フィギュア買取 もえたく！</a>
+          </li>
+          <li>
+            <a href="/figure/" class="l-footer__nav-list">フィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/kuji_prize/" class="l-footer__nav-list">プライズフィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/plamodel/" class="l-footer__nav-list">プラモデル買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/" class="l-footer__nav-list">トレカ買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/pokemon_card/" class="l-footer__nav-list">ポケモンカード買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/onepiece/" class="l-footer__nav-list">ワンピースカード買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/sell/general/" class="l-footer__nav-list l-footer__nav-list--accent">ブランド＆総合買取コース</a>
+          </li>
+          <li>
+            <a href="/kaden/" class="l-footer__nav-list">家電買取</a>
+          </li>
+          <li>
+            <a href="/kaden/camera/" class="l-footer__nav-list">カメラ買取</a>
+          </li>
+          <li>
+            <a href="/kaden/gamingpc/" class="l-footer__nav-list">ゲーミングPC買取</a>
+          </li>
+          <li>
+            <a href="/kaden/deditalstationery/lcdtablet/" class="l-footer__nav-list">液タブ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/" class="l-footer__nav-list">スマホ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/smartphone/iphone/" class="l-footer__nav-list">iPhone買取</a>
+          </li>
+          <li>
+            <a href="/clothes/" class="l-footer__nav-list">洋服・古着買取</a>
+          </li>
+          <li>
+            <a href="/brand/brand/" class="l-footer__nav-list">ブランド買取</a>
+          </li>
+          <li>
+            <a href="/brand/jewelry/" class="l-footer__nav-list">金・プラチナ買取</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  ﻿<aside id="footer-1m-banner" class="l-footer__banner">
+  <!-- バナー -->
+  <a href="https://page.line.me/trp3160p?oat__id=699595&openQrModal=true" target="0">
+    <img src="/images/banner/main/footer-1m-banner.webp" alt="LINE 公式アカウント"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?category=1643943081566646275" target="0">
+    <img src="/images/banner/main/footer-2m-banner.webp" alt="もえたく 社員募集"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?jobType=PART&category=1644999205883056129" target="0">
+    <img src="/images/banner/main/footer-3m-banner.webp" alt="ネットオフ アルバイト募集"/>
+  </a>
+</aside>
+
+
+  <nav>
+    <ul>
+      <li>
+        <a href="/kaitori-navi/" class="l-footer__nav-list">買取ナビTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/" class="l-footer__nav-list">VODチョイスTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/ebook/" class="l-footer__nav-list">おすすめ電子書籍</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/vod/" class="l-footer__nav-list">おすすめ動画配信サービス</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/" class="l-footer__nav-list">インターネット比較TOP</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/pocket-wifi/" class="l-footer__nav-list">おすすめポケット型WiFi</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/wimax-comparison/" class="l-footer__nav-list">おすすめWiMAX</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/hikari-recommendation/" class="l-footer__nav-list">おすすめ光回線</a>
+      </li>
+      <li>
+        <a href="https://fortune.netoff.co.jp/" class="l-footer__nav-list">占ナビTOP</a>
+      </li>
+      <li>
+        <a href="/notification/noticelist/" class="l-footer__nav-list">お知らせ</a>
+      </li>
+      <li>
+        <a href="/guide/beginner.jsp" class="l-footer__nav-list">初めての方へ</a>
+      </li>
+      <li>
+        <a href="/guide/" class="l-footer__nav-list">ヘルプ・お問い合わせ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__info-container">
+    <img
+      src="/img/icon_mothers_sp.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+    <div class="l-footer__button-container">
+      
+        <!-- 未ログイン -->
+        <a href="/sell/" class="l-footer__button l-footer__button--purchase l-footer__button--flex">宅配買取</a>
+        <a
+          class="l-footer__button l-footer__button--sign l-footer__button--flex"
+          href="/registration/enterinformation/"
+          >新規会員登録</a
+        >
+      
+      
+    </div>
+    <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+  </div>
+
+  <nav>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/company/">会社案内</a>
+      </li>
+      <li>
+        <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+      </li>
+    </ul>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/guide/netoff.jsp">品質ポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/">プライバシーポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/#policy02">個人情報保護方針</a>
+      </li>
+      <li>
+        <a href="/customer/">お客様への対応について</a>
+      </li>
+      <li>
+        <a href="/use/">ご利用規約</a>
+      </li>
+      <li>
+        <a href="/settlement/">資金決済法に基づく表示</a>
+      </li>
+      <li>
+        <a href="/sitemap/">サイトマップ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__netoff">
+    <span>ネットオフ株式会社</span>
+    古物商許可番号 542782100600 愛知県公安委員会許可<br />
+    <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+  </div>
+
+  <small class="l-footer__copyright">Copyright &copy; NETOFF,inc.</small>
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="b1fc02dc-957b-459a-a7a6-de5a016d402e"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+  <!-- <div class="c-modal" id="js-footerLogout">
+    <div
+      class="c-modal__background js-toggle"
+      data-target="js-footerLogout"
+    ></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button
+          type="button"
+          class="c-button--black js-toggle"
+          data-target="js-footerLogout"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          class="c-button--black-outline"
+          onClick="window.location.href='/'"
+        >
+          ログアウト
+        </button>
+      </div>
+    </div>
+  </div> -->
+</div>
+      <div class="l-footer l-footer--pc">
+  <div class="l-footer__about">
+    <img
+      src="/img/icon_mothers_pc.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+  </div>
+
+  <div class="l-footer__container">
+    <div class="l-footer__scroll-top">
+      <button type="button" onclick="window.scrollTo({ top: 0 })">▲ このページの先頭に戻る</button>
+    </div>
+    <div class="l-footer__inner">
+      <nav class="l-footer__main-nav-container">
+        <ul>
+          <li>
+            <div class="l-footer__heading">カテゴリから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/book/">古本・中古本</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comic/">コミック</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comicset/">コミックセット</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/game/">ゲーム</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">トレカ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/dvd/">DVD・Blu-ray</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/cd/">CD</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">おすすめから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/special/">キャンペーン・特集</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/timesale/">タイムセール</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">110円～！激安人気作ランキング</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}">あなたにおすすめの商品</a>
+              </li> -->
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">マイページ</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/mypagetop/">マイページトップ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/myfavorite/">お気に入り</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/incomingmaillist/">入荷メール</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/customerinfochange/">お客様情報</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ご利用サポート・その他</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/guide/">ヘルプ・お問い合わせ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="/landingpage/shippingfeeexplanation">送料について</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/guide/beginner.jsp">はじめての方へ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a th:with="noticelist = ${T(www.netoff.co.jp.web.config.UrlConfig).NOTIFICATION_NOTICELIST_URL}" th:href="${noticelist}">お知らせ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/kaitori-navi/">買取ナビ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://vod.netoff.co.jp/">VODチョイス</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://internet.netoff.co.jp/">インターネット比較</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://fortune.netoff.co.jp/">占ナビ</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ネットオフ宅配買取</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/sell/book/">本・ゲーム買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/moetaku/tcg/pokemon_card/">トレカ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/figure/">フィギュア買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mobilebuy/">スマホ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/kaden/">家電買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/sell/general/">ブランド・総合買取</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+
+      <nav class="l-footer__site-nav-container">
+        <ul class="l-footer__site-nav">
+          <li>
+            <a href="/company/">会社案内</a>
+          </li>
+          <li>
+            <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+          </li>
+          <li>
+            <a href="/guide/netoff.jsp">品質ポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/">プライバシーポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/#policy02">個人情報保護方針</a>
+          </li>
+          <li>
+            <a href="/customer/">お客様への対応について</a>
+          </li>
+          <li>
+            <a href="/use/">ご利用規約</a>
+          </li>
+          <li>
+            <a href="/settlement/">資金決済法に基づく表示</a>
+          </li>
+          <li>
+            <a href="/sitemap/">サイトマップ</a>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="l-footer__info-container">
+        <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+      </div>
+
+      <div class="l-footer__netoff-container">
+        <div>
+          <a href="/" class="l-footer__logo">
+            <picture>
+              <source srcset="/img/logo-netoff.webp" type="image/webp" />
+              <img src="/img/logo-netoff.png" alt="NET OFF" />
+            </picture>
+          </a>
+          <div class="l-footer__netoff l-footer__netoff--main">
+            <span>ネットオフ株式会社</span>
+            古物商許可番号 542782100600 愛知県公安委員会許可<br />
+            <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+          </div>
+        </div>
+
+        <small class="l-footer__copyright l-footer__copyright--main">Copyright &copy; NETOFF,inc.</small>
+      </div>
+    </div>
+  </div>
+</div>
+    </footer>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js"></script>
+    <script src="/js/common.js" defer></script>
+    <script src="/js/product.js" defer></script>
+    <script src="/js/cart.js" defer></script>
+    <script>
+      // お気に入りリスト
+      const favCmdtyCodes = null;
+    </script>
+
+    
+      
+  
+    <script>
+      const MD5Email = null;
+    </script>
+    <script src="/js/criteo.js" defer></script>
+  
+
+    
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', () => {
+        let doc = document;
+        let head = doc.getElementsByTagName('head')[0];
+        let tagEmail = '';
+        tagEmail = '<%= MD5Email %>';
+        let criteoScript = document.createElement('script');
+        criteoScript.type = 'text/javascript';
+        criteoScript.src = '//static.criteo.net/js/ld/ld.js';
+        criteoScript.async = true;
+        head.appendChild(criteoScript);
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.innerHTML = 'window.criteo_q = window.criteo_q || [];';
+        script.innerHTML += 'window.criteo_q.push(';
+        script.innerHTML += '{ event: "setAccount", account: 85067 },';
+        script.innerHTML += '{ event: "setSiteType", type: "d" },';
+        if (tagEmail != '') {
+          script.innerHTML += '{ event: "setEmail", email:"' + tagEmail + '" },';
+        }
+        script.innerHTML += '{ event: "viewHome" }';
+        script.innerHTML += ');';
+        head.appendChild(script);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/used_book/netoff_product_oos.html
+++ b/tests/fixtures/used_book/netoff_product_oos.html
@@ -1,0 +1,4085 @@
+<!doctype html>
+<html lang="ja">
+  <head><script>(function(w,i,g){w[g]=w[g]||[];if(typeof w[g].push=='function')w[g].push(i)})(window,'GTM-NPLRPRC','google_tags_first_party');</script><script>(function(w,d,s,l){w[l]=w[l]||[];(function(){w[l].push(arguments);})('set','developer_id.dYzZiYj',true);var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='/27ns5f/';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>
+    <meta charset="UTF-8" />
+    <meta name="_csrf" content="425c53ff-190d-4a7b-862b-15fb22381ff8" />
+    <meta name="_csrf_header" content="X-XSRF-TOKEN" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    
+      <title>狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－(文庫): 中古 | 月本ナシオ | 古本の通販ならネットオフ</title>
+      <link rel="canonical" href="https://www.netoff.co.jp/detail/0011631528/" />
+      
+        <meta name="description" content="「狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－(文庫): 中古 | 月本ナシオ」の購入はネットオフ！楽天ポイント・Vポイントが貯まる・使える！" />
+      
+      <meta name="robots" content="index,follow" />
+      <meta property="og:locale" content="ja_JP" />
+      <meta property="og:title" content="狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－(文庫): 中古 | 月本ナシオ | 古本の通販ならネットオフ" />
+      <meta property="og:site_name" content="ネット中古書店 ネットオフ (本・CD・DVD・ゲームソフトの買取・販売)" />
+      <meta property="og:url" content="https://www.netoff.co.jp/detail/0011631528/" />
+      <meta property="og:type" content="article" />
+      <meta property="og:image" content="https://www.netoff.co.jp/images/logo_fb.gif" />
+      <meta property="og:description" content="「狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－(文庫): 中古 | 月本ナシオ」の購入はネットオフ！楽天ポイント・Vポイントが貯まる・使える！" />
+      <meta property="fb:app_id" content="193098350747639" />
+    
+
+    
+      
+        <script type="application/ld+json">
+          /*<![CDATA[*/
+          {
+            "@context": "http://schema.org",
+            "@type": "Product",
+            "name": "狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－",
+            "image": "/ebimage/cmdty/0011631528.jpg",
+            "sku": "0011631528",
+            "gtin13": "9784041004098",
+            "url": "https://www.netoff.co.jp/detail/0011631528/",
+            "brand": {
+              "@type": "Brand",
+              "name": "月本ナシオ"
+            },
+            "offers": {
+              "@type": "Offer",
+              "price": "110",
+              "priceCurrency": "JPY",
+              "url": "https://www.netoff.co.jp/detail/0011631528/"
+            }
+          }
+          /*]]>*/
+        </script>
+      
+    
+    <link rel="shortcut icon" href="/netoff.ico" />
+    <link rel="apple-touch-icon" href="/netoff.png" />
+    <link href="/css/style.css" rel="stylesheet" />
+    <script src="/js/googleTag.js" defer></script>
+    
+      
+        
+          
+  
+    
+      
+        
+          <script>
+            /*<![CDATA[*/
+            const user = {
+              zeta_id: "",
+              zeta_gender: "",
+              zeta_age: "",
+            };
+            /*]]>*/
+            const zetaParam = {};
+            const zetaScriptUrl = "https:\/\/renet.search.zetacx.net\/static\/zd\/zd_register_prd.js";
+          </script>
+          <script src="/js/zetatags.js" defer></script>
+        
+      
+    
+  
+
+        
+      
+    
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NPLRPRC" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header>
+      <div id="js-headerContainer" class="l-header__container is-fixed">
+        <div class="l-header-common" id="js-header">
+  <!-- <div class="l-header-common__info">
+    <p>古本・CD・DVD・ゲームの買取・中古通販ならネットオフ！！</p>
+    <nav class="l-header-common__info-nav">
+      <ul>
+        <li class="l-header-common__info-nav-list">
+          <a href="/sell/">段ボール無料</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="forfirsttime = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FORFIRSTTIMEUSER_URL}" th:href="${forfirsttime}">はじめての方へ</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="faq = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FAQ_URL}" th:href="${faq}">よくある質問</a>
+        </li>
+      </ul>
+    </nav>
+  </div> -->
+  <div class="l-header">
+    <button type="button" class="l-header__nav-button js-toggle" data-target="js-headerSideNav">
+      <span></span>
+    </button>
+    <div class="l-header__logo">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <a href="/sell/" class="l-header__purchase-button">買取</a>
+    
+  </div>
+  <div class="l-header-common__inner js-topNavigation">
+    <div class="l-header__logo is-sp-hidden">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <form class="c-search-input__form l-header-common__search" id="js-searchList" name="search_form">
+      <input type="hidden" name="cat" value="" />
+      <div class="l-header-common__search-select">
+        <div class="c-select c-select--black js-select" data-target="js-headerSelect" tabindex="0">
+          <div
+            class="c-select__label js-selectLabel js-init-category"
+            data-target="js-headerSelect"
+            data-value="すべてのカテゴリー"
+          ></div>
+          <div class="c-select__option-container" id="js-headerSelect">
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="すべてのカテゴリー"
+                data-value=""
+                id="headerSearchCategory1"
+                class="js-selectOption js-searchSelect" checked="checked"
+              />
+              <label class="c-select__options" for="headerSearchCategory1">すべてのカテゴリー</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="古本・中古本"
+                data-value="1002"
+                id="headerSearchCategory4"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory4">古本・中古本</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミック"
+                data-value="1001"
+                id="headerSearchCategory2"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory2">コミック</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミックセット"
+                data-value="1011"
+                id="headerSearchCategory3"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory3">コミックセット</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="ゲーム"
+                data-value="5001"
+                id="headerSearchCategory7"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory7">ゲーム</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="DVD・Blu-ray"
+                data-value="7001"
+                id="headerSearchCategory6"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory6">DVD・Blu-ray</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="CD"
+                data-value="3001"
+                id="headerSearchCategory5"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory5">CD</label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-header-common__search-input">
+        <button type="submit" formaction="/cmdtyallsearch/" class="l-header-common__search-button">
+          <img src="/img/search_black_icon.svg" width="20px" alt="検索" />
+        </button>
+        <div class="c-search-input">
+          <div class="c-search-input__input-container">
+            <input
+              type="text"
+              placeholder="キーワードを入力"
+              class="c-search-input__input js-searchForm"
+              name="word"
+              data-target="js-searchList"
+              value=""
+              autocomplete="off"
+            />
+            <button type="button" class="c-search-input__delete-input js-searchInputDelete">
+              <img src="/img/close_gray_icon.svg" alt="削除" />
+            </button>
+          </div>
+          <button type="submit" formaction="/cmdtyallsearch/" class="c-search-input__button">
+            <img src="/img/search_icon.svg" alt="検索" />
+          </button>
+          <button type="button" class="c-search-input__cancel js-toggle" data-target="js-searchList">キャンセル</button>
+        </div>
+        <!-- <input type="text" placeholder="キーワードを入力" class="js-searchForm" data-target="js-searchList" /> -->
+        <div class="c-search-input__list-inner js-searchResult">
+          <div class="c-search-input__list-top">
+            <span class="c-search-input__history-text">検索履歴</span>
+            <span class="c-search-input__result-text">検索候補</span>
+            <button type="button" class="c-search-input__delete-all-button js-suggest-delete-all">全件削除</button>
+          </div>
+          <ul class="js-suggestList">
+            <!--
+            <li class="c-search-input__list">
+              <a th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}" th:href="@{__${url}__}">
+                <span class="c-search-input__list-text js-searchHistory">鬼滅の刃</span>
+              </a>
+              <button type="button" class="c-search-input__delete-button">
+                <img th:src="@{/img/close_gray_icon.svg}" alt="削除" />
+              </button>
+            </li>
+            -->
+          </ul>
+        </div>
+      </div>
+
+      <div class="c-search-input__list-container">
+        <div class="c-search-input__background"></div>
+      </div>
+    </form>
+    <script>
+      document.querySelectorAll('.js-searchSelect').forEach((option) => {
+        option.addEventListener('change', function () {
+          if (this.checked) {
+            const selectedValue = this.getAttribute('data-value');
+            document.querySelector('input[type="hidden"][name="cat"]').value = selectedValue;
+          }
+        });
+      });
+    </script>
+    <nav
+      class="l-header-common__nav-container"
+    >
+      <ul class="l-header-common__nav">
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/mypagetop/">
+            
+            ログイン
+          </a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/incomingmaillist/">入荷メール</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/reservation/reservationlist/">予約履歴</a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/myfavorite/">お気に入り</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/browsinghistory/">閲覧履歴</a>
+        </li>
+        <li class="l-header-common__nav-list js-cartcontainer">
+          <a href="/purchase/cart/">カート</a>
+          
+        </li>
+        <li style="display: block" class="l-header-common__nav-list l-header-common__nav-list--purchase">
+          <a href="/sell/">買取</a>
+        </li>
+        <li style="display: none" class="l-header-common__nav-list l-header-common__nav-list--cards">
+          <a href="/moetaku/tcg/pokemon_card/">トレカ<br />買取</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="l-header__nav" id="js-headerSideNav">
+    <div class="l-header__nav-back js-toggle" data-target="js-headerSideNav"></div>
+    <nav class="l-header__nav-container">
+      <!-- 未ログイン -->
+      <div>
+        <div class="l-header__login-container">
+          <div class="l-header__login-buttons">
+            <!--  
+            <a class="c-button--main" href="{$root}login/login">ログイン</a>
+            <a class="c-button--outline" th:href="@{/registration/enterinformation}">新規会員登録</a>
+          -->
+            <a class="c-button--main" href="/login/">ログイン</a>
+            <a class="c-button--outline" href="/registration/enterinformation/"
+              >新規会員登録</a
+            >
+          </div>
+          <div>
+            <!--
+            <a class="c-link--icon l-header__guide-link" href="">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" th:href="/login/resetpassword">パスワードを忘れた方はこちら</a>
+            -->
+            <a class="c-link--icon l-header__guide-link" href="/guide/beginner.jsp">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" href="/resetpassword/"
+              >パスワードを忘れた方はこちら</a
+            >
+          </div>
+        </div>
+      </div>
+      <!-- ログイン済み -->
+      
+      <ul>
+        <li class="l-header__nav-title">カテゴリ</li>
+        <li class="l-header__nav-list">
+          <a href="/book/">古本・中古本</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comic/">コミック</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comicset/">コミックセット</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/game/">ゲーム</a>
+        </li>
+        <!-- <li class="l-header__nav-list">
+          <a href="">トレカ</a>
+        </li> -->
+        <li class="l-header__nav-list">
+          <a href="/dvd/">DVD・Blu-ray</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/cd/">CD</a>
+        </li>
+      </ul>
+      <ul>
+        <li class="l-header__nav-title">買取</li>
+        <li class="l-header__nav-list">
+          <a href="/sell/">ネットオフ宅配買取TOP</a>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav1">本＆ゲーム買取</button>
+          <ul id="js-headerNav1">
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">本＆ゲーム買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/comic/">コミック・漫画</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">古本・中古本</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/campaign/game/">ゲームソフト</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/game/body.jsp">ゲーム機本体</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/dvd/">DVD・Blu-ray</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/cd/">CD</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav2">トレカ買取</button>
+          <ul id="js-headerNav2">
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/">トレカ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/pokemon_card/">ポケモンカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/onepiece/">ワンピースカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/yugioh/">遊戯王カード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/shadowverse-evolve/">シャドウバース エボルヴ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav4">フィギュア買取</button>
+          <ul id="js-headerNav4">
+            <li class="l-header__nav-list">
+              <a href="/figure/">フィギュア買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/kuji_prize/">プライズフィギュア</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/plamodel/">プラモデル</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gunpla/">ガンプラ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav3">スマホ買取</button>
+          <ul id="js-headerNav3">
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/">スマホ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/iphone/">iPhone</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/xperia/">Xperia</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/tablet/ipad/">iPad</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/galaxy/">Galaxy</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/googlepixel/">Google Pixel</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav5">家電買取</button>
+          <ul id="js-headerNav5">
+            <li class="l-header__nav-list">
+              <a href="/kaden/">家電買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/camera/">カメラ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/headphone/">ヘッドホン</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/gamingpc/">ゲーミングPC</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/wellness/">美容家電</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/deditalstationery/pentablet/">ペンタブレット</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/smartwatch/">スマートウォッチ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav6">ブランド総合買取</button>
+          <ul id="js-headerNav6">
+            <li class="l-header__nav-list">
+              <a href="/sell/general/">ブランド総合買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/brand/">ブランド品</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/clothes/">洋服・古着</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/jewelry/">金・プラチナ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gakki/">楽器</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/hikkigu/">万年筆</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <!-- <div class="c-modal" id="js-logout">
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="button" class="c-button--black-outline" onClick="window.location.href='/'">ログアウト</button>
+      </div>
+    </div>
+  </div> -->
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="425c53ff-190d-4a7b-862b-15fb22381ff8"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+</div>
+        <nav class="c-top-nav is-fixed js-topNavigation">
+  <ul class="c-top-nav__list">
+    <li class="is-active">
+      <a href="/book/" class="c-top-nav__link">古本・中古本</a>
+    </li>
+    <li>
+      <a href="/comic/" class="c-top-nav__link">コミック</a>
+    </li>
+    <li>
+      <a href="/comicset/" class="c-top-nav__link">コミックセット</a>
+    </li>
+    <li>
+      <a href="/game/" class="c-top-nav__link">ゲーム</a>
+    </li>
+    <!-- <li>
+      <a href="" class="c-top-nav__link">トレカ</a>
+    </li> -->
+    <li>
+      <a href="/dvd/" class="c-top-nav__link">DVD・Blu-ray</a>
+    </li>
+    <li>
+      <a href="/cd/" class="c-top-nav__link">CD</a>
+    </li>
+  </ul>
+</nav>
+      </div>
+    </header>
+
+    <main class="l-product l-common__header--tab l-common__footer">
+      <!-- パンくず -->
+      
+        <div
+        >
+          <ol class="c-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem" data-breadcrumb="home">
+    <a href="/" class="c-link--blue c-breadcrumbs__label" itemprop="item"><span itemprop="name">ネットオフTOP</span></a>
+    <meta itemprop="position" content="1" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    <a href="/book/" class="c-link--blue c-breadcrumbs__label" itemprop="item">
+      <span itemprop="name">古本・中古本</span>
+    </a>
+    
+    <meta itemprop="position" content="2" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    <a href="/book/10" class="c-link--blue c-breadcrumbs__label" itemprop="item">
+      <span itemprop="name">文芸</span>
+    </a>
+    
+    <meta itemprop="position" content="3" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    
+    <span class="c-breadcrumbs__label" itemprop="name">狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－/文庫</span>
+    <meta itemprop="position" content="4" />
+  </li>
+</ol>
+        </div>
+      
+
+      <div class="l-product__container">
+        <div class="l-product__main">
+          <section class="l-product__main--flex product-inner" id="js-cartTarget">
+            <div class="l-product__main-image sp-none">
+              <div class="l-product__image">
+                
+                  <img src="/ebimage/cmdty/0011631528.jpg" alt="" class="l-product__image-book" />
+                
+              </div>
+              
+            </div>
+            <div class="l-product__main-textwrap">
+              <div class="">
+                
+                <div class="l-product__category-wrap">
+                  
+                    <span class="c-category --green">古本・中古本</span>
+                  
+                  
+                    <span class="c-category">メール便対象</span>
+                  
+                  
+                    <span class="c-category">タダ本対象</span>
+                  
+                  
+                  
+                </div>
+                <h1
+                  class="l-product__main-title"
+                >狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－/文庫</h1>
+                <div class="l-product__author-wrap">
+                  <span class="l-product__author">作家</span>
+                  <span class="l-product__author-mark">：</span>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;word=%E6%9C%88%E6%9C%AC%E3%83%8A%E3%82%B7%E3%82%AA"
+                  >
+                    <span class="l-product__author-name">月本ナシオ</span>
+                  </a>
+                </div>
+              </div>
+              <div class="l-product__main-image pc-none">
+                <div class="l-product__image">
+                  
+                    <img src="/ebimage/cmdty/0011631528.jpg" alt="" class="l-product__image-book" />
+                  
+                </div>
+              </div>
+              
+              
+              
+              
+              
+              
+                <div class="l-product__price product-price">
+                  
+                  
+                    <label for="normal_price" class="product-price__normal c-product-price__btn js-changeColor selected">
+                      <input type="radio" id="normal_price" name="price_option" checked />
+                      <div class="product-price__normal-left">
+                        <p>通常価格</p>
+                        <div class="product-price__normal-text-wrap">
+                          <span class="product-price__normal-num">110</span>
+                          <span class="product-price__normal-mark">円</span>
+                          <span class="product-price__normal-tax">（税込）</span>
+                        </div>
+                      </div>
+                      
+                        <div class="product-price__normal-right">
+                          <span>定価より</span><span><span class="--red">435円</span>おトク！</span>
+                        </div>
+                      
+                    </label>
+                  
+                  
+                  
+                    <label for="tadabon_price" class="product-price__tadabon c-product-price__btn js-changeColor js-textChange" data-target="js-freeContainer">
+                      <input type="radio" id="tadabon_price" name="price_option" />
+                      <div class="product-price__tadabon-origin" id="js-textReturn2">
+                        <div class="product-price__tadabon-text-wrap">
+                          <div class="product-price__tadabon-img">
+                            <img src="/img/tadabon.png" alt="タダ本" />
+                          </div>
+                          <p class="product-price__tadabon-text">
+                            登録で<span class="--red"><span class="--em">0</span>円</span>で購入できます
+                          </p>
+                        </div>
+                      </div>
+                      <div class="product-price__tadabon-change" id="js-textChange2" style="visibility: hidden">
+                        <div class="product-price__tadabon-text-wrap">
+                          <div class="product-price__tadabon-img">
+                            <img src="/img/tadabon.png" alt="タダ本" />
+                          </div>
+                          <p class="product-price__tadabon-text --large">特典</p>
+                        </div>
+                      </div>
+                      <div class="product-price__tadabon-list-inner" id="js-freeContainer">
+                        <ul class="product-price__tadabon-list">
+                          <li class="product-price__tadabon-list-item">
+                            <p class="product-price__tadabon-list-text">タダ本登録で110円の本が毎月5冊無料</p>
+                          </li>
+                          <li class="product-price__tadabon-list-item">
+                            <p class="product-price__tadabon-list-text">すぐに使える200円分クーポン進呈</p>
+                          </li>
+                          <li class="product-price__tadabon-list-item">
+                            <p class="product-price__tadabon-list-text">メール便送料も月1回無料</p>
+                          </li>
+                        </ul>
+                        <button
+                          onclick="location.href=&#39;/tadabon2/&#39;"
+                          class="product-price__tadabon-btn"
+                        >
+                          1カ月無料で始める
+                        </button>
+                      </div>
+                    </label>
+                  
+                  
+                  
+                </div>
+              
+              <div class="l-product__coupon product-coupon sp-none">
+                <a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+
+
+<!--
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大10倍！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大500ポイントプレゼント！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント100ポイントプレゼント！</span>
+</a>
+</div>
+
+<a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+-->
+
+              </div>
+            </div>
+          </section>
+          <section class="product-inner pc-none">
+            <div class="l-product__cart --bg">
+              <div
+              ><button class="c-button--mail--outline c-cassette__button--wrap js-toggle js-incomingMailCount" data-target="js-mailReserve" value=0011631528>入荷メール＆予約</button></div>
+              <div class="c-favorite__button--wrap">
+                <button class="c-favorite__button js-favorite-button" value="0011631528" data-target="js-addfav"></button>
+              </div>
+            </div>
+            <div class="l-product__cart --bg --fixed" id="js-cartSticky">
+              <div
+              ><button class="c-button--mail--outline c-cassette__button--wrap js-toggle js-incomingMailCount" data-target="js-mailReserve" value=0011631528>入荷メール＆予約</button></div>
+              <div class="c-favorite__button--wrap">
+                <button class="c-favorite__button js-favorite-button" value="0011631528" data-target="js-addfav"></button>
+              </div>
+            </div>
+
+            <div class="l-product__stock">
+              <div class="l-product__stock--flex">
+                
+                
+              </div>
+              <div class="l-product__stock-bottom">
+                
+                <a href="/price_down/" class="l-product__condition-mail">
+                  値下げしたらメールでお知らせ！
+                </a>
+              </div>
+            </div>
+          </section>
+          <div class="l-product__coupon product-coupon pc-none">
+            <a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+
+
+<!--
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大10倍！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント最大500ポイントプレゼント！</span>
+</a>
+</div>
+
+
+<div style="margin-top:-2px;">
+<a href="/campaign/rakuten_campaign/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/images/icon_point.png" alt="ポイント" />
+  </div>
+  <span>楽天ID連携&エントリーして購入で<br>楽天ポイント100ポイントプレゼント！</span>
+</a>
+</div>
+
+<a href="/shopping_coupon/" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/coupon_green_icon.svg" alt="クーポン" />
+  </div>
+  <span>お得！10点以上まとめ買いで5％OFFクーポン！！</span>
+</a>
+
+
+<a href="https://line.me/ti/p/%40trp3160p" rel="nofollow" target="tos" class="product-coupon__link">
+  <div class="product-coupon__img">
+    <img src="/img/line_icon.svg" alt="LINE" />
+  </div>
+  <span>友だち追加で100円引き</span>
+</a>
+
+-->
+
+          </div>
+          
+          
+
+          
+          
+
+          <section class="l-product__section l-product__detail">
+            <h2 class="c-heading--gray l-product__heading--cursor js-pullDown" data-target="js-newDetailContainer">この商品の詳細</h2>
+            <div class="l-product__detail-inner" id="js-newDetailContainer">
+              <dl class="l-product__detail-list detail-list">
+                <dt>出版社</dt>
+                <dd>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;maker=%E8%A7%92%E5%B7%9D%E6%9B%B8%E5%BA%97"
+                    class="detail-list__link"
+                  >角川書店</a>
+                </dd>
+                <dt>出版社シリーズ</dt>
+                <dd>
+                  <a
+                    href="/cmdtyallsearch/?cat=1002&amp;word=%E8%A7%92%E5%B7%9D%E3%83%93%E3%83%BC%E3%83%B3%E3%82%BA%E6%96%87%E5%BA%AB"
+                    class="detail-list__link"
+                  >角川ビーンズ文庫</a>
+                </dd>
+                <dt>ISBN</dt>
+                <dd>9784041004098</dd>
+                <dt>サイズ</dt>
+                <dd>文庫</dd>
+                <dt>発売年月日</dt>
+                <dd
+                >2012年07月30日</dd>
+              </dl>
+            </div>
+            <section class="l-product__section l-product__detail"></section>
+          </section>
+          
+          
+            <article class="l-top__section">
+              <h2 class="c-heading--gray c-heading--gray--tag l-product__heading--cursor js-pullDown" data-target="js-newTagContainer">この商品の関連タグ</h2>
+              <div class="l-product__tag-list-container is-active" id="js-newTagContainer">
+                <ul class="l-product__tag-list" id="js-newTagList">
+                  
+                    <li>
+                      <a href="/tag?tagid=5444" class="c-tag">中世から近代まで！【女性向け】和風ライトノベル</a>
+                    </li>
+                  
+                </ul>
+                <button type="button" class="l-product__intro-more js-doublePullDownCommon" data-target="js-newTagList" data-height="106">
+                  <span>詳しく見る＋</span>
+                  <span>閉じる－</span>
+                </button>
+              </div>
+            </article>
+          
+          
+          <div class="l-product__purchase product-purchase pc-none">
+            <div class="product-purchase__container">
+              <p
+                class="product-purchase__title"
+              >狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－/文庫</p>
+              
+              <div class="">
+                <p class="product-purchase__present-text">
+                  買取金額50%UP<br />
+                  ＋お買物クーポン500円分プレゼント！
+                </p>
+                <div class="product-purchase__present-img">
+                  <img src="/img/dummy/coupon.png" alt="ネットオフで使えるクーポン" />
+                </div>
+              </div>
+              <div class="product-purchase__btn">
+                <a href="/campaign/2250" class="product-btn">
+                  <span>買取を申し込む</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <article class="l-product__section">
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--faq"
+                href="/qa/"
+              >
+                よくある質問
+                <span class="c-heading__link"> もっと見る </span>
+              </a>
+            </h2>
+            <div class="l-product__faq-inner">
+              <ul class="l-product__faq-container">
+                <li>
+                  <a href="/guide/goods.jsp#01" class="c-tag--faq"> 品質 </a>
+                </li>
+                <li>
+                  <a href="/guide/qa.jsp#q1_29" class="c-tag--faq"> 送料 </a>
+                </li>
+                <li>
+                  <a
+                    href="/guide/delivery.jsp#01"
+                    class="c-tag--faq"
+                  >
+                    お届け日数
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="/guide/qa.jsp#q1_36"
+                    class="c-tag--faq"
+                  >
+                    返品・交換
+                  </a>
+                </li>
+                <li>
+                  <a href="/qa/#q1_5" class="c-tag--faq">
+                    サイズ
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </article>
+          <article class="l-top__section"></article>
+        </div>
+
+        <div class="l-product__cta sp-none">
+          <section class="l-product__cta-inner">
+            <div class="l-product__cart-wrap">
+              <div class="l-product__cart" id="cart-button">
+                
+                  <div
+                  ><button class="c-button--mail--outline c-cassette__button--wrap js-toggle js-incomingMailCount" data-target="js-mailReserve" value=0011631528>入荷メール＆予約</button></div>
+                  <div class="l-product__cart-favorite">
+                    <button class="c-favorite__button js-favorite-button" value="0011631528" data-target="js-addfav">お気に入り</button>
+                  </div>
+                
+              </div>
+            </div>
+            <div class="l-product__stock">
+              
+              
+              <div class="l-product__stock-bottom">
+                <!-- <a
+                  th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}"
+                  th:href="@{__${url}__(__(${bookDetail.getCtgrycode() != null ? 'cat=${bookDetail.getCtgrycode()}':','})__,__(${bookDetail.getTitle() != null ? 'word=${bookDetail.getTitle()}':','})__,__(${ebCmdtyDetail.getAuthor() != null ? 'author=${ebCmdtyDetail.getAuthor()}':','})__,__(${bookDetail.getBooksize() != null ? 'size=${bookDetail.getBooksize()}':','})__,__(${bookDetail.getPublisher() != null ? 'maker=${bookDetail.getPublisher()}':','})__)}"
+                  class="c-arrow-link"
+                >
+                  <span class="c-arrow-link__icon"></span>
+                  <span class="c-arrow-link__text">︎他の巻を探す</span>
+                </a> -->
+                
+                <a href="/price_down/" class="l-product__condition-mail">
+                  値下げしたらメールでお知らせ！
+                </a>
+              </div>
+            </div>
+            <div class="l-product__purchase product-purchase">
+              <div class="product-purchase__container">
+                <p
+                  class="product-purchase__title"
+                >狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－/文庫</p>
+                
+                <div class="product-purchase__present-wrap">
+                  <p class="product-purchase__present-text">
+                    買取金額50%UP<br />
+                    ＋お買物クーポン500円分<br class="sp-none" />プレゼント！
+                  </p>
+                  <div class="product-purchase__present-img">
+                    <img src="/img/dummy/coupon.png" alt="ネットオフで使えるクーポン" />
+                  </div>
+                </div>
+                <div class="product-purchase__btn">
+                  <a href="/campaign/2250" class="product-btn">
+                    <span>買取を申し込む</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          
+          <div class="l-product__small-cta" id="floatingCartContainer">
+            <div class="l-product__small-cta-inner">
+              <p
+                class="l-product__small-cta-title"
+              >狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－/文庫</p>
+              
+              
+                <div class="l-product__small-cta-price">
+                  <span class="l-product__small-cta-price--em">110</span>
+                  <span>円</span>(税込)
+                </div>
+              
+              
+              
+              <div class="l-product__stock-note">
+                
+              </div>
+              <div class="l-product__small-cta-cart l-product__cart">
+                <div
+                ><button class="c-button--mail--outline c-cassette__button--wrap js-toggle js-incomingMailCount" data-target="js-mailReserve" value=0011631528>入荷メール＆予約</button></div>
+                <div class="l-product__cart-favorite">
+                  <button class="c-favorite__button js-favorite-button" value="0011631528" data-target="js-addfav">お気に入り</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-product__container-bottom">
+        
+        
+          
+            <article class="l-top__section">
+              <h2>
+                <a
+                  class="c-heading--gray c-heading--gray--recommend"
+                  href="/cmdtyallsearch/?stock=1&amp;used=0&amp;cat=1002&amp;author=%E6%9C%88%E6%9C%AC%E3%83%8A%E3%82%B7%E3%82%AA"
+                >
+                  <span>同じ作家の商品</span>
+                  <span class="c-heading__link">もっと見る </span>
+                </a>
+              </h2>
+              <div class="splide c-splide__products js-productListSlideLarge">
+                <div class="splide__arrows">
+                  <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                  </button>
+                  <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                  </button>
+                </div>
+                <div class="splide__track c-splide__track-small">
+                  <ul class="splide__list">
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012196504/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012196504.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">冥恋十王帳 彼岸の彼方も縁次第</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012025857/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012025857.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">星紋の神聖士官</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011945017/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011945017.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">王子様と鉄壁の聖獣医 お迎えは、間違いだらけ！</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011699572/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011699572.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">狐と乙女の大正恋日記－貴女に、永遠に憑いていきます？－</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011568561/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011568561.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">狐と乙女の大正恋日記</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011489592/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011489592.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">タロットは愛を結ぶ フォーチュン・オブ・ウィッカ6</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011465475/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011465475.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">タロットは運命をためす</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010446525/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010446525.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">花に降る千の翼－光の戴冠－</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010314729/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010314729.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">花に降る千の翼－暁色のささやき－</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010245416/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010245416.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">花に降る千の翼－蝶の渡る海－</span>
+                          
+                          <span class="c-splide__products-price">110円</span>
+                        </a>
+                      </li>
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010191217/" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010191217.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">花に降る千の翼－碧翠の剣－</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  </ul>
+                </div>
+              </div>
+            </article>
+          
+        
+        
+
+        
+        
+          
+            <article class="l-top__section">
+              <h2>
+                <a
+                  class="c-heading--gray c-heading--gray--recommend"
+                  href="/recommend/?req_model=700&amp;req_device=pc&amp;showMore=on&amp;htextno=1000&amp;cat=1002&amp;cmdtycode=0011631528"
+                >
+                  <span>良く一緒に買われている商品</span>
+                  <span class="c-heading__link">もっと見る</span>
+                </a>
+              </h2>
+              <div class="splide c-splide__products js-productListSlideLarge">
+                <div class="splide__arrows">
+                  <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                  </button>
+                  <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                    <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                  </button>
+                </div>
+                <div class="splide__track c-splide__track-small">
+                  <ul class="splide__list">
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000496954/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000496954.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">【CD付】ビートマニアゴッタミックス公式ガイド</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000250070/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000250070.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">Official guide of Dungeon Master  II  Skullkeep</span>
+                            
+                            <span class="c-splide__products-price">1,260円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000952456/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000952456.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">tsugunai～つぐない～公式攻略ガイド</span>
+                            
+                            <span class="c-splide__products-price">165円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000462818/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/noimage_book_01.gif" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ザ・キング・オブ・ファイターズ&#39;98－最大多数の最大幸福－</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000776174/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000776174.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">姉妹物語 PRETTY5－安藤有里・水野さやか・水沢早紀・高原みゆき・かとう由梨写真集</span>
+                            
+                            <span class="c-splide__products-price">447円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0000778234/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0000778234.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ホースブレーカーマスターブック</span>
+                            
+                            <span class="c-splide__products-price">275円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0010698963/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0010698963.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">エルフレア</span>
+                            
+                            <span class="c-splide__products-price">165円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0001443125/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0001443125.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">ポケモンコロシアム公式完全クリアガイド ［バーチャルトレーナーカード付属なし］</span>
+                            
+                            <span class="c-splide__products-price">400円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0010322584/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0010322584.jpg" alt="" />
+                              
+                            </div>
+                            
+                              <span
+                                class="c-splide__products-name"
+                              >『ファイブスター物語』の秘密＜2＞</span>
+                            
+                            
+                            <span class="c-splide__products-price">1,890円</span>
+                          </a>
+                        </li>
+                      
+                    
+                      
+                        <li class="splide__slide">
+                          <a href="/detail/0001465085/?model=700" class="c-splide__products-list">
+                            <div class="c-splide__products-img">
+                              
+                                <img src="/ebimage/cmdty/0001465085.jpg" alt="" />
+                              
+                            </div>
+                            
+                            
+                              <span class="c-splide__products-name">パワプロスーパー大全 コナミ公式パーフェクトシリーズ</span>
+                            
+                            <span class="c-splide__products-price">220円</span>
+                          </a>
+                        </li>
+                      
+                    
+                  </ul>
+                </div>
+              </div>
+            </article>
+          
+        
+        
+
+        
+        
+          <article class="l-top__section">
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--recommend"
+                href="/recommend/?req_model=400&amp;req_device=pc&amp;showMore=on&amp;htextno=311&amp;cat=1002&amp;cmdtycode=0011631528"
+              >
+                この商品を見た人におすすめ
+                <span class="c-heading__link">もっと見る</span>
+              </a>
+            </h2>
+            <div class="splide c-splide__products js-productListSlideLarge">
+              <div class="splide__arrows">
+                <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+                  <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+                </button>
+                <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+                  <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+                </button>
+              </div>
+              <div class="splide__track c-splide__track-small">
+                <ul class="splide__list">
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000496954/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000496954.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">【CD付】ビートマニアゴッタミックス公式ガイド</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000250070/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000250070.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">Official guide of Dungeon Master  II  Skullkeep</span>
+                          
+                          <span class="c-splide__products-price">1,260円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000952456/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000952456.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">tsugunai～つぐない～公式攻略ガイド</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000462818/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ザ・キング・オブ・ファイターズ&#39;98－最大多数の最大幸福－</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000778234/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0000778234.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ホースブレーカーマスターブック</span>
+                          
+                          <span class="c-splide__products-price">275円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010698963/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010698963.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">エルフレア</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001443125/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001443125.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">ポケモンコロシアム公式完全クリアガイド ［バーチャルトレーナーカード付属なし］</span>
+                          
+                          <span class="c-splide__products-price">400円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010322584/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0010322584.jpg" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >『ファイブスター物語』の秘密＜2＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">1,890円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001465085/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001465085.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">パワプロスーパー大全 コナミ公式パーフェクトシリーズ</span>
+                          
+                          <span class="c-splide__products-price">220円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011433105/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">完全保存版 ビーストウォーズII 超図鑑</span>
+                          
+                          <span class="c-splide__products-price">630円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0012371270/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0012371270.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">【限定版 ドラマCD付】おジャ魔女どれみ19</span>
+                          
+                          <span class="c-splide__products-price">2,470円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000393390/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">スターフォックス64最終攻略読本</span>
+                          
+                          <span class="c-splide__products-price">550円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0010335551/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >たまごっちカップまるわかりガイド 超ねんじゅーかいさいカードでおーえん！＜2006秋＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000124941/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                            <span
+                              class="c-splide__products-name"
+                            >魯迅文集＜1＞</span>
+                          
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011002061/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011002061.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">プロティノス「美について」</span>
+                          
+                          <span class="c-splide__products-price">710円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001309270/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">100％リッチー・コッツェン</span>
+                          
+                          <span class="c-splide__products-price">800円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0001157814/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0001157814.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">スターオーシャン－ブルースフィア－</span>
+                          
+                          <span class="c-splide__products-price">165円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011948710/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011948710.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">アニメCGの現場 2014 3DCGを中心とした映像制作技術を徹底取材！</span>
+                          
+                          <span class="c-splide__products-price">550円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0011103313/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/cmdty/0011103313.jpg" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">世界の歴史（5）－ギリシアとローマ－</span>
+                          
+                          <span class="c-splide__products-price">990円</span>
+                        </a>
+                      </li>
+                    
+                  
+                    
+                      <li class="splide__slide">
+                        <a href="/detail/0000202537/?model=400" class="c-splide__products-list">
+                          <div class="c-splide__products-img">
+                            
+                              <img src="/ebimage/noimage_book_01.gif" alt="" />
+                            
+                          </div>
+                          
+                          
+                            <span class="c-splide__products-name">アイドル工学</span>
+                          
+                          <span class="c-splide__products-price">275円</span>
+                        </a>
+                      </li>
+                    
+                  
+                </ul>
+              </div>
+            </div>
+          </article>
+        
+
+        <article class="l-top__section">
+          <h2 class="c-heading--gray c-heading--gray--shipping">
+            
+              <span>
+                送料無料まであと
+                <span
+                  class="c-heading__em"
+                >1,800円</span>
+                ！
+              </span>
+            
+            
+          </h2>
+          <div class="l-product__shipping-inner">
+            <ul class="l-top__shipping-container">
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=1&amp;filter_price_max=110&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >110円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=111&amp;filter_price_max=165&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >165円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=166&amp;filter_price_max=220&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >220円</a
+                  >
+                
+              </li>
+              <li class="c-top__shipping-item">
+                
+                  <a
+                    href="/cmdtyallsearch/?filter_price_min=221&amp;filter_price_max=275&amp;used=0&amp;stock=1&amp;&amp;filter_category=1002&amp;filter_genre=1002_10"
+                    class="c-tag--shipping"
+                    >275円</a
+                  >
+                
+              </li>
+              </th:block>
+            </ul>
+          </div>
+        </article>
+        <div class="pc-none">
+          <div id="shohinshosai-1m-banner" class="l-product__banner">
+            <!-- <img th:src="@{/img/dummy/banner_dummy3.png}" alt="タダ本会員バナー" /> -->
+          </div>
+        </div>
+      </div>
+      <div class="c-bottom-nav" id="js-searchModal">
+  <div class="c-bottom-nav__button-container">
+    <div class="c-bottom-nav__buttons">
+      <button type="" class="c-button--outline c-button-nav__clear-button" data-target="js-bottomNavSortForm">条件を解除する</button>
+      <button type="" class="c-button--next-green c-button-nav__search-button" disabled>検索する</button>
+    </div>
+
+    <nav>
+      <ul class="c-bottom-nav__list">
+        <li class="c-bottom-nav__nav">
+          <button type="button" class="c-bottom-nav__link js-toggle" data-target="js-searchModal" id="memory-ajax">
+            <span class="c-button-nav__search">商品を探す</span>
+            <span class="c-button-nav__close">閉じる</span>
+          </button>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/myfavorite/" class="c-bottom-nav__link">
+            
+            
+            お気に入り
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/incomingmaillist/" class="c-bottom-nav__link">
+            
+            
+            入荷・予約
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/browsinghistory/" class="c-bottom-nav__link">閲覧履歴</a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/purchase/cart/" class="c-bottom-nav__link">
+            
+            カート
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="c-bottom-nav__modal">
+    <ul class="c-bottom-nav__tab-list">
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="search-srot" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab2" />
+        <label for="search-srot" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--sort" onclick="handleTabClick('search', null, null)">商品を探す</label>
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="recommend" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab3" />
+        <label for="recommend" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--recommend" onclick="handleTabClick('taglist', null, '1002')"
+          >ネットオフの<br />おすすめ</label
+        >
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="memory" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab1" />
+        <label for="memory" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--memory" onclick="handleTabClick('memory', null, null)">思い出の作品</label>
+      </li>
+    </ul>
+
+    <!-- 思い出の作品 -->
+    <div class="c-bottom-nav__modal-inner">
+      <div class="c-bottom-nav__modal-contents c-bottom-nav__memory js-tabContent" id="js-bottomNavTab1">
+        <ul class="l-bottom-nav__select-container">
+          <!-- ジャンル表示ここから -->
+          <li class="c-bottom-nav__memory-category-list l-bottom-nav__category-list" id="memory-select-container-category">
+            <div class="c-select js-select" data-target="js-bottomNavCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavCategory"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavCategory">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="男性向けコミック" data-value="男性向けコミック" id="bottomNavCategory1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory1">男性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="女性向けコミック" data-value="女性向けコミック" id="bottomNavCategory2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory2">女性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="文庫小説・エッセイ" data-value="文庫小説・エッセイ" id="bottomNavCategory3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory3">文庫小説・エッセイ </label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="単行本小説・エッセイ" data-value="単行本小説・エッセイ" id="bottomNavCategory4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory4">単行本小説・エッセイ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ライトノベル" data-value="ライトノベル" id="bottomNavCategory5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory5">ライトノベル</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ゲーム" data-value="ゲーム" id="bottomNavCategory6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory6">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="映画・ドラマ" data-value="映画・ドラマ" id="bottomNavCategory7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory7">映画・ドラマ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="アニメ" data-value="アニメ" id="bottomNavCategory8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory8">アニメ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="邦楽" data-value="邦楽" id="bottomNavCategory9" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory9">邦楽</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- ジャンル表示ここまで -->
+          <!-- 年表示ここから -->
+          <li class="l-bottom-nav__generation-list" id="memory-select-container-generation">
+            <div class="c-select js-select" data-target="js-bottomNavGeneration" tabindex="0">
+              <div class="c-select__label js-selectLabel js-memory-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavGeneration"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavGeneration">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="2000年" data-value="2000" id="bottomNavGeneration1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration1">2000年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2005年" data-value="2005" id="bottomNavGeneration2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration2">2005年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2010年" data-value="2010" id="bottomNavGeneration3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration3">2010年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2015年" data-value="2015" id="bottomNavGeneration4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration4">2015年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2020年" data-value="2020" id="bottomNavGeneration5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration5">2020年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2021年" data-value="2021" id="bottomNavGeneration6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration6">2021年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2022年" data-value="2022" id="bottomNavGeneration7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration7">2022年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2023年" data-value="2023" id="bottomNavGeneration8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration8">2023年</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- 年表示ここまで -->
+          <li>
+            <div class="l-bottom-nav__btn-wrap">
+              <button type="submit" class="l-bottom-nav__submit-btn" id="memory-submit-btn"></button>
+            </div>
+          </li>
+        </ul>
+        <div class="l-bottom-nav__ranking-container">
+          
+          <ul id="memory-container" class="c-bottom-nav__ranking-list">
+            <li>
+              <p class="l-bottom-nav__ranking-text">
+                作品がありません<br />
+                他の条件で探してみましょう！
+              </p>
+            </li>
+          </ul>
+          
+          <!-- <ul class="c-bottom-nav__ranking-list">
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--1">1</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--2">2</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--3">3</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy3.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--4">4</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy4.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+          </ul> -->
+        </div>
+      </div>
+    </div>
+    <!-- 思い出の作品 -->
+
+    <form id="js-bottomNavSortForm" method="GET" action="/cmdtyallsearch/">
+      <!-- 絞り込み -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab2">
+        <div class="c-bottom-nav__input">
+          <input id="js-bottomNavWord" type="text" name="word" placeholder="キーワードを入力" />
+          <input type="hidden" id="hiddenCat" name="cat" value="" />
+          <input type="hidden" id="hiddenGenre" name="genre" value="" />
+          <button type="button" class="c-bottom_nav__input-button">
+            <img src="/img/search_simple_icon.svg" alt="search" />
+          </button>
+        </div>
+        <ul id="search-category">
+          
+          <!-- <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory1">古本・中古本</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory1">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks1" />
+                    <label for="js-bottomNavSortGenreBooks1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks2" />
+                    <label for="js-bottomNavSortGenreBooks2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks3" />
+                    <label for="js-bottomNavSortGenreBooks3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks4" />
+                    <label for="js-bottomNavSortGenreBooks4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown is-active" data-target="js-bottomNavSortCategory2">コミック</div>
+              <div class="c-bottom-nav__sort-genre-container" id="js-bottomNavSortCategory2">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics1" />
+                    <label for="js-bottomNavSortGenreComics1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics2" />
+                    <label for="js-bottomNavSortGenreComics2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics3" />
+                    <label for="js-bottomNavSortGenreComics3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics4" />
+                    <label for="js-bottomNavSortGenreComics4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory3">コミックセット</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory3">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet1" />
+                    <label for="js-bottomNavSortGenreComicsSet1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet2" />
+                    <label for="js-bottomNavSortGenreComicsSet2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet3" />
+                    <label for="js-bottomNavSortGenreComicsSet3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet4" />
+                    <label for="js-bottomNavSortGenreComicsSet4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet5" />
+                    <label for="js-bottomNavSortGenreComicsSet5">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory4">ゲーム</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory4">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames1" />
+                    <label for="js-bottomNavSortGenreGames1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames2" />
+                    <label for="js-bottomNavSortGenreGames2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames3" />
+                    <label for="js-bottomNavSortGenreGames3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames4" />
+                    <label for="js-bottomNavSortGenreGames4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory5">トレカ</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory5">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards1" />
+                    <label for="js-bottomNavSortGenreCards1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards2" />
+                    <label for="js-bottomNavSortGenreCards2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards3" />
+                    <label for="js-bottomNavSortGenreCards3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards4" />
+                    <label for="js-bottomNavSortGenreCards4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory6">DVD・Blu-ray</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory6">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD1" />
+                    <label for="js-bottomNavSortGenreDVD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD2" />
+                    <label for="js-bottomNavSortGenreDVD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD3" />
+                    <label for="js-bottomNavSortGenreDVD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD4" />
+                    <label for="js-bottomNavSortGenreDVD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory7">CD</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory7">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD1" />
+                    <label for="js-bottomNavSortGenreCD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD2" />
+                    <label for="js-bottomNavSortGenreCD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD3" />
+                    <label for="js-bottomNavSortGenreCD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD4" />
+                    <label for="js-bottomNavSortGenreCD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li> -->
+        </ul>
+      </div>
+      <!-- 絞り込み -->
+      <!-- ネットオフのおすすめ -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab3">
+        <p class="c-bottom-nav__tag-heading">人気タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavPopularCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavPopularCategory">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavPopularCategory">
+                <div>
+                  <input type="radio" name="popular-category" value="古本・中古本" data-value="1002" id="popular-category1" checked class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category1" id="popular-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミック" data-value="1001" id="popular-category2" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category2" id="popular-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミックセット" data-value="1011" id="popular-category3" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="ゲーム" data-value="5001" id="popular-category4" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="DVD・Blu-ray" data-value="7001" id="popular-category5" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="CD" data-value="3001" id="popular-category6" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="popularTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <p class="c-bottom-nav__tag-heading">新着タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavTagNewCategory1" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavTagNewCategory1">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavTagNewCategory1">
+                <div>
+                  <input type="radio" name="new-category" value="古本・中古本" data-value="1002" id="new-category1" checked class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミック" data-value="1001" id="new-category2" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミックセット" data-value="1011" id="new-category3" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="ゲーム" data-value="5001" id="new-category4" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="DVD・Blu-ray" data-value="7001" id="new-category5" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="CD" data-value="3001" id="new-category6" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="newTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+
+          <!-- <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown is-active" data-target="js-bottomNavTagCategory1">コミック</div>
+            <div class="c-bottom-nav__tag-container" id="js-bottomNavTagCategory1">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li>
+          <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown" data-target="js-bottomNavTagCategory2">コミックセット</div>
+            <div class="c-bottom-nav__tag-container c-bottom-nav__tag-container--close" id="js-bottomNavTagCategory2">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li> -->
+        </div>
+        <p class="c-bottom-nav__tag-heading">好きな商品の関連商品を探す</p>
+        <div class="l-bottom-nav__tag-search">
+          <p class="l-bottom-nav__lead-text c-link--blue">お好きな商品を含むタグの一覧を表示します</p>
+          <div class="c-bottom-nav__input" method="GET" action="/cmdtyallsearch/">
+            <input type="text" name="word" id="wordInput" placeholder="キーワードを入力" />
+            <button type="button" class="c-bottom_nav__input-button" onclick="handleButtonClick()">
+              <img src="/img/search_simple_icon.svg" alt="search" />
+            </button>
+          </div>
+          <div class="c-bottom-nav__tag-container">
+            <ul class="c-bottom-nav__tag-list" id="tagSearch">
+              <!-- <li>
+                <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                  <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                    <span>2023年映画化</span>
+                  </label>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+              </li> -->
+            </ul>
+            <div class="c-bottom-nav__tag-link-container">
+              <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+            </div>
+          </div>
+        </div>
+        <p class="c-bottom-nav__tag-heading">おすすめの特集から探す</p>
+        <ul class="l-bottom-nav__campaign-list">
+          <li class="l-bottom-nav__campaign-item">
+            <a href="https://www.netoff.co.jp/special/comicset.jsp">
+  <img src="/images/banner/main/serchmodal-1m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/ranking2023/">
+  <img src="/images/banner/main/serchmodal-2m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/bl_comic.jsp">
+  <img src="/images/banner/main/serchmodal-3m-banner.webp" alt="" />
+</a>
+
+          </li>
+        </ul>
+      </div>
+      <!-- ネットオフのおすすめ -->
+    </form>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/bottom-navigation.js" defer></script>
+  </div>
+</div>
+    </main>
+
+    <!-- /* 商品カセット用モーダル */ -->
+    <div>
+  <!-- /* 入荷メール&予約モーダル */ -->
+  <div class="c-modal" id="js-mailReserve">
+    <div class="c-modal__background js-toggle" data-target="js-mailReserve"></div>
+    <div class="c-modal__inner c-modal__inner--sort">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailReserve">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-search__modal">
+        <div class="l-search__modal__inner l-search__modal__inner--green">
+          <p class="l-search__modal-heading">商品が入荷したらメールでお知らせ</p>
+          <p class="l-search__modal-text">
+            取り置きではありませんので、<br />
+            すぐに売り切れになる場合もございます。
+          </p>
+          <button type="button" class="c-button--mail l-search__modal-button js-incomingMailButton" data-target="js-mailSetting">入荷メールを登録（無料）</button>
+          <p class="l-search__modal-text js-mailregistercount-text"></p>
+        </div>
+        <div class="l-search__modal__inner l-search__modal__inner--red js-reserve-region"></div>
+      </div>
+    </div>
+  </div>
+</div>
+    <div>
+  <!-- /* 商品詳細用カート追加モーダル */ -->
+  <div class="c-modal" id="js-addcart">
+    <div class="c-modal__background js-toggle" data-target="js-addcart"></div>
+    <div class="c-modal__inner">
+      <div class="c-modal__close-container">
+        <button type="button" class="c-modal__close js-toggle" data-target="js-addcart">
+          <img src="/img/close_black_icon.svg" alt="閉じる" />
+        </button>
+      </div>
+      <div class="c-modal__product-container--mx">
+        <p class="c-modal__cart-heading">以下の商品をカートに入れました</p>
+        <div
+          class="c-modal__cart-text"
+        >
+          <p class="c-modal__cart-name">狐と乙女の大正恋日記－貴方、歌劇場に憑いてます？－</p>
+          <p
+            class="c-modal__cart-info"
+          >古本・中古本／文芸／月本ナシオ</p>
+          <!-- /* カートに入っている値段の合計値で送料計算 */ -->
+          <p class="c-modal__cart-shipping">現在の送料：<span class="free js-shippingfee-text"></span></p>
+          <p class="c-modal__cart-shipping-free js-forfreeshipping">あと<span class="bold js-forfreeshipping-text"></span>で送料無料！</p>
+        </div>
+
+        <!-- /* タダ本会員の場合、カート内の対象商品数とあと〇点買えるのか表示する */ -->
+        
+
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addcart">閉じる</button>
+          <a type="button" class="c-button--cart js-toggle" data-target="js-addcart" href="/purchase/cart/">カートに進む</a>
+        </div>
+
+        
+          <p class="c-modal__product-list-heading">この商品を買った人はこちらも</p>
+          <ul class="c-modal__product-list-container">
+            <li>
+              
+                <a href="/detail/0000496954/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000496954.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >【ＣＤ付】ビートマニアゴッタミックス公式ガイド</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000250070/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000250070.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >Ｏｆｆｉｃｉａｌ　ｇｕｉｄｅ　ｏｆ　Ｄｕｎｇｅｏｎ　Ｍａｓｔｅｒ　 ＩＩ 　Ｓｋｕｌｌｋｅｅｐ</span>
+                  <span class="c-modal__product-price">1,260円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000952456/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000952456.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ｔｓｕｇｕｎａｉ～つぐない～公式攻略ガイド</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000462818/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ザ・キング・オブ・ファイターズ’９８－最大多数の最大幸福－</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000778234/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000778234.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ホースブレーカーマスターブック</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010698963/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010698963.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >エルフレア</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001443125/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001443125.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >ポケモンコロシアム公式完全クリアガイド　［バーチャルトレーナーカード付属なし］</span>
+                  <span class="c-modal__product-price">400円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010322584/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010322584.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >『ファイブスター物語』の秘密＜２＞</span>
+                  <span class="c-modal__product-price">1,890円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001465085/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001465085.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >パワプロスーパー大全　コナミ公式パーフェクトシリーズ</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011433105/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >完全保存版　ビーストウォーズＩＩ　超図鑑</span>
+                  <span class="c-modal__product-price">630円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0012371270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0012371270.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >【限定版　ドラマＣＤ付】おジャ魔女どれみ１９</span>
+                  <span class="c-modal__product-price">2,470円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000393390/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >スターフォックス６４最終攻略読本</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010335551/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >たまごっちカップまるわかりガイド　超ねんじゅーかいさいカードでおーえん！＜２００６秋＞</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000124941/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >魯迅文集＜1＞</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011002061/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011002061.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >プロティノス「美について」</span>
+                  <span class="c-modal__product-price">710円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001309270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >１００％リッチー・コッツェン</span>
+                  <span class="c-modal__product-price">800円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001157814/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001157814.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >スターオーシャン－ブルースフィア－</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011948710/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011948710.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >アニメＣＧの現場　２０１４　３ＤＣＧを中心とした映像制作技術を徹底取材！</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011103313/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011103313.jpg"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >世界の歴史（５）－ギリシアとローマ－</span>
+                  <span class="c-modal__product-price">990円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000202537/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span
+                    class="c-modal__product-name"
+                  >アイドル工学</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+          </ul>
+        
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品詳細用入荷メールモーダル */ -->
+  <div class="c-modal" id="js-mailSetting">
+    <div class="c-modal__background js-toggle" data-target="js-mailSetting"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailSetting">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品を入荷メールに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-mailSetting">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り登録モーダル */ -->
+  <div class="c-modal" id="js-addfav">
+    <div class="c-modal__background js-toggle" data-target="js-addfav"></div>
+    <div class="c-modal__inner">
+      <div class="c-modal__close-container">
+        <button type="button" class="c-modal__close js-toggle" data-target="js-addfav">
+          <img src="/img/close_black_icon.svg" alt="閉じる" />
+        </button>
+      </div>
+      <div class="c-modal__product-container--mx">
+        <p>商品をお気に入りに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addfav">閉じる</button>
+        </div>
+        
+          <p class="c-modal__product-list-heading">この商品を買った人はこちらも</p>
+          <ul class="c-modal__product-list-container">
+            <li>
+              
+                <a href="/detail/0000496954/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000496954.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">【ＣＤ付】ビートマニアゴッタミックス公式ガイド</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000250070/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000250070.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">Ｏｆｆｉｃｉａｌ　ｇｕｉｄｅ　ｏｆ　Ｄｕｎｇｅｏｎ　Ｍａｓｔｅｒ　 ＩＩ 　Ｓｋｕｌｌｋｅｅｐ</span>
+                  <span class="c-modal__product-price">1,260円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000952456/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000952456.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ｔｓｕｇｕｎａｉ～つぐない～公式攻略ガイド</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000462818/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ザ・キング・オブ・ファイターズ’９８－最大多数の最大幸福－</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000778234/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0000778234.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ホースブレーカーマスターブック</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010698963/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010698963.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">エルフレア</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001443125/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001443125.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">ポケモンコロシアム公式完全クリアガイド　［バーチャルトレーナーカード付属なし］</span>
+                  <span class="c-modal__product-price">400円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010322584/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0010322584.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">『ファイブスター物語』の秘密２</span>
+                  <span class="c-modal__product-price">1,890円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001465085/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001465085.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">パワプロスーパー大全　コナミ公式パーフェクトシリーズ</span>
+                  <span class="c-modal__product-price">220円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011433105/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">完全保存版　ビーストウォーズＩＩ　超図鑑</span>
+                  <span class="c-modal__product-price">630円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0012371270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0012371270.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">【限定版　ドラマＣＤ付】おジャ魔女どれみ１９</span>
+                  <span class="c-modal__product-price">2,470円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000393390/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">スターフォックス６４最終攻略読本</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0010335551/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">たまごっちカップまるわかりガイド　超ねんじゅーかいさいカードでおーえん！２００６秋</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000124941/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">魯迅文集1</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011002061/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011002061.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">プロティノス「美について」</span>
+                  <span class="c-modal__product-price">710円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001309270/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">１００％リッチー・コッツェン</span>
+                  <span class="c-modal__product-price">800円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0001157814/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0001157814.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">スターオーシャン－ブルースフィア－</span>
+                  <span class="c-modal__product-price">165円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011948710/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011948710.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">アニメＣＧの現場　２０１４　３ＤＣＧを中心とした映像制作技術を徹底取材！</span>
+                  <span class="c-modal__product-price">550円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0011103313/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/cmdty/0011103313.jpg"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">世界の歴史（５）－ギリシアとローマ－</span>
+                  <span class="c-modal__product-price">990円</span>
+                </a>
+              
+            </li>
+            <li>
+              
+                <a href="/detail/0000202537/?model=400" class="c-modal__product-list">
+                  <img
+                    class="c-modal__product-img"
+                    src="/ebimage/noimage_book_01.gif"
+                    alt=""
+                  />
+                  <span class="c-modal__product-name">アイドル工学</span>
+                  <span class="c-modal__product-price">275円</span>
+                </a>
+              
+            </li>
+          </ul>
+        
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り解除モーダル */ -->
+  <div class="c-modal" id="js-delfav">
+    <div class="c-modal__background js-toggle" data-target="js-delfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-delfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りから登録解除しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-delfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+    
+    <div>
+  
+  <div class="c-snackbar" id="js-addcart-ng">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-addcart-ng">閉じる</button>
+  </div>
+  <div class="c-snackbar" id="js-snack-common">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-snack-common">閉じる</button>
+  </div>
+  
+  
+  
+</div>
+
+    <input id="reserveLimit" type="hidden" value="1" />
+    <input id="reserveAmount" type="hidden" value="0" />
+    <input id="reserveKind" type="hidden" value="11" />
+    <input id="reserveNewFullFlg" type="hidden" value="0" />
+
+    <footer>
+      <div class="l-footer l-footer--sp">
+  <nav>
+    <ul>
+      <li>
+        <div class="l-footer__heading">カテゴリから探す</div>
+        <ul>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav1">古本・中古本</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav1">
+              <li>
+                <a href="/book/" class="l-footer__nav-list l-footer__nav-list--category-link">古本・中古本 TOP</a>
+              </li>
+              <li>
+                <a href="/book/10/" class="l-footer__nav-list l-footer__nav-list--category-link">文芸</a>
+              </li>
+              <li>
+                <a href="/book/11/" class="l-footer__nav-list l-footer__nav-list--category-link">ビジネス</a>
+              </li>
+              <li>
+                <a href="/book/12/" class="l-footer__nav-list l-footer__nav-list--category-link">政治・経済・法律</a>
+              </li>
+              <li>
+                <a href="/book/13/" class="l-footer__nav-list l-footer__nav-list--category-link">料理・趣味・児童</a>
+              </li>
+              <li>
+                <a href="/book/14/" class="l-footer__nav-list l-footer__nav-list--category-link">教育・福祉・資格</a>
+              </li>
+              <li>
+                <a href="/book/15/" class="l-footer__nav-list l-footer__nav-list--category-link">女性・生活・コンピュータ</a>
+              </li>
+              <li>
+                <a href="/book/16/" class="l-footer__nav-list l-footer__nav-list--category-link">産業・学術・歴史</a>
+              </li>
+              <li>
+                <a href="/book/17/" class="l-footer__nav-list l-footer__nav-list--category-link">スポーツ・健康・医療</a>
+              </li>
+              <li>
+                <a href="/book/18/" class="l-footer__nav-list l-footer__nav-list--category-link">写真集</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav2">コミック</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav2">
+              <li>
+                <a href="/comic/" class="l-footer__nav-list l-footer__nav-list--category-link">コミック TOP</a>
+              </li>
+              <li>
+                <a href="/comic/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comic/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comic/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <li>
+                <a href="/comic/26/" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li>
+              <li>
+                <a href="/comic/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav3">コミックセット</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav3">
+              <li>
+                <a href="/comicset/" class="l-footer__nav-list l-footer__nav-list--category-link">コミックセット TOP</a>
+              </li>
+              <li>
+                <a href="/comicset/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comicset/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <!-- <li>
+                <a href="/comicset/26" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li> -->
+              <li>
+                <a href="/comicset/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav4">ゲーム</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav4">
+              <li><a href="/game/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲーム TOP</a></li>
+              <li><a href="/game/80/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch2</a></li>
+              <li><a href="/game/75/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch</a></li>
+              <li><a href="/game/72/" class="l-footer__nav-list l-footer__nav-list--category-link">WiiU</a></li>
+              <li><a href="/game/67/" class="l-footer__nav-list l-footer__nav-list--category-link">Wii</a></li>
+              <li><a href="/game/70/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドー3DS</a></li>
+              <li><a href="/game/56/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドーDS</a></li>
+              <!-- <li><a href="/game/54/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/game/57/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=54&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=57&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li>
+              <li><a href="/game/77/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション5</a></li>
+              <li><a href="/game/73/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション4</a></li>
+              <li><a href="/game/66/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション3</a></li>
+              <li><a href="/game/51/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション2</a></li>
+              <li><a href="/game/52/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション</a></li>
+              <li><a href="/game/71/" class="l-footer__nav-list l-footer__nav-list--category-link">PS Vita</a></li>
+              <li><a href="/game/53/" class="l-footer__nav-list l-footer__nav-list--category-link">PSP</a></li>
+              <!-- <li><a href="/game/74/" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/game/65/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/game/61/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=74&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=65&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=61&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li>
+              <li><a href="/game/78/" class="l-footer__nav-list l-footer__nav-list--category-link">レトロゲーム</a></li>
+              <li><a href="/game/68/" class="l-footer__nav-list l-footer__nav-list--category-link">PCゲーム</a></li>
+            </ul>
+          </li>
+          <!-- <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav5">トレカ</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav5">
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">トレカ TOP</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ポケモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ワンピースカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">シャドウバース エボルブ</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">遊戯王</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">デジモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ヴァンガード</a>
+              </li>
+            </ul>
+          </li> -->
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav6">DVD・Blu-ray</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav6">
+              <li>
+                <a href="/dvd/" class="l-footer__nav-list l-footer__nav-list--category-link">DVD・Blu-ray TOP</a>
+              </li>
+              <li>
+                <a href="/dvd/41/" class="l-footer__nav-list l-footer__nav-list--category-link">洋画</a>
+              </li>
+              <li>
+                <a href="/dvd/42/" class="l-footer__nav-list l-footer__nav-list--category-link">邦画</a>
+              </li>
+              <li>
+                <a href="/dvd/43/" class="l-footer__nav-list l-footer__nav-list--category-link">ミュージック</a>
+              </li>
+              <li>
+                <a href="/dvd/44/" class="l-footer__nav-list l-footer__nav-list--category-link">アニメ</a>
+              </li>
+              <li>
+                <a href="/dvd/45/" class="l-footer__nav-list l-footer__nav-list--category-link">芸能・スポーツ・その他</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav7">CD</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav7">
+              <li>
+                <a href="/cd/" class="l-footer__nav-list l-footer__nav-list--category-link">CD TOP</a>
+              </li>
+              <li>
+                <a href="/cd/31/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャパニーズポップス</a>
+              </li>
+              <li>
+                <a href="/cd/32/" class="l-footer__nav-list l-footer__nav-list--category-link">海外のロック＆ポップス</a>
+              </li>
+              <li>
+                <a href="/cd/33/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャズ＆フュージョン</a>
+              </li>
+              <li>
+                <a href="/cd/34/" class="l-footer__nav-list l-footer__nav-list--category-link">イージーリスニング</a>
+              </li>
+              <li>
+                <a href="/cd/35/" class="l-footer__nav-list l-footer__nav-list--category-link">クラシック</a>
+              </li>
+              <li>
+                <a href="/cd/36/" class="l-footer__nav-list l-footer__nav-list--category-link">サウンドトラック</a>
+              </li>
+              <li>
+                <a href="/cd/37/" class="l-footer__nav-list l-footer__nav-list--category-link">童謡・民謡・その他</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__heading">おすすめから探す</div>
+        <ul>
+          <li><a class="l-footer__nav-list" href="/special/">キャンペーン・特集</a></li>
+          <li><a class="l-footer__nav-list" href="/timesale/">タイムセール</a></li>
+          <!-- <li>
+            <a th:with="result = ${T(www.netoff.co.jp.web.config.UrlConfig).TAG_DETAILS_URL}" th:href="${result + '?tagid=19821&cat=7001'}">110円～！激安人気作ランキング</a>
+          </li>
+          <li>
+            <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}" class="l-footer__nav-list"
+              >あなたにおすすめの商品</a
+            >
+          </li> -->
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__purchase">
+          <span>ラクして売るなら</span>
+          ネットオフ宅配買取
+        </div>
+        <ul>
+          <li>
+            <a href="/sell/book/" class="l-footer__nav-list l-footer__nav-list--accent">本＆ゲーム買取コース</a>
+          </li>
+          <li>
+            <a href="/sell/book/book/" class="l-footer__nav-list">古本・中古本買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/comic/" class="l-footer__nav-list">コミック買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/" class="l-footer__nav-list">ゲームソフト買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/body.jsp" class="l-footer__nav-list">ゲーム機本体買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/dvd/" class="l-footer__nav-list">DVD・Blu-ray買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/cd/" class="l-footer__nav-list">CD買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/moetaku/" class="l-footer__nav-list l-footer__nav-list--accent">ホビー・フィギュア買取 もえたく！</a>
+          </li>
+          <li>
+            <a href="/figure/" class="l-footer__nav-list">フィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/kuji_prize/" class="l-footer__nav-list">プライズフィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/plamodel/" class="l-footer__nav-list">プラモデル買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/" class="l-footer__nav-list">トレカ買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/pokemon_card/" class="l-footer__nav-list">ポケモンカード買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/onepiece/" class="l-footer__nav-list">ワンピースカード買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/sell/general/" class="l-footer__nav-list l-footer__nav-list--accent">ブランド＆総合買取コース</a>
+          </li>
+          <li>
+            <a href="/kaden/" class="l-footer__nav-list">家電買取</a>
+          </li>
+          <li>
+            <a href="/kaden/camera/" class="l-footer__nav-list">カメラ買取</a>
+          </li>
+          <li>
+            <a href="/kaden/gamingpc/" class="l-footer__nav-list">ゲーミングPC買取</a>
+          </li>
+          <li>
+            <a href="/kaden/deditalstationery/lcdtablet/" class="l-footer__nav-list">液タブ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/" class="l-footer__nav-list">スマホ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/smartphone/iphone/" class="l-footer__nav-list">iPhone買取</a>
+          </li>
+          <li>
+            <a href="/clothes/" class="l-footer__nav-list">洋服・古着買取</a>
+          </li>
+          <li>
+            <a href="/brand/brand/" class="l-footer__nav-list">ブランド買取</a>
+          </li>
+          <li>
+            <a href="/brand/jewelry/" class="l-footer__nav-list">金・プラチナ買取</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  ﻿<aside id="footer-1m-banner" class="l-footer__banner">
+  <!-- バナー -->
+  <a href="https://page.line.me/trp3160p?oat__id=699595&openQrModal=true" target="0">
+    <img src="/images/banner/main/footer-1m-banner.webp" alt="LINE 公式アカウント"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?category=1643943081566646275" target="0">
+    <img src="/images/banner/main/footer-2m-banner.webp" alt="もえたく 社員募集"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?jobType=PART&category=1644999205883056129" target="0">
+    <img src="/images/banner/main/footer-3m-banner.webp" alt="ネットオフ アルバイト募集"/>
+  </a>
+</aside>
+
+
+  <nav>
+    <ul>
+      <li>
+        <a href="/kaitori-navi/" class="l-footer__nav-list">買取ナビTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/" class="l-footer__nav-list">VODチョイスTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/ebook/" class="l-footer__nav-list">おすすめ電子書籍</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/vod/" class="l-footer__nav-list">おすすめ動画配信サービス</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/" class="l-footer__nav-list">インターネット比較TOP</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/pocket-wifi/" class="l-footer__nav-list">おすすめポケット型WiFi</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/wimax-comparison/" class="l-footer__nav-list">おすすめWiMAX</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/hikari-recommendation/" class="l-footer__nav-list">おすすめ光回線</a>
+      </li>
+      <li>
+        <a href="https://fortune.netoff.co.jp/" class="l-footer__nav-list">占ナビTOP</a>
+      </li>
+      <li>
+        <a href="/notification/noticelist/" class="l-footer__nav-list">お知らせ</a>
+      </li>
+      <li>
+        <a href="/guide/beginner.jsp" class="l-footer__nav-list">初めての方へ</a>
+      </li>
+      <li>
+        <a href="/guide/" class="l-footer__nav-list">ヘルプ・お問い合わせ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__info-container">
+    <img
+      src="/img/icon_mothers_sp.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+    <div class="l-footer__button-container">
+      
+        <!-- 未ログイン -->
+        <a href="/sell/" class="l-footer__button l-footer__button--purchase l-footer__button--flex">宅配買取</a>
+        <a
+          class="l-footer__button l-footer__button--sign l-footer__button--flex"
+          href="/registration/enterinformation/"
+          >新規会員登録</a
+        >
+      
+      
+    </div>
+    <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+  </div>
+
+  <nav>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/company/">会社案内</a>
+      </li>
+      <li>
+        <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+      </li>
+    </ul>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/guide/netoff.jsp">品質ポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/">プライバシーポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/#policy02">個人情報保護方針</a>
+      </li>
+      <li>
+        <a href="/customer/">お客様への対応について</a>
+      </li>
+      <li>
+        <a href="/use/">ご利用規約</a>
+      </li>
+      <li>
+        <a href="/settlement/">資金決済法に基づく表示</a>
+      </li>
+      <li>
+        <a href="/sitemap/">サイトマップ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__netoff">
+    <span>ネットオフ株式会社</span>
+    古物商許可番号 542782100600 愛知県公安委員会許可<br />
+    <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+  </div>
+
+  <small class="l-footer__copyright">Copyright &copy; NETOFF,inc.</small>
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="425c53ff-190d-4a7b-862b-15fb22381ff8"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+  <!-- <div class="c-modal" id="js-footerLogout">
+    <div
+      class="c-modal__background js-toggle"
+      data-target="js-footerLogout"
+    ></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button
+          type="button"
+          class="c-button--black js-toggle"
+          data-target="js-footerLogout"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          class="c-button--black-outline"
+          onClick="window.location.href='/'"
+        >
+          ログアウト
+        </button>
+      </div>
+    </div>
+  </div> -->
+</div>
+      <div class="l-footer l-footer--pc">
+  <div class="l-footer__about">
+    <img
+      src="/img/icon_mothers_pc.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+  </div>
+
+  <div class="l-footer__container">
+    <div class="l-footer__scroll-top">
+      <button type="button" onclick="window.scrollTo({ top: 0 })">▲ このページの先頭に戻る</button>
+    </div>
+    <div class="l-footer__inner">
+      <nav class="l-footer__main-nav-container">
+        <ul>
+          <li>
+            <div class="l-footer__heading">カテゴリから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/book/">古本・中古本</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comic/">コミック</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comicset/">コミックセット</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/game/">ゲーム</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">トレカ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/dvd/">DVD・Blu-ray</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/cd/">CD</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">おすすめから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/special/">キャンペーン・特集</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/timesale/">タイムセール</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">110円～！激安人気作ランキング</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}">あなたにおすすめの商品</a>
+              </li> -->
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">マイページ</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/mypagetop/">マイページトップ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/myfavorite/">お気に入り</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/incomingmaillist/">入荷メール</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/customerinfochange/">お客様情報</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ご利用サポート・その他</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/guide/">ヘルプ・お問い合わせ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="/landingpage/shippingfeeexplanation">送料について</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/guide/beginner.jsp">はじめての方へ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a th:with="noticelist = ${T(www.netoff.co.jp.web.config.UrlConfig).NOTIFICATION_NOTICELIST_URL}" th:href="${noticelist}">お知らせ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/kaitori-navi/">買取ナビ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://vod.netoff.co.jp/">VODチョイス</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://internet.netoff.co.jp/">インターネット比較</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://fortune.netoff.co.jp/">占ナビ</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ネットオフ宅配買取</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/sell/book/">本・ゲーム買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/moetaku/tcg/pokemon_card/">トレカ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/figure/">フィギュア買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mobilebuy/">スマホ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/kaden/">家電買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/sell/general/">ブランド・総合買取</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+
+      <nav class="l-footer__site-nav-container">
+        <ul class="l-footer__site-nav">
+          <li>
+            <a href="/company/">会社案内</a>
+          </li>
+          <li>
+            <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+          </li>
+          <li>
+            <a href="/guide/netoff.jsp">品質ポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/">プライバシーポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/#policy02">個人情報保護方針</a>
+          </li>
+          <li>
+            <a href="/customer/">お客様への対応について</a>
+          </li>
+          <li>
+            <a href="/use/">ご利用規約</a>
+          </li>
+          <li>
+            <a href="/settlement/">資金決済法に基づく表示</a>
+          </li>
+          <li>
+            <a href="/sitemap/">サイトマップ</a>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="l-footer__info-container">
+        <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+      </div>
+
+      <div class="l-footer__netoff-container">
+        <div>
+          <a href="/" class="l-footer__logo">
+            <picture>
+              <source srcset="/img/logo-netoff.webp" type="image/webp" />
+              <img src="/img/logo-netoff.png" alt="NET OFF" />
+            </picture>
+          </a>
+          <div class="l-footer__netoff l-footer__netoff--main">
+            <span>ネットオフ株式会社</span>
+            古物商許可番号 542782100600 愛知県公安委員会許可<br />
+            <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+          </div>
+        </div>
+
+        <small class="l-footer__copyright l-footer__copyright--main">Copyright &copy; NETOFF,inc.</small>
+      </div>
+    </div>
+  </div>
+</div>
+    </footer>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js"></script>
+    <script src="/js/common.js" defer></script>
+    <script src="/js/product.js" defer></script>
+    <script src="/js/cart.js" defer></script>
+    <script>
+      // お気に入りリスト
+      const favCmdtyCodes = null;
+    </script>
+
+    
+      
+  
+    <script>
+      const MD5Email = null;
+    </script>
+    <script src="/js/criteo.js" defer></script>
+  
+
+    
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', () => {
+        let doc = document;
+        let head = doc.getElementsByTagName('head')[0];
+        let tagEmail = '';
+        tagEmail = '<%= MD5Email %>';
+        let criteoScript = document.createElement('script');
+        criteoScript.type = 'text/javascript';
+        criteoScript.src = '//static.criteo.net/js/ld/ld.js';
+        criteoScript.async = true;
+        head.appendChild(criteoScript);
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.innerHTML = 'window.criteo_q = window.criteo_q || [];';
+        script.innerHTML += 'window.criteo_q.push(';
+        script.innerHTML += '{ event: "setAccount", account: 85067 },';
+        script.innerHTML += '{ event: "setSiteType", type: "d" },';
+        if (tagEmail != '') {
+          script.innerHTML += '{ event: "setEmail", email:"' + tagEmail + '" },';
+        }
+        script.innerHTML += '{ event: "viewHome" }';
+        script.innerHTML += ');';
+        head.appendChild(script);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/used_book/netoff_search.html
+++ b/tests/fixtures/used_book/netoff_search.html
@@ -1,0 +1,3922 @@
+<!doctype html>
+<html lang="ja">
+  <head><script>(function(w,i,g){w[g]=w[g]||[];if(typeof w[g].push=='function')w[g].push(i)})(window,'GTM-NPLRPRC','google_tags_first_party');</script><script>(function(w,d,s,l){w[l]=w[l]||[];(function(){w[l].push(arguments);})('set','developer_id.dYzZiYj',true);var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='/27ns5f/';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>
+    <meta charset="UTF-8" />
+    <meta name="_csrf" content="e38a53ff-1a5f-4df6-8603-fecb5d37496f" />
+    <meta name="_csrf_header" content="X-XSRF-TOKEN" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>9784813705185の古本 ｜中古通販ならネットオフ</title>
+    <meta name="description" content="【9784813705185】の古本 検索結果です。古本・CD・DVD・ゲームの買取や購入ならネットオフ！楽天ポイント・Vポイントが貯まる・使える！ご自宅から買取が依頼できる宅配買取サービスも充実" />
+    <meta name="keyword" content="古本,中古本,通販,買取,古本 買取" />
+    <meta name="robots" content="noindex,nofollow" />
+    
+    
+    <link rel="canonical" href="https://www.netoff.co.jp/cmdtyallsearch/?word=9784813705185&amp;cat=1002" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:title" content="9784813705185の古本 ｜中古通販ならネットオフ" />
+    <meta property="og:site_name" content="ネット中古書店 ネットオフ (本・CD・DVD・ゲームソフトの買取・販売)" />
+    
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="https://www.netoff.co.jp/images/logo_fb.gif" />
+    <meta name="og:description" content="【9784813705185】の古本 検索結果です。古本・CD・DVD・ゲームの買取や購入ならネットオフ！楽天ポイント・Vポイントが貯まる・使える！ご自宅から買取が依頼できる宅配買取サービスも充実" />
+    <meta property="fb:app_id" content="193098350747639" />
+    <link rel="shortcut icon" href="/netoff.ico" />
+    <link rel="apple-touch-icon" href="/netoff.png" />
+    <link href="/css/style.css" rel="stylesheet" />
+    <script src="/js/googleTag.js" defer></script>
+
+    
+      
+        
+          
+  
+    
+      
+        
+          <script>
+            /*<![CDATA[*/
+            const user = {
+              zeta_id: "",
+              zeta_gender: "",
+              zeta_age: "",
+            };
+            /*]]>*/
+            const zetaParam = {};
+            const zetaScriptUrl = "https:\/\/renet.search.zetacx.net\/static\/zd\/zd_register_prd.js";
+          </script>
+          <script src="/js/zetatags.js" defer></script>
+        
+      
+    
+  
+
+        
+      
+    
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NPLRPRC" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header>
+      <div id="js-headerContainer" class="l-header__container is-fixed">
+        <div class="l-header-common" id="js-header">
+  <!-- <div class="l-header-common__info">
+    <p>古本・CD・DVD・ゲームの買取・中古通販ならネットオフ！！</p>
+    <nav class="l-header-common__info-nav">
+      <ul>
+        <li class="l-header-common__info-nav-list">
+          <a href="/sell/">段ボール無料</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="forfirsttime = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FORFIRSTTIMEUSER_URL}" th:href="${forfirsttime}">はじめての方へ</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="faq = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FAQ_URL}" th:href="${faq}">よくある質問</a>
+        </li>
+      </ul>
+    </nav>
+  </div> -->
+  <div class="l-header">
+    <button type="button" class="l-header__nav-button js-toggle" data-target="js-headerSideNav">
+      <span></span>
+    </button>
+    <div class="l-header__logo">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <a href="/sell/" class="l-header__purchase-button">買取</a>
+    
+  </div>
+  <div class="l-header-common__inner js-topNavigation">
+    <div class="l-header__logo is-sp-hidden">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <form class="c-search-input__form l-header-common__search" id="js-searchList" name="search_form">
+      <input type="hidden" name="cat" value="" />
+      <div class="l-header-common__search-select">
+        <div class="c-select c-select--black js-select" data-target="js-headerSelect" tabindex="0">
+          <div
+            class="c-select__label js-selectLabel js-init-category"
+            data-target="js-headerSelect"
+            data-value="1002"
+          ></div>
+          <div class="c-select__option-container" id="js-headerSelect">
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="すべてのカテゴリー"
+                data-value=""
+                id="headerSearchCategory1"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory1">すべてのカテゴリー</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="古本・中古本"
+                data-value="1002"
+                id="headerSearchCategory4"
+                class="js-selectOption js-searchSelect" checked="checked"
+              />
+              <label class="c-select__options" for="headerSearchCategory4">古本・中古本</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミック"
+                data-value="1001"
+                id="headerSearchCategory2"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory2">コミック</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミックセット"
+                data-value="1011"
+                id="headerSearchCategory3"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory3">コミックセット</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="ゲーム"
+                data-value="5001"
+                id="headerSearchCategory7"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory7">ゲーム</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="DVD・Blu-ray"
+                data-value="7001"
+                id="headerSearchCategory6"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory6">DVD・Blu-ray</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="CD"
+                data-value="3001"
+                id="headerSearchCategory5"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory5">CD</label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-header-common__search-input">
+        <button type="submit" formaction="/cmdtyallsearch/" class="l-header-common__search-button">
+          <img src="/img/search_black_icon.svg" width="20px" alt="検索" />
+        </button>
+        <div class="c-search-input">
+          <div class="c-search-input__input-container">
+            <input
+              type="text"
+              placeholder="キーワードを入力"
+              class="c-search-input__input js-searchForm"
+              name="word"
+              data-target="js-searchList"
+              value="9784813705185"
+              autocomplete="off"
+            />
+            <button type="button" class="c-search-input__delete-input js-searchInputDelete">
+              <img src="/img/close_gray_icon.svg" alt="削除" />
+            </button>
+          </div>
+          <button type="submit" formaction="/cmdtyallsearch/" class="c-search-input__button">
+            <img src="/img/search_icon.svg" alt="検索" />
+          </button>
+          <button type="button" class="c-search-input__cancel js-toggle" data-target="js-searchList">キャンセル</button>
+        </div>
+        <!-- <input type="text" placeholder="キーワードを入力" class="js-searchForm" data-target="js-searchList" /> -->
+        <div class="c-search-input__list-inner js-searchResult">
+          <div class="c-search-input__list-top">
+            <span class="c-search-input__history-text">検索履歴</span>
+            <span class="c-search-input__result-text">検索候補</span>
+            <button type="button" class="c-search-input__delete-all-button js-suggest-delete-all">全件削除</button>
+          </div>
+          <ul class="js-suggestList">
+            <!--
+            <li class="c-search-input__list">
+              <a th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}" th:href="@{__${url}__}">
+                <span class="c-search-input__list-text js-searchHistory">鬼滅の刃</span>
+              </a>
+              <button type="button" class="c-search-input__delete-button">
+                <img th:src="@{/img/close_gray_icon.svg}" alt="削除" />
+              </button>
+            </li>
+            -->
+          </ul>
+        </div>
+      </div>
+
+      <div class="c-search-input__list-container">
+        <div class="c-search-input__background"></div>
+      </div>
+    </form>
+    <script>
+      document.querySelectorAll('.js-searchSelect').forEach((option) => {
+        option.addEventListener('change', function () {
+          if (this.checked) {
+            const selectedValue = this.getAttribute('data-value');
+            document.querySelector('input[type="hidden"][name="cat"]').value = selectedValue;
+          }
+        });
+      });
+    </script>
+    <nav
+      class="l-header-common__nav-container"
+    >
+      <ul class="l-header-common__nav">
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/mypagetop/">
+            
+            ログイン
+          </a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/incomingmaillist/">入荷メール</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/reservation/reservationlist/">予約履歴</a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/myfavorite/">お気に入り</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/browsinghistory/">閲覧履歴</a>
+        </li>
+        <li class="l-header-common__nav-list js-cartcontainer">
+          <a href="/purchase/cart/">カート</a>
+          
+        </li>
+        <li style="display: block" class="l-header-common__nav-list l-header-common__nav-list--purchase">
+          <a href="/sell/">買取</a>
+        </li>
+        <li style="display: none" class="l-header-common__nav-list l-header-common__nav-list--cards">
+          <a href="/moetaku/tcg/pokemon_card/">トレカ<br />買取</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="l-header__nav" id="js-headerSideNav">
+    <div class="l-header__nav-back js-toggle" data-target="js-headerSideNav"></div>
+    <nav class="l-header__nav-container">
+      <!-- 未ログイン -->
+      <div>
+        <div class="l-header__login-container">
+          <div class="l-header__login-buttons">
+            <!--  
+            <a class="c-button--main" href="{$root}login/login">ログイン</a>
+            <a class="c-button--outline" th:href="@{/registration/enterinformation}">新規会員登録</a>
+          -->
+            <a class="c-button--main" href="/login/">ログイン</a>
+            <a class="c-button--outline" href="/registration/enterinformation/"
+              >新規会員登録</a
+            >
+          </div>
+          <div>
+            <!--
+            <a class="c-link--icon l-header__guide-link" href="">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" th:href="/login/resetpassword">パスワードを忘れた方はこちら</a>
+            -->
+            <a class="c-link--icon l-header__guide-link" href="/guide/beginner.jsp">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" href="/resetpassword/"
+              >パスワードを忘れた方はこちら</a
+            >
+          </div>
+        </div>
+      </div>
+      <!-- ログイン済み -->
+      
+      <ul>
+        <li class="l-header__nav-title">カテゴリ</li>
+        <li class="l-header__nav-list">
+          <a href="/book/">古本・中古本</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comic/">コミック</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comicset/">コミックセット</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/game/">ゲーム</a>
+        </li>
+        <!-- <li class="l-header__nav-list">
+          <a href="">トレカ</a>
+        </li> -->
+        <li class="l-header__nav-list">
+          <a href="/dvd/">DVD・Blu-ray</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/cd/">CD</a>
+        </li>
+      </ul>
+      <ul>
+        <li class="l-header__nav-title">買取</li>
+        <li class="l-header__nav-list">
+          <a href="/sell/">ネットオフ宅配買取TOP</a>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav1">本＆ゲーム買取</button>
+          <ul id="js-headerNav1">
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">本＆ゲーム買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/comic/">コミック・漫画</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">古本・中古本</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/campaign/game/">ゲームソフト</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/game/body.jsp">ゲーム機本体</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/dvd/">DVD・Blu-ray</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/cd/">CD</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav2">トレカ買取</button>
+          <ul id="js-headerNav2">
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/">トレカ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/pokemon_card/">ポケモンカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/onepiece/">ワンピースカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/yugioh/">遊戯王カード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/shadowverse-evolve/">シャドウバース エボルヴ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav4">フィギュア買取</button>
+          <ul id="js-headerNav4">
+            <li class="l-header__nav-list">
+              <a href="/figure/">フィギュア買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/kuji_prize/">プライズフィギュア</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/plamodel/">プラモデル</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gunpla/">ガンプラ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav3">スマホ買取</button>
+          <ul id="js-headerNav3">
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/">スマホ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/iphone/">iPhone</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/xperia/">Xperia</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/tablet/ipad/">iPad</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/galaxy/">Galaxy</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/googlepixel/">Google Pixel</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav5">家電買取</button>
+          <ul id="js-headerNav5">
+            <li class="l-header__nav-list">
+              <a href="/kaden/">家電買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/camera/">カメラ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/headphone/">ヘッドホン</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/gamingpc/">ゲーミングPC</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/wellness/">美容家電</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/deditalstationery/pentablet/">ペンタブレット</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/smartwatch/">スマートウォッチ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav6">ブランド総合買取</button>
+          <ul id="js-headerNav6">
+            <li class="l-header__nav-list">
+              <a href="/sell/general/">ブランド総合買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/brand/">ブランド品</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/clothes/">洋服・古着</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/jewelry/">金・プラチナ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gakki/">楽器</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/hikkigu/">万年筆</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <!-- <div class="c-modal" id="js-logout">
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="button" class="c-button--black-outline" onClick="window.location.href='/'">ログアウト</button>
+      </div>
+    </div>
+  </div> -->
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="e38a53ff-1a5f-4df6-8603-fecb5d37496f"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+</div>
+        <nav class="c-top-nav is-fixed js-topNavigation">
+  <ul class="c-top-nav__list">
+    <li>
+      <a href="/book/" class="c-top-nav__link">古本・中古本</a>
+    </li>
+    <li>
+      <a href="/comic/" class="c-top-nav__link">コミック</a>
+    </li>
+    <li>
+      <a href="/comicset/" class="c-top-nav__link">コミックセット</a>
+    </li>
+    <li>
+      <a href="/game/" class="c-top-nav__link">ゲーム</a>
+    </li>
+    <!-- <li>
+      <a href="" class="c-top-nav__link">トレカ</a>
+    </li> -->
+    <li>
+      <a href="/dvd/" class="c-top-nav__link">DVD・Blu-ray</a>
+    </li>
+    <li>
+      <a href="/cd/" class="c-top-nav__link">CD</a>
+    </li>
+  </ul>
+</nav>
+      </div>
+    </header>
+
+    <main class="l-common__header--tab l-common__footer">
+      <!-- パンくず -->
+      <div>
+        <ol class="c-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem" data-breadcrumb="home">
+    <a href="/" class="c-link--blue c-breadcrumbs__label" itemprop="item"><span itemprop="name">ネットオフTOP</span></a>
+    <meta itemprop="position" content="1" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    
+    <span class="c-breadcrumbs__label" itemprop="name">検索結果一覧</span>
+    <meta itemprop="position" content="2" />
+  </li>
+</ol>
+      </div>
+
+      <div class="l-common">
+        <!-- サイドバー -->
+        <div class="l-sidebar l-sidebar__nav">
+  <a href="/site-directory/" class="l-sidebar__show-more">すべてのカテゴリーを見る</a>
+
+  <div class="l-sidebar__nav-container">
+    <h3>絞込み</h3>
+
+    <div class="l-sidebar__nav-inner">
+      <h4>カテゴリー</h4>
+      <ul>
+        <li>
+          <a
+            href=""
+            class="l-sidebar__nav-list l-sidebar__nav-list--link js-sidebar-link"
+            data-value="1002"
+            data-baseurl="/cmdtyallsearch/"
+          >古本・中古本（1）</a>
+        </li>
+        <li>
+          <a
+            href=""
+            class="l-sidebar__nav-list l-sidebar__nav-list--link js-sidebar-link"
+            data-value="1002-10"
+            data-baseurl="/cmdtyallsearch/"
+          >　文芸（1）</a>
+        </li>
+        <li>
+          <a
+            href=""
+            class="l-sidebar__nav-list l-sidebar__nav-list--link js-sidebar-link"
+            data-value="1002-10-01"
+            data-baseurl="/cmdtyallsearch/"
+          >　　日本人作家（1）</a>
+        </li>
+      </ul>
+    </div>
+
+    <form>
+      <div class="l-sidebar__nav-inner">
+        <h4>おすすめ</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="recommend"
+              type="checkbox"
+              class="c-checkbox js-sidebar-cond"
+              id="js-sideRecom0"
+              value="deliveryclass"
+              data-key="recommend"
+            />
+            <label for="js-sideRecom0">
+              <span class="c-checkbox__label">メール便対象商品（1）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="recommend"
+              type="checkbox"
+              class="c-checkbox js-sidebar-cond"
+              id="js-sideRecom-tadabon"
+              value="1"
+              data-key="freebook"
+            />
+            <label for="js-sideRecom-tadabon">
+              <span class="c-checkbox__label">タダ本対象・無料商品</span>
+            </label>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput" data-name="recommend">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>在庫</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="stock"
+              type="checkbox"
+              class="c-checkbox js-sidebar-cond"
+              id="js-sidebarStock1"
+              value="1"
+              data-key="stock"
+            />
+            <label for="js-sidebarStock1">
+              <span class="c-checkbox__label">在庫あり</span>
+            </label>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear" onclick="document.getElementById('js-sidebarStock1').checked = false">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>作家/アーティスト/出演</h4>
+        
+        
+          <ul>
+            <li class="l-sidebar__check-list">
+              <input
+                name="author"
+                type="radio"
+                class="c-checkbox js-sidebar-cond js-toggle-radio"
+                id="js-sidebarAuthor0"
+                value="%E6%B1%90%E8%A6%8B%E5%A4%8F%E8%A1%9B"
+                data-key="author"
+              />
+              <label for="js-sidebarAuthor0">
+                <span class="c-checkbox__label">汐見夏衛（1）</span>
+              </label>
+            </li>
+          </ul>
+        
+        <button type="button" class="l-sidebar__list-more-button js-pullDown" data-target="js-sidebarShowMore1">
+          
+        </button>
+
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput" data-name="author">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>出版社・メーカー</h4>
+        
+        
+          <ul>
+            <li class="l-sidebar__check-list">
+              <input
+                name="publisher"
+                type="radio"
+                class="c-checkbox js-sidebar-cond js-toggle-radio"
+                id="js-sidebarPublisher0"
+                value="maker:スターツ出版"
+                data-key="facet"
+              />
+              <label for="js-sidebarPublisher0">
+                <span class="c-checkbox__label">スターツ出版（1）</span>
+              </label>
+            </li>
+          </ul>
+        
+
+        <button type="button" class="l-sidebar__list-more-button js-pullDown" data-target="js-sidebarShowMore2">
+          
+        </button>
+
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput" data-name="publisher">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>サイズ</h4>
+        
+        
+          <ul>
+            <li class="l-sidebar__check-list">
+              <input name="size" type="radio" class="c-checkbox js-sidebar-cond js-toggle-radio" id="js-sidebarSize0" value="%E6%96%87%E5%BA%AB" data-key="size" />
+              <label for="js-sidebarSize0">
+                <span class="c-checkbox__label">文庫（1）</span>
+              </label>
+            </li>
+          </ul>
+        
+        <button type="button" class="l-sidebar__list-more-button js-pullDown" data-target="js-sidebarShowMore3">
+          
+        </button>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput" data-name="size">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>販売価格</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice0"
+              value="price:1 ～ 1000"
+              data-key="facet"
+            />
+            <label for="js-sidebarPrice0">
+              <span class="c-checkbox__label">1円 ～ 1,000円（1）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice1"
+              value="price:1001 ～ 2000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice1">
+              <span class="c-checkbox__label">1,001円 ～ 2,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice2"
+              value="price:2001 ～ 3000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice2">
+              <span class="c-checkbox__label">2,001円 ～ 3,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice3"
+              value="price:3001 ～ 5000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice3">
+              <span class="c-checkbox__label">3,001円 ～ 5,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice4"
+              value="5001"
+              data-key="facet"
+              data-ftflg="pricef" disabled="disabled"
+            />
+            <label for="js-sidebarPrice4">
+              <span class="c-checkbox__label">5,001円 ～（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="price-min-range"
+                value=""
+              />&ensp;円&#65374;
+            </div>
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="price-max-range"
+                value=""
+              />&ensp;円
+            </div>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput js-clearSidePrice" data-name="price">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>発行年</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear0"
+              value="2026"
+              data-key="facet"
+              data-ftflg="issuef" disabled="disabled"
+            />
+            <label for="js-sidebarYear0">
+              <span class="c-checkbox__label">2026年 ～（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear1"
+              value="issue:2023 ～ 2025"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear1">
+              <span class="c-checkbox__label">2023年 ～ 2025年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear2"
+              value="issue:2018 ～ 2022"
+              data-key="facet"
+            />
+            <label for="js-sidebarYear2">
+              <span class="c-checkbox__label">2018年 ～ 2022年（1）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear3"
+              value="issue:2008 ～ 2017"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear3">
+              <span class="c-checkbox__label">2008年 ～ 2017年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear4"
+              value="issue:1998 ～ 2007"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear4">
+              <span class="c-checkbox__label">1998年 ～ 2007年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear5"
+              value="1997"
+              data-key="facet"
+              data-ftflg="issuet" disabled="disabled"
+            />
+            <label for="js-sidebarYear5">
+              <span class="c-checkbox__label">～ 1997年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="year-min-range"
+                value=""
+              />&ensp;年&#65374;
+            </div>
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="year-max-range"
+                value=""
+              />&ensp;年
+            </div>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput js-clearSideYear" data-name="year">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <ul>
+  <li class="l-sidebar__ad">
+    <a
+      href="http://www.discas.net/netdvd/entry_site.pl?SITE=movie_a00_n_adot_etc_99_007657&AP=comic_top&sc_cid=movie_a00_n_adot_etc_99_007657"
+      rel="nofollow"
+      target="_blank"
+    >
+      <img
+        src="/images/banner/side/sidemenu-2m-banner.webp"
+        alt="TSUTAYA DISCAS"
+      />
+    </a>
+  </li>
+</ul>
+</div>
+
+        <div class="l-common__container">
+          <section>
+            <div class="l-search__inner">
+              <ul class="l-search__tag-list">
+                
+              </ul>
+              <h1 class="c-heading--main c-heading--main--marginless">9784813705185の古本 検索結果</h1>
+            </div>
+            <ul class="c-tab">
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-0"
+                  value=""
+                  autocomplete="off"
+                />
+                <label for="reservation-category-0">すべて</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-1"
+                  value="1002"
+                  autocomplete="off" checked="checked"
+                />
+                <label for="reservation-category-1">古本・中古本(1)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-2"
+                  value="1001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-2">コミック(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-3"
+                  value="5001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-3">ゲーム(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-4"
+                  value="7001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-4">DVD・Blu-ray(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-5"
+                  value="3001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-5">CD(0)</label>
+              </li>
+            </ul>
+
+            <div class="c-sort-button-container l-search__button-container">
+              <form action="/cmdtyallsearch/" name="stockForm">
+                <input
+                  type="hidden"
+                  name="clFrom"
+                  value="1"
+                /><input
+                  type="hidden"
+                  name="cat"
+                  value="1002"
+                /><input
+                  type="hidden"
+                  name="clTo"
+                  value="1"
+                /><input
+                  type="hidden"
+                  name="clNext"
+                  value="100"
+                /><input
+                  type="hidden"
+                  name="clPrev"
+                  value="-100"
+                /><input
+                  type="hidden"
+                  name="word"
+                  value="9784813705185"
+                /><input
+                  type="hidden"
+                  name="dnum"
+                  value="100"
+                /><input
+                  type="hidden"
+                  name="pageMax"
+                  value="1"
+                />
+                <div>
+                  <input
+                    name="stock"
+                    type="checkbox"
+                    class="c-checkbox js-research"
+                    id="stock"
+                    value="1"
+                    onchange="document.forms.stockForm.submit()"
+                  />
+                  <label for="stock">
+                    <span class="c-checkbox__label c-checkbox__label--small">在庫あり</span>
+                  </label>
+                </div>
+              </form>
+              <div class="c-sort-button-container__buttons">
+                <button type="button" class="c-sort-button-container__button c-sort-button-container__button--sort js-toggle" data-target="js-sort-modal">並び替え</button>
+                <button type="button" class="c-sort-button-container__button c-sort-button-container__button--filter js-toggle" data-target="js-filter-tab-modal">絞込み</button>
+              </div>
+            </div>
+            <div class="l-search__pages">
+              <span>全 1件中</span>
+              <span>1～1件</span>
+              <span>（全1ページ）</span>
+            </div>
+
+            
+
+            <!-- 一覧 -->
+            <ul>
+              
+              
+                <li
+                  class="l-search__products"
+                >
+                  <div
+  class="c-cassette  "
+>
+  <!-- /* ゴミ箱アイコン表示 */ -->
+  <!-- /* お気に入り、ランキング、検索結果の時は不要 */ -->
+  
+  
+  
+  <div class="c-cassette__ranking--wrap">
+    
+    
+    
+    
+    
+    <a href="/detail/0012822282/" class="c-cassette__img">
+      
+      
+      
+      <img src="/ebimage/cmdty/0012822282.jpg" alt="" />
+    </a>
+  </div>
+  <div
+    class="is-selectbox_cardstock c-cassette__flex--arrivalmail"
+  >
+    <!-- /* お気に入りページ、入荷メール一覧、閲覧履歴で左右コンテナもクラスを付け替える */ -->
+    <div>
+      <div class="c-cassette__flex--label">
+        
+        
+        
+        <div class="c-cassette__label">古本・中古本</div>
+        
+        
+        <div class="c-cassette__label c-cassette__label--attention">メール便対象</div>
+        
+        
+        
+      </div>
+      
+      
+      <a href="/detail/0012822282/" class="c-link--blue c-cassette__title">
+        <span>海に願いを風に祈りをそして君に誓いを</span>
+      </a>
+
+      
+      <div class="c-cassette__author">
+        
+        
+        
+          
+          <span>汐見夏衛</span>
+          <span> / 文庫</span>
+        
+        
+        
+        
+        <span class="pc-not"> / 2018年08月</span>
+        
+      </div>
+      
+      
+        <div class="c-cassette__flex--price">
+          <div class="c-cassete__flex--pricemessage">
+            
+            
+            
+            <div class="c-cassette__price"><span>220</span>円</div>
+
+            
+            <div class="c-cassette__price--message">
+              <span>440</span>円おトク！
+            </div>
+          </div>
+        </div>
+      
+
+      
+      
+      
+
+      
+      
+        <div class="c-cassette__stock--message">在庫あと<span class="c-cassette__stock--number">1</span>点！</div>
+      
+      
+      
+      
+    </div>
+    
+    <div
+      class="c-cassette__container--right"
+    >
+      
+      <div class="c-cassette__button--info">
+        
+        
+        
+        
+      </div>
+      <div class="c-cassette__button--flex">
+        
+        <div
+        ><button class="c-button--cart c-cassette__button--wrap addCart" value="0012822282" data-target="js-addcart" data-reload="false">カートに入れる</button></div>
+        
+        <div class="c-favorite__button--wrap">
+          <button class="c-favorite__button js-favorite-button" value="0012822282" data-target="js-addfav"></button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input type="hidden" class="js-value-reserveLimit" value="9" />
+  <input type="hidden" class="js-value-reserveAmount" value="0" />
+  <input type="hidden" class="js-value-reserveKind" value="0" />
+  <input type="hidden" class="js-value-reserveNewFullFlg" value="0" />
+</div>
+                </li>
+                <!-- おすすめのタグ -->
+                <article class="l-search__recommend_tag">
+                  <h3 class="l-search__recommend_tag-heading">＃9784813705185を検索した人におすすめのタグ</h3>
+                  <ul class="l-search__recommend_tag-list">
+                    <li>
+                      <a href="/tag?tagid=2024" class="c-tag">切ないライトノベル</a>
+                    </li>
+                    <li>
+                      <a href="/tag?tagid=19481" class="c-tag">２点までなら送料１５０円！メール便対象の人気作</a>
+                    </li>
+                    <li>
+                      <a href="/tag?tagid=1142" class="c-tag">恋愛・ラブコメライトノベル</a>
+                    </li>
+                    <li>
+                      <a href="/tag?tagid=1041" class="c-tag">泣けるライトノベル</a>
+                    </li>
+                  </ul>
+                </article>
+              
+              
+              
+            </ul>
+
+            <!-- ページネーション -->
+            <div
+              class="l-search__pagination"
+            >
+              <ul class="c-pagination">
+  
+  <li>
+    <button type="button" class="c-pagination__item--link js-pagination-item isCurrent" page="1">
+      <span>1</span>
+    </button>
+  </li>
+  
+</ul>
+            </div>
+            <div class="l-search__link">
+              <a href="/mypage/mypagetop/" class="c-button--outline">マイページトップ</a>
+            </div>
+          </section>
+
+          <section>
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--recommend"
+                href="/recommend/"
+              >
+                あなたにおすすめの商品
+                <span class="c-heading__link">もっと見る</span>
+              </a>
+            </h2>
+            <div class="splide c-splide__products js-productListSlideLarge">
+  <div class="splide__arrows">
+    <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+      <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+    </button>
+    <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+      <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+    </button>
+  </div>
+  <div class="splide__track c-splide__track-small">
+    <ul class="splide__list">
+      <li class="splide__slide">
+        <a
+          href="/ipad/"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0014131002.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >iPad 7th Wi-Fi 32GB</span>
+          <span class="c-splide__products-price">17,578円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000018377/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000018377.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ONE PIECE＜5＞</span>
+          <span class="c-splide__products-price">110円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0013993327/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0013993327.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >SILENT HILL2</span>
+          <span class="c-splide__products-price">3,798円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000496954/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000496954.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【CD付】ビートマニアゴッタミックス公式ガイド</span>
+          <span class="c-splide__products-price">220円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000250070/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000250070.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >Official guide of Dungeon Master  II  Skullkeep</span>
+          <span class="c-splide__products-price">1,260円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000952456/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000952456.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >tsugunai～つぐない～公式攻略ガイド</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001496388/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001496388.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >降神</span>
+          <span class="c-splide__products-price">990円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000462818/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/noimage_home_01.gif"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ザ・キング・オブ・ファイターズ&#39;98－最大多数の最大幸福－</span>
+          <span class="c-splide__products-price">220円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011585020/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011585020.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ALIVE－MONSTER EDITION－</span>
+          <span class="c-splide__products-price">220円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000778234/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000778234.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ホースブレーカーマスターブック</span>
+          <span class="c-splide__products-price">275円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011861079/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011861079.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >漫画少年版 ジャングル大帝 【普及版】＜1＞</span>
+          <span class="c-splide__products-price">663円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001223287/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001223287.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >天野喜孝 ワン・サウザンド・ワン・ナイツ 1001Nights</span>
+          <span class="c-splide__products-price">220円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010698963/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010698963.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >エルフレア</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001431847/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001431847.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >7人の麦わら海賊団ライヴ大海戦！～ワンピースキャラクターソングアルバムpiece．2～</span>
+          <span class="c-splide__products-price">330円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001190180/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001190180.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >『ご近所物語』イラスト集</span>
+          <span class="c-splide__products-price">4,298円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001443125/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001443125.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ポケモンコロシアム公式完全クリアガイド ［バーチャルトレーナーカード付属なし］</span>
+          <span class="c-splide__products-price">400円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010322584/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010322584.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >『ファイブスター物語』の秘密＜2＞</span>
+          <span class="c-splide__products-price">1,890円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000018375/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000018375.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ONE PIECE＜3＞</span>
+          <span class="c-splide__products-price">110円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001465085/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001465085.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >パワプロスーパー大全 コナミ公式パーフェクトシリーズ</span>
+          <span class="c-splide__products-price">220円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011433105/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/noimage_home_01.gif"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >完全保存版 ビーストウォーズII 超図鑑</span>
+          <span class="c-splide__products-price">630円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0012371270/?model=400"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0012371270.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【限定版 ドラマCD付】おジャ魔女どれみ19</span>
+          <span class="c-splide__products-price">2,470円</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+          </section>
+        </div>
+      </div>
+      <form action="/cmdtyallsearch/" name="sortModalForm1">
+        <input
+          type="hidden"
+          name="clFrom"
+          value="1"
+        /><input
+          type="hidden"
+          name="cat"
+          value="1002"
+        /><input
+          type="hidden"
+          name="clTo"
+          value="1"
+        /><input
+          type="hidden"
+          name="clNext"
+          value="100"
+        /><input
+          type="hidden"
+          name="clPrev"
+          value="-100"
+        /><input
+          type="hidden"
+          name="word"
+          value="9784813705185"
+        /><input
+          type="hidden"
+          name="dnum"
+          value="100"
+        /><input
+          type="hidden"
+          name="pageMax"
+          value="1"
+        />
+        <div class="c-modal" id="js-sort-modal">
+  <div class="c-modal__background js-toggle" data-target="js-sort-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle" data-target="js-sort-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <p class="l-sort__modal--title">並び順</p>
+    </div>
+    <div class="c-modal__inner--scroll">
+      <ul class="l-sort__modal--categorylist">
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--1">
+            <input
+              type="radio"
+              id="sort--modal--1"
+              name="sort"
+              data-text="関連度順"
+              value="relevance" checked="checked"
+            />
+            <span class="c-radio">関連度順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--2">
+            <input
+              type="radio"
+              id="sort--modal--2"
+              name="sort"
+              data-text="よく見られている順"
+              value="popular"
+            />
+            <span class="c-radio">よく見られている順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--3">
+            <input
+              type="radio"
+              id="sort--modal--3"
+              name="sort"
+              data-text="発売日が新しい順"
+              value="newest"
+            />
+            <span class="c-radio">発売日が新しい順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--4">
+            <input
+              type="radio"
+              id="sort--modal--4"
+              name="sort"
+              data-text="発売日が古い順"
+              value="oldest"
+            />
+            <span class="c-radio">発売日が古い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--5">
+            <input
+              type="radio"
+              id="sort--modal--5"
+              name="sort"
+              data-text="価格が安い順"
+              value="cheap"
+            />
+            <span class="c-radio">価格が安い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--6">
+            <input
+              type="radio"
+              id="sort--modal--6"
+              name="sort"
+              data-text="価格が高い順"
+              value="expensive"
+            />
+            <span class="c-radio">価格が高い順</span>
+          </label>
+        </li>
+      </ul>
+      
+        <p class="l-sort__modal--title l-sort__modal--title--number">表示件数</p>
+        <ul>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-1">
+              <input
+                type="radio"
+                id="sort--modal-1"
+                name="display-amount"
+                class=""
+                value="50"
+              />
+              <span class="c-radio">50件</span>
+            </label>
+          </li>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-2">
+              <input
+                type="radio"
+                id="sort--modal-2"
+                name="display-amount"
+                class=""
+                value="100" checked="checked"
+              />
+              <span class="c-radio">100件</span>
+            </label>
+          </li>
+        </ul>
+      
+    </div>
+    <div class="l-sort__modal--button">
+      <!-- フォームサブミット -->
+      <button type="submit" class="c-button--search-orange" id="js-sortButton">変更する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <form action="/cmdtyallsearch/" name="filterModalForm1">
+        <input type="hidden" name="word" value="9784813705185" />
+        <!-- ソートモーダル -->
+        <div
+  class="c-modal"
+  id="js-filter-tab-modal"
+>
+  <div class="c-modal__background js-toggle" data-target="js-filter-tab-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle c-modal__close-adjust" data-target="js-filter-tab-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-filter-tab__list--title-flex">
+        <p class="l-filter-tab__list--title">絞込み</p>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm pc-none" data-target="js-filterTabForm">条件をリセット</button>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm sp-none" data-target="js-filterTabForm">条件をリセット</button>
+      </div>
+    </div>
+    
+    <div class="c-modal__inner--scroll" id="js-filterTabForm">
+      <div>
+        <h4 class="l-filter-tab__title--category">カテゴリ</h4>
+        <ul class="l-filter-tab__list js-filter-list-category">
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_1"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="7001"
+            />
+            <label for="filter_category_1" class="c-checkbox__label--tag">DVD・Blu-ray(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_2"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="5001"
+            />
+            <label for="filter_category_2" class="c-checkbox__label--tag">ゲーム(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_3"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1002" checked="checked"
+            />
+            <label for="filter_category_3" class="c-checkbox__label--tag">古本・中古本(1)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_4"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1001"
+            />
+            <label for="filter_category_4" class="c-checkbox__label--tag">コミック(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_5"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="3001"
+            />
+            <label for="filter_category_5" class="c-checkbox__label--tag">CD(0)</label>
+          </li>
+        </ul>
+      </div>
+      
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">ジャンル</h4>
+          <ul class="l-filter-tab__list js-filter-list-genre">
+            <li class="l-filter-tab__list--item">
+              <input
+                type="radio"
+                id="filter_genre_1"
+                name="filter_genre"
+                class="c-checkbox__tag js-filter-modal-genre"
+                value="1002_10"
+              />
+              <label for="filter_genre_1" class="c-checkbox__label--tag">文芸(1)</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">著者/アーティスト</h4>
+          <ul class="l-filter-tab__list js-filter-list-artist">
+            <li class="l-filter-tab__list--item">
+              <input type="radio" id="filter_artist_1" name="filter_artist" class="c-checkbox__tag" value="汐見夏衛" />
+              <label for="filter_artist_1" class="c-checkbox__label--tag">汐見夏衛</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">在庫</h4>
+        <div class="l-filter-tab__list--checkbox">
+          <input name="filter_stock" type="checkbox" class="c-checkbox" id="filter_tag_stock" value="1" />
+          <label for="filter_tag_stock">
+            <span class="c-checkbox__label">在庫あり</span>
+          </label>
+        </div>
+      </div>
+      <div>
+        <h4 class="l-filter-tab__title--category">価格帯</h4>
+        <div class="js_filter_modal_price_container">
+          <div class="l-filter-tab__list--input">
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_min" value="" />&ensp;円&#65374;
+            </div>
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_max" value="" />&ensp;円
+            </div>
+            <div class="l-filter-tab__list--input-error">
+              <span class="c-input-text__error-message">価格帯は半角数字のみで入力してください。</span>
+            </div>
+          </div>
+          <ul class="l-filter-tab__list">
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp10" name="filter_tag_price_110" class="c-checkbox__tag js_filter_modal_price" value="0_110" />
+              <label for="filter_tmp10" class="c-checkbox__label--tag">&#65374; 110円以下</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp11" name="filter_tag_price_111_500" class="c-checkbox__tag js_filter_modal_price" value="111_500" />
+              <label for="filter_tmp11" class="c-checkbox__label--tag">111円 &#65374; 500円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp12" name="filter_tag_price_501_1000" class="c-checkbox__tag js_filter_modal_price" value="501_1000" />
+              <label for="filter_tmp12" class="c-checkbox__label--tag">501円 &#65374; 1,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp13" name="filter_tag_price_1001_3000" class="c-checkbox__tag js_filter_modal_price" value="1001_3000" />
+              <label for="filter_tmp13" class="c-checkbox__label--tag">1,001円 &#65374; 3,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp14" name="filter_tag_price_3001_5000" class="c-checkbox__tag js_filter_modal_price" value="3001_5000" />
+              <label for="filter_tmp14" class="c-checkbox__label--tag">3,001円 &#65374; 5,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp15" name="filter_tag_price_5001" class="c-checkbox__tag js_filter_modal_price" value="5001_0" />
+              <label for="filter_tmp15" class="c-checkbox__label--tag">5,001円 &#65374; </label>
+            </li>
+          </ul>
+        </div>
+      </div>
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">サイズ</h4>
+          <ul class="l-filter-tab__list js-filter-list-size">
+            <li class="l-filter-tab__list--item">
+              <input type="radio" id="filter_size_1" name="filter_size" class="c-checkbox__tag" value="文庫" />
+              <label for="filter_size_1" class="c-checkbox__label--tag">文庫</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">おすすめ</h4>
+        <ul class="l-filter-tab__list">
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_1" name="filter_recommend_1" class="c-checkbox__tag" value="1" />
+            <label for="filter_recommend_1" class="c-checkbox__label--tag">メール便対象商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_2" name="filter_recommend_2" class="c-checkbox__tag" value="2" />
+            <label for="filter_recommend_2" class="c-checkbox__label--tag">値下げ商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_3" name="filter_recommend_3" class="c-checkbox__tag" value="3" />
+            <label for="filter_recommend_3" class="c-checkbox__label--tag">激安商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_4" name="filter_recommend_4" class="c-checkbox__tag" value="4" />
+            <label for="filter_recommend_4" class="c-checkbox__label--tag">タダ本対象商品</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="l-sort__modal--button l-filter-tab__button">
+      <button type="submit" class="c-button--search-orange" id="js-filterButton">検索する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <!-- 下部固定ナビゲーション -->
+      <div class="c-bottom-nav" id="js-searchModal">
+  <div class="c-bottom-nav__button-container">
+    <div class="c-bottom-nav__buttons">
+      <button type="" class="c-button--outline c-button-nav__clear-button" data-target="js-bottomNavSortForm">条件を解除する</button>
+      <button type="" class="c-button--next-green c-button-nav__search-button" disabled>検索する</button>
+    </div>
+
+    <nav>
+      <ul class="c-bottom-nav__list">
+        <li class="c-bottom-nav__nav">
+          <button type="button" class="c-bottom-nav__link js-toggle" data-target="js-searchModal" id="memory-ajax">
+            <span class="c-button-nav__search">商品を探す</span>
+            <span class="c-button-nav__close">閉じる</span>
+          </button>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/myfavorite/" class="c-bottom-nav__link">
+            
+            
+            お気に入り
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/incomingmaillist/" class="c-bottom-nav__link">
+            
+            
+            入荷・予約
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/browsinghistory/" class="c-bottom-nav__link">閲覧履歴</a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/purchase/cart/" class="c-bottom-nav__link">
+            
+            カート
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="c-bottom-nav__modal">
+    <ul class="c-bottom-nav__tab-list">
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="search-srot" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab2" />
+        <label for="search-srot" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--sort" onclick="handleTabClick('search', null, null)">商品を探す</label>
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="recommend" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab3" />
+        <label for="recommend" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--recommend" onclick="handleTabClick('taglist', null, '1002')"
+          >ネットオフの<br />おすすめ</label
+        >
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="memory" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab1" />
+        <label for="memory" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--memory" onclick="handleTabClick('memory', null, null)">思い出の作品</label>
+      </li>
+    </ul>
+
+    <!-- 思い出の作品 -->
+    <div class="c-bottom-nav__modal-inner">
+      <div class="c-bottom-nav__modal-contents c-bottom-nav__memory js-tabContent" id="js-bottomNavTab1">
+        <ul class="l-bottom-nav__select-container">
+          <!-- ジャンル表示ここから -->
+          <li class="c-bottom-nav__memory-category-list l-bottom-nav__category-list" id="memory-select-container-category">
+            <div class="c-select js-select" data-target="js-bottomNavCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavCategory"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavCategory">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="男性向けコミック" data-value="男性向けコミック" id="bottomNavCategory1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory1">男性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="女性向けコミック" data-value="女性向けコミック" id="bottomNavCategory2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory2">女性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="文庫小説・エッセイ" data-value="文庫小説・エッセイ" id="bottomNavCategory3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory3">文庫小説・エッセイ </label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="単行本小説・エッセイ" data-value="単行本小説・エッセイ" id="bottomNavCategory4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory4">単行本小説・エッセイ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ライトノベル" data-value="ライトノベル" id="bottomNavCategory5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory5">ライトノベル</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ゲーム" data-value="ゲーム" id="bottomNavCategory6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory6">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="映画・ドラマ" data-value="映画・ドラマ" id="bottomNavCategory7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory7">映画・ドラマ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="アニメ" data-value="アニメ" id="bottomNavCategory8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory8">アニメ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="邦楽" data-value="邦楽" id="bottomNavCategory9" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory9">邦楽</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- ジャンル表示ここまで -->
+          <!-- 年表示ここから -->
+          <li class="l-bottom-nav__generation-list" id="memory-select-container-generation">
+            <div class="c-select js-select" data-target="js-bottomNavGeneration" tabindex="0">
+              <div class="c-select__label js-selectLabel js-memory-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavGeneration"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavGeneration">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="2000年" data-value="2000" id="bottomNavGeneration1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration1">2000年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2005年" data-value="2005" id="bottomNavGeneration2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration2">2005年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2010年" data-value="2010" id="bottomNavGeneration3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration3">2010年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2015年" data-value="2015" id="bottomNavGeneration4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration4">2015年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2020年" data-value="2020" id="bottomNavGeneration5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration5">2020年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2021年" data-value="2021" id="bottomNavGeneration6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration6">2021年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2022年" data-value="2022" id="bottomNavGeneration7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration7">2022年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2023年" data-value="2023" id="bottomNavGeneration8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration8">2023年</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- 年表示ここまで -->
+          <li>
+            <div class="l-bottom-nav__btn-wrap">
+              <button type="submit" class="l-bottom-nav__submit-btn" id="memory-submit-btn"></button>
+            </div>
+          </li>
+        </ul>
+        <div class="l-bottom-nav__ranking-container">
+          
+          <ul id="memory-container" class="c-bottom-nav__ranking-list">
+            <li>
+              <p class="l-bottom-nav__ranking-text">
+                作品がありません<br />
+                他の条件で探してみましょう！
+              </p>
+            </li>
+          </ul>
+          
+          <!-- <ul class="c-bottom-nav__ranking-list">
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--1">1</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--2">2</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--3">3</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy3.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--4">4</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy4.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+          </ul> -->
+        </div>
+      </div>
+    </div>
+    <!-- 思い出の作品 -->
+
+    <form id="js-bottomNavSortForm" method="GET" action="/cmdtyallsearch/">
+      <!-- 絞り込み -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab2">
+        <div class="c-bottom-nav__input">
+          <input id="js-bottomNavWord" type="text" name="word" placeholder="キーワードを入力" />
+          <input type="hidden" id="hiddenCat" name="cat" value="" />
+          <input type="hidden" id="hiddenGenre" name="genre" value="" />
+          <button type="button" class="c-bottom_nav__input-button">
+            <img src="/img/search_simple_icon.svg" alt="search" />
+          </button>
+        </div>
+        <ul id="search-category">
+          
+          <!-- <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory1">古本・中古本</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory1">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks1" />
+                    <label for="js-bottomNavSortGenreBooks1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks2" />
+                    <label for="js-bottomNavSortGenreBooks2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks3" />
+                    <label for="js-bottomNavSortGenreBooks3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks4" />
+                    <label for="js-bottomNavSortGenreBooks4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown is-active" data-target="js-bottomNavSortCategory2">コミック</div>
+              <div class="c-bottom-nav__sort-genre-container" id="js-bottomNavSortCategory2">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics1" />
+                    <label for="js-bottomNavSortGenreComics1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics2" />
+                    <label for="js-bottomNavSortGenreComics2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics3" />
+                    <label for="js-bottomNavSortGenreComics3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics4" />
+                    <label for="js-bottomNavSortGenreComics4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory3">コミックセット</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory3">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet1" />
+                    <label for="js-bottomNavSortGenreComicsSet1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet2" />
+                    <label for="js-bottomNavSortGenreComicsSet2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet3" />
+                    <label for="js-bottomNavSortGenreComicsSet3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet4" />
+                    <label for="js-bottomNavSortGenreComicsSet4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet5" />
+                    <label for="js-bottomNavSortGenreComicsSet5">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory4">ゲーム</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory4">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames1" />
+                    <label for="js-bottomNavSortGenreGames1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames2" />
+                    <label for="js-bottomNavSortGenreGames2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames3" />
+                    <label for="js-bottomNavSortGenreGames3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames4" />
+                    <label for="js-bottomNavSortGenreGames4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory5">トレカ</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory5">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards1" />
+                    <label for="js-bottomNavSortGenreCards1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards2" />
+                    <label for="js-bottomNavSortGenreCards2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards3" />
+                    <label for="js-bottomNavSortGenreCards3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards4" />
+                    <label for="js-bottomNavSortGenreCards4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory6">DVD・Blu-ray</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory6">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD1" />
+                    <label for="js-bottomNavSortGenreDVD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD2" />
+                    <label for="js-bottomNavSortGenreDVD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD3" />
+                    <label for="js-bottomNavSortGenreDVD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD4" />
+                    <label for="js-bottomNavSortGenreDVD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory7">CD</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory7">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD1" />
+                    <label for="js-bottomNavSortGenreCD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD2" />
+                    <label for="js-bottomNavSortGenreCD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD3" />
+                    <label for="js-bottomNavSortGenreCD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD4" />
+                    <label for="js-bottomNavSortGenreCD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li> -->
+        </ul>
+      </div>
+      <!-- 絞り込み -->
+      <!-- ネットオフのおすすめ -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab3">
+        <p class="c-bottom-nav__tag-heading">人気タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavPopularCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavPopularCategory">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavPopularCategory">
+                <div>
+                  <input type="radio" name="popular-category" value="古本・中古本" data-value="1002" id="popular-category1" checked class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category1" id="popular-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミック" data-value="1001" id="popular-category2" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category2" id="popular-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミックセット" data-value="1011" id="popular-category3" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="ゲーム" data-value="5001" id="popular-category4" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="DVD・Blu-ray" data-value="7001" id="popular-category5" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="CD" data-value="3001" id="popular-category6" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="popularTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <p class="c-bottom-nav__tag-heading">新着タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavTagNewCategory1" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavTagNewCategory1">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavTagNewCategory1">
+                <div>
+                  <input type="radio" name="new-category" value="古本・中古本" data-value="1002" id="new-category1" checked class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミック" data-value="1001" id="new-category2" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミックセット" data-value="1011" id="new-category3" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="ゲーム" data-value="5001" id="new-category4" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="DVD・Blu-ray" data-value="7001" id="new-category5" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="CD" data-value="3001" id="new-category6" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="newTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+
+          <!-- <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown is-active" data-target="js-bottomNavTagCategory1">コミック</div>
+            <div class="c-bottom-nav__tag-container" id="js-bottomNavTagCategory1">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li>
+          <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown" data-target="js-bottomNavTagCategory2">コミックセット</div>
+            <div class="c-bottom-nav__tag-container c-bottom-nav__tag-container--close" id="js-bottomNavTagCategory2">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li> -->
+        </div>
+        <p class="c-bottom-nav__tag-heading">好きな商品の関連商品を探す</p>
+        <div class="l-bottom-nav__tag-search">
+          <p class="l-bottom-nav__lead-text c-link--blue">お好きな商品を含むタグの一覧を表示します</p>
+          <div class="c-bottom-nav__input" method="GET" action="/cmdtyallsearch/">
+            <input type="text" name="word" id="wordInput" placeholder="キーワードを入力" />
+            <button type="button" class="c-bottom_nav__input-button" onclick="handleButtonClick()">
+              <img src="/img/search_simple_icon.svg" alt="search" />
+            </button>
+          </div>
+          <div class="c-bottom-nav__tag-container">
+            <ul class="c-bottom-nav__tag-list" id="tagSearch">
+              <!-- <li>
+                <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                  <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                    <span>2023年映画化</span>
+                  </label>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+              </li> -->
+            </ul>
+            <div class="c-bottom-nav__tag-link-container">
+              <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+            </div>
+          </div>
+        </div>
+        <p class="c-bottom-nav__tag-heading">おすすめの特集から探す</p>
+        <ul class="l-bottom-nav__campaign-list">
+          <li class="l-bottom-nav__campaign-item">
+            <a href="https://www.netoff.co.jp/special/comicset.jsp">
+  <img src="/images/banner/main/serchmodal-1m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/ranking2023/">
+  <img src="/images/banner/main/serchmodal-2m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/bl_comic.jsp">
+  <img src="/images/banner/main/serchmodal-3m-banner.webp" alt="" />
+</a>
+
+          </li>
+        </ul>
+      </div>
+      <!-- ネットオフのおすすめ -->
+    </form>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/bottom-navigation.js" defer></script>
+  </div>
+</div>
+
+      <form action="/cmdtyallsearch/" name="sortModalForm2">
+        <input
+          type="hidden"
+          name="clFrom"
+          value="1"
+        /><input
+          type="hidden"
+          name="cat"
+          value="1002"
+        /><input
+          type="hidden"
+          name="clTo"
+          value="1"
+        /><input
+          type="hidden"
+          name="clNext"
+          value="100"
+        /><input
+          type="hidden"
+          name="clPrev"
+          value="-100"
+        /><input
+          type="hidden"
+          name="word"
+          value="9784813705185"
+        /><input
+          type="hidden"
+          name="dnum"
+          value="100"
+        /><input
+          type="hidden"
+          name="pageMax"
+          value="1"
+        />
+        <!-- ソートモーダル -->
+        <div class="c-modal" id="js-sort-modal">
+  <div class="c-modal__background js-toggle" data-target="js-sort-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle" data-target="js-sort-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <p class="l-sort__modal--title">並び順</p>
+    </div>
+    <div class="c-modal__inner--scroll">
+      <ul class="l-sort__modal--categorylist">
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--1">
+            <input
+              type="radio"
+              id="sort--modal--1"
+              name="sort"
+              data-text="関連度順"
+              value="relevance" checked="checked"
+            />
+            <span class="c-radio">関連度順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--2">
+            <input
+              type="radio"
+              id="sort--modal--2"
+              name="sort"
+              data-text="よく見られている順"
+              value="popular"
+            />
+            <span class="c-radio">よく見られている順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--3">
+            <input
+              type="radio"
+              id="sort--modal--3"
+              name="sort"
+              data-text="発売日が新しい順"
+              value="newest"
+            />
+            <span class="c-radio">発売日が新しい順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--4">
+            <input
+              type="radio"
+              id="sort--modal--4"
+              name="sort"
+              data-text="発売日が古い順"
+              value="oldest"
+            />
+            <span class="c-radio">発売日が古い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--5">
+            <input
+              type="radio"
+              id="sort--modal--5"
+              name="sort"
+              data-text="価格が安い順"
+              value="cheap"
+            />
+            <span class="c-radio">価格が安い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--6">
+            <input
+              type="radio"
+              id="sort--modal--6"
+              name="sort"
+              data-text="価格が高い順"
+              value="expensive"
+            />
+            <span class="c-radio">価格が高い順</span>
+          </label>
+        </li>
+      </ul>
+      
+        <p class="l-sort__modal--title l-sort__modal--title--number">表示件数</p>
+        <ul>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-1">
+              <input
+                type="radio"
+                id="sort--modal-1"
+                name="display-amount"
+                class=""
+                value="50"
+              />
+              <span class="c-radio">50件</span>
+            </label>
+          </li>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-2">
+              <input
+                type="radio"
+                id="sort--modal-2"
+                name="display-amount"
+                class=""
+                value="100" checked="checked"
+              />
+              <span class="c-radio">100件</span>
+            </label>
+          </li>
+        </ul>
+      
+    </div>
+    <div class="l-sort__modal--button">
+      <!-- フォームサブミット -->
+      <button type="submit" class="c-button--search-orange" id="js-sortButton">変更する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <form action="/cmdtyallsearch/" name="filterModalForm2">
+        <input type="hidden" name="word" value="9784813705185" />
+        <div
+  class="c-modal"
+  id="js-filter-tab-modal"
+>
+  <div class="c-modal__background js-toggle" data-target="js-filter-tab-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle c-modal__close-adjust" data-target="js-filter-tab-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-filter-tab__list--title-flex">
+        <p class="l-filter-tab__list--title">絞込み</p>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm pc-none" data-target="js-filterTabForm">条件をリセット</button>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm sp-none" data-target="js-filterTabForm">条件をリセット</button>
+      </div>
+    </div>
+    
+    <div class="c-modal__inner--scroll" id="js-filterTabForm">
+      <div>
+        <h4 class="l-filter-tab__title--category">カテゴリ</h4>
+        <ul class="l-filter-tab__list js-filter-list-category">
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_1"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="7001"
+            />
+            <label for="filter_category_1" class="c-checkbox__label--tag">DVD・Blu-ray(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_2"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="5001"
+            />
+            <label for="filter_category_2" class="c-checkbox__label--tag">ゲーム(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_3"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1002" checked="checked"
+            />
+            <label for="filter_category_3" class="c-checkbox__label--tag">古本・中古本(1)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_4"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1001"
+            />
+            <label for="filter_category_4" class="c-checkbox__label--tag">コミック(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_5"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="3001"
+            />
+            <label for="filter_category_5" class="c-checkbox__label--tag">CD(0)</label>
+          </li>
+        </ul>
+      </div>
+      
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">ジャンル</h4>
+          <ul class="l-filter-tab__list js-filter-list-genre">
+            <li class="l-filter-tab__list--item">
+              <input
+                type="radio"
+                id="filter_genre_1"
+                name="filter_genre"
+                class="c-checkbox__tag js-filter-modal-genre"
+                value="1002_10"
+              />
+              <label for="filter_genre_1" class="c-checkbox__label--tag">文芸(1)</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">著者/アーティスト</h4>
+          <ul class="l-filter-tab__list js-filter-list-artist">
+            <li class="l-filter-tab__list--item">
+              <input type="radio" id="filter_artist_1" name="filter_artist" class="c-checkbox__tag" value="汐見夏衛" />
+              <label for="filter_artist_1" class="c-checkbox__label--tag">汐見夏衛</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">在庫</h4>
+        <div class="l-filter-tab__list--checkbox">
+          <input name="filter_stock" type="checkbox" class="c-checkbox" id="filter_tag_stock" value="1" />
+          <label for="filter_tag_stock">
+            <span class="c-checkbox__label">在庫あり</span>
+          </label>
+        </div>
+      </div>
+      <div>
+        <h4 class="l-filter-tab__title--category">価格帯</h4>
+        <div class="js_filter_modal_price_container">
+          <div class="l-filter-tab__list--input">
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_min" value="" />&ensp;円&#65374;
+            </div>
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_max" value="" />&ensp;円
+            </div>
+            <div class="l-filter-tab__list--input-error">
+              <span class="c-input-text__error-message">価格帯は半角数字のみで入力してください。</span>
+            </div>
+          </div>
+          <ul class="l-filter-tab__list">
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp10" name="filter_tag_price_110" class="c-checkbox__tag js_filter_modal_price" value="0_110" />
+              <label for="filter_tmp10" class="c-checkbox__label--tag">&#65374; 110円以下</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp11" name="filter_tag_price_111_500" class="c-checkbox__tag js_filter_modal_price" value="111_500" />
+              <label for="filter_tmp11" class="c-checkbox__label--tag">111円 &#65374; 500円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp12" name="filter_tag_price_501_1000" class="c-checkbox__tag js_filter_modal_price" value="501_1000" />
+              <label for="filter_tmp12" class="c-checkbox__label--tag">501円 &#65374; 1,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp13" name="filter_tag_price_1001_3000" class="c-checkbox__tag js_filter_modal_price" value="1001_3000" />
+              <label for="filter_tmp13" class="c-checkbox__label--tag">1,001円 &#65374; 3,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp14" name="filter_tag_price_3001_5000" class="c-checkbox__tag js_filter_modal_price" value="3001_5000" />
+              <label for="filter_tmp14" class="c-checkbox__label--tag">3,001円 &#65374; 5,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp15" name="filter_tag_price_5001" class="c-checkbox__tag js_filter_modal_price" value="5001_0" />
+              <label for="filter_tmp15" class="c-checkbox__label--tag">5,001円 &#65374; </label>
+            </li>
+          </ul>
+        </div>
+      </div>
+      
+        <div>
+          <h4 class="l-filter-tab__title--category">サイズ</h4>
+          <ul class="l-filter-tab__list js-filter-list-size">
+            <li class="l-filter-tab__list--item">
+              <input type="radio" id="filter_size_1" name="filter_size" class="c-checkbox__tag" value="文庫" />
+              <label for="filter_size_1" class="c-checkbox__label--tag">文庫</label>
+            </li>
+          </ul>
+        </div>
+        
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">おすすめ</h4>
+        <ul class="l-filter-tab__list">
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_1" name="filter_recommend_1" class="c-checkbox__tag" value="1" />
+            <label for="filter_recommend_1" class="c-checkbox__label--tag">メール便対象商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_2" name="filter_recommend_2" class="c-checkbox__tag" value="2" />
+            <label for="filter_recommend_2" class="c-checkbox__label--tag">値下げ商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_3" name="filter_recommend_3" class="c-checkbox__tag" value="3" />
+            <label for="filter_recommend_3" class="c-checkbox__label--tag">激安商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_4" name="filter_recommend_4" class="c-checkbox__tag" value="4" />
+            <label for="filter_recommend_4" class="c-checkbox__label--tag">タダ本対象商品</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="l-sort__modal--button l-filter-tab__button">
+      <button type="submit" class="c-button--search-orange" id="js-filterButton">検索する</button>
+    </div>
+  </div>
+</div>
+      </form>
+    </main>
+
+    <footer>
+      <div class="l-footer l-footer--sp">
+  <nav>
+    <ul>
+      <li>
+        <div class="l-footer__heading">カテゴリから探す</div>
+        <ul>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav1">古本・中古本</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav1">
+              <li>
+                <a href="/book/" class="l-footer__nav-list l-footer__nav-list--category-link">古本・中古本 TOP</a>
+              </li>
+              <li>
+                <a href="/book/10/" class="l-footer__nav-list l-footer__nav-list--category-link">文芸</a>
+              </li>
+              <li>
+                <a href="/book/11/" class="l-footer__nav-list l-footer__nav-list--category-link">ビジネス</a>
+              </li>
+              <li>
+                <a href="/book/12/" class="l-footer__nav-list l-footer__nav-list--category-link">政治・経済・法律</a>
+              </li>
+              <li>
+                <a href="/book/13/" class="l-footer__nav-list l-footer__nav-list--category-link">料理・趣味・児童</a>
+              </li>
+              <li>
+                <a href="/book/14/" class="l-footer__nav-list l-footer__nav-list--category-link">教育・福祉・資格</a>
+              </li>
+              <li>
+                <a href="/book/15/" class="l-footer__nav-list l-footer__nav-list--category-link">女性・生活・コンピュータ</a>
+              </li>
+              <li>
+                <a href="/book/16/" class="l-footer__nav-list l-footer__nav-list--category-link">産業・学術・歴史</a>
+              </li>
+              <li>
+                <a href="/book/17/" class="l-footer__nav-list l-footer__nav-list--category-link">スポーツ・健康・医療</a>
+              </li>
+              <li>
+                <a href="/book/18/" class="l-footer__nav-list l-footer__nav-list--category-link">写真集</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav2">コミック</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav2">
+              <li>
+                <a href="/comic/" class="l-footer__nav-list l-footer__nav-list--category-link">コミック TOP</a>
+              </li>
+              <li>
+                <a href="/comic/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comic/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comic/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <li>
+                <a href="/comic/26/" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li>
+              <li>
+                <a href="/comic/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav3">コミックセット</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav3">
+              <li>
+                <a href="/comicset/" class="l-footer__nav-list l-footer__nav-list--category-link">コミックセット TOP</a>
+              </li>
+              <li>
+                <a href="/comicset/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comicset/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <!-- <li>
+                <a href="/comicset/26" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li> -->
+              <li>
+                <a href="/comicset/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav4">ゲーム</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav4">
+              <li><a href="/game/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲーム TOP</a></li>
+              <li><a href="/game/80/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch2</a></li>
+              <li><a href="/game/75/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch</a></li>
+              <li><a href="/game/72/" class="l-footer__nav-list l-footer__nav-list--category-link">WiiU</a></li>
+              <li><a href="/game/67/" class="l-footer__nav-list l-footer__nav-list--category-link">Wii</a></li>
+              <li><a href="/game/70/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドー3DS</a></li>
+              <li><a href="/game/56/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドーDS</a></li>
+              <!-- <li><a href="/game/54/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/game/57/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=54&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=57&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li>
+              <li><a href="/game/77/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション5</a></li>
+              <li><a href="/game/73/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション4</a></li>
+              <li><a href="/game/66/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション3</a></li>
+              <li><a href="/game/51/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション2</a></li>
+              <li><a href="/game/52/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション</a></li>
+              <li><a href="/game/71/" class="l-footer__nav-list l-footer__nav-list--category-link">PS Vita</a></li>
+              <li><a href="/game/53/" class="l-footer__nav-list l-footer__nav-list--category-link">PSP</a></li>
+              <!-- <li><a href="/game/74/" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/game/65/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/game/61/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=74&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=65&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=61&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li>
+              <li><a href="/game/78/" class="l-footer__nav-list l-footer__nav-list--category-link">レトロゲーム</a></li>
+              <li><a href="/game/68/" class="l-footer__nav-list l-footer__nav-list--category-link">PCゲーム</a></li>
+            </ul>
+          </li>
+          <!-- <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav5">トレカ</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav5">
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">トレカ TOP</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ポケモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ワンピースカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">シャドウバース エボルブ</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">遊戯王</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">デジモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ヴァンガード</a>
+              </li>
+            </ul>
+          </li> -->
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav6">DVD・Blu-ray</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav6">
+              <li>
+                <a href="/dvd/" class="l-footer__nav-list l-footer__nav-list--category-link">DVD・Blu-ray TOP</a>
+              </li>
+              <li>
+                <a href="/dvd/41/" class="l-footer__nav-list l-footer__nav-list--category-link">洋画</a>
+              </li>
+              <li>
+                <a href="/dvd/42/" class="l-footer__nav-list l-footer__nav-list--category-link">邦画</a>
+              </li>
+              <li>
+                <a href="/dvd/43/" class="l-footer__nav-list l-footer__nav-list--category-link">ミュージック</a>
+              </li>
+              <li>
+                <a href="/dvd/44/" class="l-footer__nav-list l-footer__nav-list--category-link">アニメ</a>
+              </li>
+              <li>
+                <a href="/dvd/45/" class="l-footer__nav-list l-footer__nav-list--category-link">芸能・スポーツ・その他</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav7">CD</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav7">
+              <li>
+                <a href="/cd/" class="l-footer__nav-list l-footer__nav-list--category-link">CD TOP</a>
+              </li>
+              <li>
+                <a href="/cd/31/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャパニーズポップス</a>
+              </li>
+              <li>
+                <a href="/cd/32/" class="l-footer__nav-list l-footer__nav-list--category-link">海外のロック＆ポップス</a>
+              </li>
+              <li>
+                <a href="/cd/33/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャズ＆フュージョン</a>
+              </li>
+              <li>
+                <a href="/cd/34/" class="l-footer__nav-list l-footer__nav-list--category-link">イージーリスニング</a>
+              </li>
+              <li>
+                <a href="/cd/35/" class="l-footer__nav-list l-footer__nav-list--category-link">クラシック</a>
+              </li>
+              <li>
+                <a href="/cd/36/" class="l-footer__nav-list l-footer__nav-list--category-link">サウンドトラック</a>
+              </li>
+              <li>
+                <a href="/cd/37/" class="l-footer__nav-list l-footer__nav-list--category-link">童謡・民謡・その他</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__heading">おすすめから探す</div>
+        <ul>
+          <li><a class="l-footer__nav-list" href="/special/">キャンペーン・特集</a></li>
+          <li><a class="l-footer__nav-list" href="/timesale/">タイムセール</a></li>
+          <!-- <li>
+            <a th:with="result = ${T(www.netoff.co.jp.web.config.UrlConfig).TAG_DETAILS_URL}" th:href="${result + '?tagid=19821&cat=7001'}">110円～！激安人気作ランキング</a>
+          </li>
+          <li>
+            <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}" class="l-footer__nav-list"
+              >あなたにおすすめの商品</a
+            >
+          </li> -->
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__purchase">
+          <span>ラクして売るなら</span>
+          ネットオフ宅配買取
+        </div>
+        <ul>
+          <li>
+            <a href="/sell/book/" class="l-footer__nav-list l-footer__nav-list--accent">本＆ゲーム買取コース</a>
+          </li>
+          <li>
+            <a href="/sell/book/book/" class="l-footer__nav-list">古本・中古本買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/comic/" class="l-footer__nav-list">コミック買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/" class="l-footer__nav-list">ゲームソフト買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/body.jsp" class="l-footer__nav-list">ゲーム機本体買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/dvd/" class="l-footer__nav-list">DVD・Blu-ray買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/cd/" class="l-footer__nav-list">CD買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/moetaku/" class="l-footer__nav-list l-footer__nav-list--accent">ホビー・フィギュア買取 もえたく！</a>
+          </li>
+          <li>
+            <a href="/figure/" class="l-footer__nav-list">フィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/kuji_prize/" class="l-footer__nav-list">プライズフィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/plamodel/" class="l-footer__nav-list">プラモデル買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/" class="l-footer__nav-list">トレカ買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/pokemon_card/" class="l-footer__nav-list">ポケモンカード買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/onepiece/" class="l-footer__nav-list">ワンピースカード買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/sell/general/" class="l-footer__nav-list l-footer__nav-list--accent">ブランド＆総合買取コース</a>
+          </li>
+          <li>
+            <a href="/kaden/" class="l-footer__nav-list">家電買取</a>
+          </li>
+          <li>
+            <a href="/kaden/camera/" class="l-footer__nav-list">カメラ買取</a>
+          </li>
+          <li>
+            <a href="/kaden/gamingpc/" class="l-footer__nav-list">ゲーミングPC買取</a>
+          </li>
+          <li>
+            <a href="/kaden/deditalstationery/lcdtablet/" class="l-footer__nav-list">液タブ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/" class="l-footer__nav-list">スマホ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/smartphone/iphone/" class="l-footer__nav-list">iPhone買取</a>
+          </li>
+          <li>
+            <a href="/clothes/" class="l-footer__nav-list">洋服・古着買取</a>
+          </li>
+          <li>
+            <a href="/brand/brand/" class="l-footer__nav-list">ブランド買取</a>
+          </li>
+          <li>
+            <a href="/brand/jewelry/" class="l-footer__nav-list">金・プラチナ買取</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  ﻿<aside id="footer-1m-banner" class="l-footer__banner">
+  <!-- バナー -->
+  <a href="https://page.line.me/trp3160p?oat__id=699595&openQrModal=true" target="0">
+    <img src="/images/banner/main/footer-1m-banner.webp" alt="LINE 公式アカウント"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?category=1643943081566646275" target="0">
+    <img src="/images/banner/main/footer-2m-banner.webp" alt="もえたく 社員募集"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?jobType=PART&category=1644999205883056129" target="0">
+    <img src="/images/banner/main/footer-3m-banner.webp" alt="ネットオフ アルバイト募集"/>
+  </a>
+</aside>
+
+
+  <nav>
+    <ul>
+      <li>
+        <a href="/kaitori-navi/" class="l-footer__nav-list">買取ナビTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/" class="l-footer__nav-list">VODチョイスTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/ebook/" class="l-footer__nav-list">おすすめ電子書籍</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/vod/" class="l-footer__nav-list">おすすめ動画配信サービス</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/" class="l-footer__nav-list">インターネット比較TOP</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/pocket-wifi/" class="l-footer__nav-list">おすすめポケット型WiFi</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/wimax-comparison/" class="l-footer__nav-list">おすすめWiMAX</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/hikari-recommendation/" class="l-footer__nav-list">おすすめ光回線</a>
+      </li>
+      <li>
+        <a href="https://fortune.netoff.co.jp/" class="l-footer__nav-list">占ナビTOP</a>
+      </li>
+      <li>
+        <a href="/notification/noticelist/" class="l-footer__nav-list">お知らせ</a>
+      </li>
+      <li>
+        <a href="/guide/beginner.jsp" class="l-footer__nav-list">初めての方へ</a>
+      </li>
+      <li>
+        <a href="/guide/" class="l-footer__nav-list">ヘルプ・お問い合わせ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__info-container">
+    <img
+      src="/img/icon_mothers_sp.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+    <div class="l-footer__button-container">
+      
+        <!-- 未ログイン -->
+        <a href="/sell/" class="l-footer__button l-footer__button--purchase l-footer__button--flex">宅配買取</a>
+        <a
+          class="l-footer__button l-footer__button--sign l-footer__button--flex"
+          href="/registration/enterinformation/"
+          >新規会員登録</a
+        >
+      
+      
+    </div>
+    <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+  </div>
+
+  <nav>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/company/">会社案内</a>
+      </li>
+      <li>
+        <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+      </li>
+    </ul>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/guide/netoff.jsp">品質ポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/">プライバシーポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/#policy02">個人情報保護方針</a>
+      </li>
+      <li>
+        <a href="/customer/">お客様への対応について</a>
+      </li>
+      <li>
+        <a href="/use/">ご利用規約</a>
+      </li>
+      <li>
+        <a href="/settlement/">資金決済法に基づく表示</a>
+      </li>
+      <li>
+        <a href="/sitemap/">サイトマップ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__netoff">
+    <span>ネットオフ株式会社</span>
+    古物商許可番号 542782100600 愛知県公安委員会許可<br />
+    <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+  </div>
+
+  <small class="l-footer__copyright">Copyright &copy; NETOFF,inc.</small>
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="e38a53ff-1a5f-4df6-8603-fecb5d37496f"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+  <!-- <div class="c-modal" id="js-footerLogout">
+    <div
+      class="c-modal__background js-toggle"
+      data-target="js-footerLogout"
+    ></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button
+          type="button"
+          class="c-button--black js-toggle"
+          data-target="js-footerLogout"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          class="c-button--black-outline"
+          onClick="window.location.href='/'"
+        >
+          ログアウト
+        </button>
+      </div>
+    </div>
+  </div> -->
+</div>
+      <div class="l-footer l-footer--pc">
+  <div class="l-footer__about">
+    <img
+      src="/img/icon_mothers_pc.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+  </div>
+
+  <div class="l-footer__container">
+    <div class="l-footer__scroll-top">
+      <button type="button" onclick="window.scrollTo({ top: 0 })">▲ このページの先頭に戻る</button>
+    </div>
+    <div class="l-footer__inner">
+      <nav class="l-footer__main-nav-container">
+        <ul>
+          <li>
+            <div class="l-footer__heading">カテゴリから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/book/">古本・中古本</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comic/">コミック</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comicset/">コミックセット</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/game/">ゲーム</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">トレカ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/dvd/">DVD・Blu-ray</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/cd/">CD</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">おすすめから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/special/">キャンペーン・特集</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/timesale/">タイムセール</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">110円～！激安人気作ランキング</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}">あなたにおすすめの商品</a>
+              </li> -->
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">マイページ</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/mypagetop/">マイページトップ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/myfavorite/">お気に入り</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/incomingmaillist/">入荷メール</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/customerinfochange/">お客様情報</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ご利用サポート・その他</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/guide/">ヘルプ・お問い合わせ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="/landingpage/shippingfeeexplanation">送料について</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/guide/beginner.jsp">はじめての方へ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a th:with="noticelist = ${T(www.netoff.co.jp.web.config.UrlConfig).NOTIFICATION_NOTICELIST_URL}" th:href="${noticelist}">お知らせ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/kaitori-navi/">買取ナビ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://vod.netoff.co.jp/">VODチョイス</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://internet.netoff.co.jp/">インターネット比較</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://fortune.netoff.co.jp/">占ナビ</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ネットオフ宅配買取</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/sell/book/">本・ゲーム買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/moetaku/tcg/pokemon_card/">トレカ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/figure/">フィギュア買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mobilebuy/">スマホ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/kaden/">家電買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/sell/general/">ブランド・総合買取</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+
+      <nav class="l-footer__site-nav-container">
+        <ul class="l-footer__site-nav">
+          <li>
+            <a href="/company/">会社案内</a>
+          </li>
+          <li>
+            <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+          </li>
+          <li>
+            <a href="/guide/netoff.jsp">品質ポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/">プライバシーポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/#policy02">個人情報保護方針</a>
+          </li>
+          <li>
+            <a href="/customer/">お客様への対応について</a>
+          </li>
+          <li>
+            <a href="/use/">ご利用規約</a>
+          </li>
+          <li>
+            <a href="/settlement/">資金決済法に基づく表示</a>
+          </li>
+          <li>
+            <a href="/sitemap/">サイトマップ</a>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="l-footer__info-container">
+        <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+      </div>
+
+      <div class="l-footer__netoff-container">
+        <div>
+          <a href="/" class="l-footer__logo">
+            <picture>
+              <source srcset="/img/logo-netoff.webp" type="image/webp" />
+              <img src="/img/logo-netoff.png" alt="NET OFF" />
+            </picture>
+          </a>
+          <div class="l-footer__netoff l-footer__netoff--main">
+            <span>ネットオフ株式会社</span>
+            古物商許可番号 542782100600 愛知県公安委員会許可<br />
+            <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+          </div>
+        </div>
+
+        <small class="l-footer__copyright l-footer__copyright--main">Copyright &copy; NETOFF,inc.</small>
+      </div>
+    </div>
+  </div>
+</div>
+    </footer>
+
+    <!-- /* 商品カセット用モーダル */ -->
+    <div>
+  
+  <div class="c-snackbar" id="js-addcart-ng">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-addcart-ng">閉じる</button>
+  </div>
+  <div class="c-snackbar" id="js-snack-common">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-snack-common">閉じる</button>
+  </div>
+  
+  
+  
+</div>
+    <div>
+  <!-- /* 入荷メール&予約モーダル */ -->
+  <div class="c-modal" id="js-mailReserve">
+    <div class="c-modal__background js-toggle" data-target="js-mailReserve"></div>
+    <div class="c-modal__inner c-modal__inner--sort">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailReserve">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-search__modal">
+        <div class="l-search__modal__inner l-search__modal__inner--green">
+          <p class="l-search__modal-heading">商品が入荷したらメールでお知らせ</p>
+          <p class="l-search__modal-text">
+            取り置きではありませんので、<br />
+            すぐに売り切れになる場合もございます。
+          </p>
+          <button type="button" class="c-button--mail l-search__modal-button js-incomingMailButton" data-target="js-mailSetting">入荷メールを登録（無料）</button>
+          <p class="l-search__modal-text js-mailregistercount-text"></p>
+        </div>
+        <div class="l-search__modal__inner l-search__modal__inner--red js-reserve-region"></div>
+      </div>
+    </div>
+  </div>
+</div>
+    <div>
+  <!-- /* 商品カセット用カート追加モーダル */ -->
+  <div class="c-modal" id="js-addcart">
+    <div class="c-modal__background js-toggle" data-target="js-addcart"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-addcart">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をカートに入れました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addcart">閉じる</button>
+          <a type="button" class="c-button--cart js-toggle" data-target="js-addcart" href="/purchase/cart/">カートに進む</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用入荷メールモーダル */ -->
+  <div class="c-modal" id="js-mailSetting">
+    <div class="c-modal__background js-toggle" data-target="js-mailSetting"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailSetting">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品を入荷メールに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-mailSetting">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り登録モーダル */ -->
+  <div class="c-modal" id="js-addfav">
+    <div class="c-modal__background js-toggle" data-target="js-addfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-addfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り解除モーダル */ -->
+  <div class="c-modal" id="js-delfav">
+    <div class="c-modal__background js-toggle" data-target="js-delfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-delfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りから登録解除しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-delfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+    <script src="/js/common.js" defer></script>
+    <script src="/js/searchResult.js" defer></script>
+    <script>
+      // 検索条件
+      const condition = {"clFrom":"1","cat":"1002","clTo":"1","clNext":"100","page":"1","clPrev":"-100","word":"9784813705185","dnum":"100","pageMax":"1"};
+      // お気に入りリスト
+      const favCmdtyCodes = null;
+    </script>
+    <script>
+      function setCookie() {
+        var tmp = 'r18flg=1;';
+        tmp += 'path=/; expires=Tue, 31-Dec-2040 23:59:59; ';
+        document.cookie = tmp;
+        location.reload();
+      }
+    </script>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/cart.js" defer></script>
+
+    
+      
+  
+    <script>
+      const MD5Email = null;
+    </script>
+    <script src="/js/criteo.js" defer></script>
+  
+
+    
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', () => {
+        let doc = document;
+        let head = doc.getElementsByTagName('head')[0];
+        let tagEmail = '';
+        tagEmail = '<%= MD5Email %>';
+        let criteoScript = document.createElement('script');
+        criteoScript.type = 'text/javascript';
+        criteoScript.src = '//static.criteo.net/js/ld/ld.js';
+        criteoScript.async = true;
+        head.appendChild(criteoScript);
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.innerHTML = 'window.criteo_q = window.criteo_q || [];';
+        script.innerHTML += 'window.criteo_q.push(';
+        script.innerHTML += '{ event: "setAccount", account: 85067 },';
+        script.innerHTML += '{ event: "setSiteType", type: "d" },';
+        if (tagEmail != '') {
+          script.innerHTML += '{ event: "setEmail", email:"' + tagEmail + '" },';
+        }
+        script.innerHTML += '{ event: "viewHome" }';
+        script.innerHTML += ');';
+        head.appendChild(script);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/used_book/netoff_search_empty.html
+++ b/tests/fixtures/used_book/netoff_search_empty.html
@@ -1,0 +1,3720 @@
+<!doctype html>
+<html lang="ja">
+  <head><script>(function(w,i,g){w[g]=w[g]||[];if(typeof w[g].push=='function')w[g].push(i)})(window,'GTM-NPLRPRC','google_tags_first_party');</script><script>(function(w,d,s,l){w[l]=w[l]||[];(function(){w[l].push(arguments);})('set','developer_id.dYzZiYj',true);var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src='/27ns5f/';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>
+    <meta charset="UTF-8" />
+    <meta name="_csrf" content="b87c4825-6cb9-415b-aeb1-b165dbbe8203" />
+    <meta name="_csrf_header" content="X-XSRF-TOKEN" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>9784000000000の古本 ｜中古通販ならネットオフ</title>
+    <meta name="description" content="【9784000000000】の古本 検索結果です。古本・CD・DVD・ゲームの買取や購入ならネットオフ！楽天ポイント・Vポイントが貯まる・使える！ご自宅から買取が依頼できる宅配買取サービスも充実" />
+    <meta name="keyword" content="古本,中古本,通販,買取,古本 買取" />
+    <meta name="robots" content="noindex,nofollow" />
+    
+    
+    <link rel="canonical" href="https://www.netoff.co.jp/cmdtyallsearch/?word=9784000000000&amp;cat=1002" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:title" content="9784000000000の古本 ｜中古通販ならネットオフ" />
+    <meta property="og:site_name" content="ネット中古書店 ネットオフ (本・CD・DVD・ゲームソフトの買取・販売)" />
+    
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="https://www.netoff.co.jp/images/logo_fb.gif" />
+    <meta name="og:description" content="【9784000000000】の古本 検索結果です。古本・CD・DVD・ゲームの買取や購入ならネットオフ！楽天ポイント・Vポイントが貯まる・使える！ご自宅から買取が依頼できる宅配買取サービスも充実" />
+    <meta property="fb:app_id" content="193098350747639" />
+    <link rel="shortcut icon" href="/netoff.ico" />
+    <link rel="apple-touch-icon" href="/netoff.png" />
+    <link href="/css/style.css" rel="stylesheet" />
+    <script src="/js/googleTag.js" defer></script>
+
+    
+      
+        
+          
+  
+    
+      
+        
+          <script>
+            /*<![CDATA[*/
+            const user = {
+              zeta_id: "",
+              zeta_gender: "",
+              zeta_age: "",
+            };
+            /*]]>*/
+            const zetaParam = {};
+            const zetaScriptUrl = "https:\/\/renet.search.zetacx.net\/static\/zd\/zd_register_prd.js";
+          </script>
+          <script src="/js/zetatags.js" defer></script>
+        
+      
+    
+  
+
+        
+      
+    
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NPLRPRC" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header>
+      <div id="js-headerContainer" class="l-header__container is-fixed">
+        <div class="l-header-common" id="js-header">
+  <!-- <div class="l-header-common__info">
+    <p>古本・CD・DVD・ゲームの買取・中古通販ならネットオフ！！</p>
+    <nav class="l-header-common__info-nav">
+      <ul>
+        <li class="l-header-common__info-nav-list">
+          <a href="/sell/">段ボール無料</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="forfirsttime = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FORFIRSTTIMEUSER_URL}" th:href="${forfirsttime}">はじめての方へ</a>
+        </li>
+        <li class="l-header-common__info-nav-list">
+          <a th:with="faq = ${T(www.netoff.co.jp.web.config.UrlConfig).GUIDE_FAQ_URL}" th:href="${faq}">よくある質問</a>
+        </li>
+      </ul>
+    </nav>
+  </div> -->
+  <div class="l-header">
+    <button type="button" class="l-header__nav-button js-toggle" data-target="js-headerSideNav">
+      <span></span>
+    </button>
+    <div class="l-header__logo">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <a href="/sell/" class="l-header__purchase-button">買取</a>
+    
+  </div>
+  <div class="l-header-common__inner js-topNavigation">
+    <div class="l-header__logo is-sp-hidden">
+      <a href="/">
+        <picture>
+          <source srcset="/img/logo-netoff.webp" type="image/webp" />
+          <img src="/img/logo-netoff.png" alt="NET OFF" />
+        </picture>
+      </a>
+    </div>
+    <form class="c-search-input__form l-header-common__search" id="js-searchList" name="search_form">
+      <input type="hidden" name="cat" value="" />
+      <div class="l-header-common__search-select">
+        <div class="c-select c-select--black js-select" data-target="js-headerSelect" tabindex="0">
+          <div
+            class="c-select__label js-selectLabel js-init-category"
+            data-target="js-headerSelect"
+            data-value="1002"
+          ></div>
+          <div class="c-select__option-container" id="js-headerSelect">
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="すべてのカテゴリー"
+                data-value=""
+                id="headerSearchCategory1"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory1">すべてのカテゴリー</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="古本・中古本"
+                data-value="1002"
+                id="headerSearchCategory4"
+                class="js-selectOption js-searchSelect" checked="checked"
+              />
+              <label class="c-select__options" for="headerSearchCategory4">古本・中古本</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミック"
+                data-value="1001"
+                id="headerSearchCategory2"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory2">コミック</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="コミックセット"
+                data-value="1011"
+                id="headerSearchCategory3"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory3">コミックセット</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="ゲーム"
+                data-value="5001"
+                id="headerSearchCategory7"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory7">ゲーム</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="DVD・Blu-ray"
+                data-value="7001"
+                id="headerSearchCategory6"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory6">DVD・Blu-ray</label>
+            </div>
+            <div>
+              <input
+                type="radio"
+                name="cname"
+                value="CD"
+                data-value="3001"
+                id="headerSearchCategory5"
+                class="js-selectOption js-searchSelect"
+              />
+              <label class="c-select__options" for="headerSearchCategory5">CD</label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="l-header-common__search-input">
+        <button type="submit" formaction="/cmdtyallsearch/" class="l-header-common__search-button">
+          <img src="/img/search_black_icon.svg" width="20px" alt="検索" />
+        </button>
+        <div class="c-search-input">
+          <div class="c-search-input__input-container">
+            <input
+              type="text"
+              placeholder="キーワードを入力"
+              class="c-search-input__input js-searchForm"
+              name="word"
+              data-target="js-searchList"
+              value="9784000000000"
+              autocomplete="off"
+            />
+            <button type="button" class="c-search-input__delete-input js-searchInputDelete">
+              <img src="/img/close_gray_icon.svg" alt="削除" />
+            </button>
+          </div>
+          <button type="submit" formaction="/cmdtyallsearch/" class="c-search-input__button">
+            <img src="/img/search_icon.svg" alt="検索" />
+          </button>
+          <button type="button" class="c-search-input__cancel js-toggle" data-target="js-searchList">キャンセル</button>
+        </div>
+        <!-- <input type="text" placeholder="キーワードを入力" class="js-searchForm" data-target="js-searchList" /> -->
+        <div class="c-search-input__list-inner js-searchResult">
+          <div class="c-search-input__list-top">
+            <span class="c-search-input__history-text">検索履歴</span>
+            <span class="c-search-input__result-text">検索候補</span>
+            <button type="button" class="c-search-input__delete-all-button js-suggest-delete-all">全件削除</button>
+          </div>
+          <ul class="js-suggestList">
+            <!--
+            <li class="c-search-input__list">
+              <a th:with="url=${T(www.netoff.co.jp.web.config.UrlConfig).SEARCH_RESULT_URL}" th:href="@{__${url}__}">
+                <span class="c-search-input__list-text js-searchHistory">鬼滅の刃</span>
+              </a>
+              <button type="button" class="c-search-input__delete-button">
+                <img th:src="@{/img/close_gray_icon.svg}" alt="削除" />
+              </button>
+            </li>
+            -->
+          </ul>
+        </div>
+      </div>
+
+      <div class="c-search-input__list-container">
+        <div class="c-search-input__background"></div>
+      </div>
+    </form>
+    <script>
+      document.querySelectorAll('.js-searchSelect').forEach((option) => {
+        option.addEventListener('change', function () {
+          if (this.checked) {
+            const selectedValue = this.getAttribute('data-value');
+            document.querySelector('input[type="hidden"][name="cat"]').value = selectedValue;
+          }
+        });
+      });
+    </script>
+    <nav
+      class="l-header-common__nav-container"
+    >
+      <ul class="l-header-common__nav">
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/mypagetop/">
+            
+            ログイン
+          </a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/incomingmaillist/">入荷メール</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/reservation/reservationlist/">予約履歴</a>
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/myfavorite/">お気に入り</a>
+          
+        </li>
+        <li class="l-header-common__nav-list">
+          <a href="/mypage/browsinghistory/">閲覧履歴</a>
+        </li>
+        <li class="l-header-common__nav-list js-cartcontainer">
+          <a href="/purchase/cart/">カート</a>
+          
+        </li>
+        <li style="display: block" class="l-header-common__nav-list l-header-common__nav-list--purchase">
+          <a href="/sell/">買取</a>
+        </li>
+        <li style="display: none" class="l-header-common__nav-list l-header-common__nav-list--cards">
+          <a href="/moetaku/tcg/pokemon_card/">トレカ<br />買取</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="l-header__nav" id="js-headerSideNav">
+    <div class="l-header__nav-back js-toggle" data-target="js-headerSideNav"></div>
+    <nav class="l-header__nav-container">
+      <!-- 未ログイン -->
+      <div>
+        <div class="l-header__login-container">
+          <div class="l-header__login-buttons">
+            <!--  
+            <a class="c-button--main" href="{$root}login/login">ログイン</a>
+            <a class="c-button--outline" th:href="@{/registration/enterinformation}">新規会員登録</a>
+          -->
+            <a class="c-button--main" href="/login/">ログイン</a>
+            <a class="c-button--outline" href="/registration/enterinformation/"
+              >新規会員登録</a
+            >
+          </div>
+          <div>
+            <!--
+            <a class="c-link--icon l-header__guide-link" href="">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" th:href="/login/resetpassword">パスワードを忘れた方はこちら</a>
+            -->
+            <a class="c-link--icon l-header__guide-link" href="/guide/beginner.jsp">初めてご利用の方ガイドはこちら</a>
+            <a class="c-link--icon l-header__guide-link" href="/resetpassword/"
+              >パスワードを忘れた方はこちら</a
+            >
+          </div>
+        </div>
+      </div>
+      <!-- ログイン済み -->
+      
+      <ul>
+        <li class="l-header__nav-title">カテゴリ</li>
+        <li class="l-header__nav-list">
+          <a href="/book/">古本・中古本</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comic/">コミック</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/comicset/">コミックセット</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/game/">ゲーム</a>
+        </li>
+        <!-- <li class="l-header__nav-list">
+          <a href="">トレカ</a>
+        </li> -->
+        <li class="l-header__nav-list">
+          <a href="/dvd/">DVD・Blu-ray</a>
+        </li>
+        <li class="l-header__nav-list">
+          <a href="/cd/">CD</a>
+        </li>
+      </ul>
+      <ul>
+        <li class="l-header__nav-title">買取</li>
+        <li class="l-header__nav-list">
+          <a href="/sell/">ネットオフ宅配買取TOP</a>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav1">本＆ゲーム買取</button>
+          <ul id="js-headerNav1">
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">本＆ゲーム買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/comic/">コミック・漫画</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/book/">古本・中古本</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/campaign/game/">ゲームソフト</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/game/body.jsp">ゲーム機本体</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/dvd/">DVD・Blu-ray</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/sell/book/cd/">CD</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav2">トレカ買取</button>
+          <ul id="js-headerNav2">
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/">トレカ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/pokemon_card/">ポケモンカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/onepiece/">ワンピースカード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/yugioh/">遊戯王カード</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/moetaku/tcg/shadowverse-evolve/">シャドウバース エボルヴ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav4">フィギュア買取</button>
+          <ul id="js-headerNav4">
+            <li class="l-header__nav-list">
+              <a href="/figure/">フィギュア買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/kuji_prize/">プライズフィギュア</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/figure/plamodel/">プラモデル</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gunpla/">ガンプラ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav3">スマホ買取</button>
+          <ul id="js-headerNav3">
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/">スマホ買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/iphone/">iPhone</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/xperia/">Xperia</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/tablet/ipad/">iPad</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/galaxy/">Galaxy</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/mobilebuy/smartphone/googlepixel/">Google Pixel</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav5">家電買取</button>
+          <ul id="js-headerNav5">
+            <li class="l-header__nav-list">
+              <a href="/kaden/">家電買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/camera/">カメラ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/headphone/">ヘッドホン</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/gamingpc/">ゲーミングPC</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/wellness/">美容家電</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/deditalstationery/pentablet/">ペンタブレット</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/kaden/smartwatch/">スマートウォッチ</a>
+            </li>
+          </ul>
+        </li>
+        <li class="l-header__nav-list--red">
+          <button class="js-pullDown" data-target="js-headerNav6">ブランド総合買取</button>
+          <ul id="js-headerNav6">
+            <li class="l-header__nav-list">
+              <a href="/sell/general/">ブランド総合買取TOP</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/brand/">ブランド品</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/clothes/">洋服・古着</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/brand/jewelry/">金・プラチナ</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/gakki/">楽器</a>
+            </li>
+            <li class="l-header__nav-list">
+              <a href="/hikkigu/">万年筆</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <!-- <div class="c-modal" id="js-logout">
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="button" class="c-button--black-outline" onClick="window.location.href='/'">ログアウト</button>
+      </div>
+    </div>
+  </div> -->
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="b87c4825-6cb9-415b-aeb1-b165dbbe8203"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+</div>
+        <nav class="c-top-nav is-fixed js-topNavigation">
+  <ul class="c-top-nav__list">
+    <li>
+      <a href="/book/" class="c-top-nav__link">古本・中古本</a>
+    </li>
+    <li>
+      <a href="/comic/" class="c-top-nav__link">コミック</a>
+    </li>
+    <li>
+      <a href="/comicset/" class="c-top-nav__link">コミックセット</a>
+    </li>
+    <li>
+      <a href="/game/" class="c-top-nav__link">ゲーム</a>
+    </li>
+    <!-- <li>
+      <a href="" class="c-top-nav__link">トレカ</a>
+    </li> -->
+    <li>
+      <a href="/dvd/" class="c-top-nav__link">DVD・Blu-ray</a>
+    </li>
+    <li>
+      <a href="/cd/" class="c-top-nav__link">CD</a>
+    </li>
+  </ul>
+</nav>
+      </div>
+    </header>
+
+    <main class="l-common__header--tab l-common__footer">
+      <!-- パンくず -->
+      <div>
+        <ol class="c-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem" data-breadcrumb="home">
+    <a href="/" class="c-link--blue c-breadcrumbs__label" itemprop="item"><span itemprop="name">ネットオフTOP</span></a>
+    <meta itemprop="position" content="1" />
+  </li>
+  <li class="c-breadcrumbs_list" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    
+    <span class="c-breadcrumbs__label" itemprop="name">検索結果一覧</span>
+    <meta itemprop="position" content="2" />
+  </li>
+</ol>
+      </div>
+
+      <div class="l-common">
+        <!-- サイドバー -->
+        <div class="l-sidebar l-sidebar__nav">
+  <a href="/site-directory/" class="l-sidebar__show-more">すべてのカテゴリーを見る</a>
+
+  <div class="l-sidebar__nav-container">
+    <h3>絞込み</h3>
+
+    <div class="l-sidebar__nav-inner">
+      <h4>カテゴリー</h4>
+      <ul>
+        
+      </ul>
+    </div>
+
+    <form>
+      <div class="l-sidebar__nav-inner">
+        <h4>おすすめ</h4>
+        <ul>
+          
+          <li class="l-sidebar__check-list">
+            <input
+              name="recommend"
+              type="checkbox"
+              class="c-checkbox js-sidebar-cond"
+              id="js-sideRecom-tadabon"
+              value="1"
+              data-key="freebook"
+            />
+            <label for="js-sideRecom-tadabon">
+              <span class="c-checkbox__label">タダ本対象・無料商品</span>
+            </label>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput" data-name="recommend">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>在庫</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="stock"
+              type="checkbox"
+              class="c-checkbox js-sidebar-cond"
+              id="js-sidebarStock1"
+              value="1"
+              data-key="stock"
+            />
+            <label for="js-sidebarStock1">
+              <span class="c-checkbox__label">在庫あり</span>
+            </label>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear" onclick="document.getElementById('js-sidebarStock1').checked = false">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      
+
+      
+
+      
+
+      <div class="l-sidebar__nav-inner">
+        <h4>販売価格</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice0"
+              value="price:1 ～ 1000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice0">
+              <span class="c-checkbox__label">1円 ～ 1,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice1"
+              value="price:1001 ～ 2000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice1">
+              <span class="c-checkbox__label">1,001円 ～ 2,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice2"
+              value="price:2001 ～ 3000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice2">
+              <span class="c-checkbox__label">2,001円 ～ 3,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice3"
+              value="price:3001 ～ 5000"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarPrice3">
+              <span class="c-checkbox__label">3,001円 ～ 5,000円（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="price"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarPrice4"
+              value="5001"
+              data-key="facet"
+              data-ftflg="pricef" disabled="disabled"
+            />
+            <label for="js-sidebarPrice4">
+              <span class="c-checkbox__label">5,001円 ～（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="price-min-range"
+                value=""
+              />&ensp;円&#65374;
+            </div>
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="price-max-range"
+                value=""
+              />&ensp;円
+            </div>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput js-clearSidePrice" data-name="price">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+
+      <div class="l-sidebar__nav-inner">
+        <h4>発行年</h4>
+        <ul>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear0"
+              value="2026"
+              data-key="facet"
+              data-ftflg="issuef" disabled="disabled"
+            />
+            <label for="js-sidebarYear0">
+              <span class="c-checkbox__label">2026年 ～ （0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear1"
+              value="issue:2023 ～ 2025"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear1">
+              <span class="c-checkbox__label">2023年 ～ 2025年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear2"
+              value="issue:2018 ～ 2022"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear2">
+              <span class="c-checkbox__label">2018年 ～ 2022年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear3"
+              value="issue:2008 ～ 2017"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear3">
+              <span class="c-checkbox__label">2008年 ～ 2017年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear4"
+              value="issue:1998 ～ 2007"
+              data-key="facet"
+              disabled="disabled"
+            />
+            <label for="js-sidebarYear4">
+              <span class="c-checkbox__label">1998年 ～ 2007年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <input
+              name="year"
+              type="radio"
+              class="c-checkbox js-sidebar-cond js-toggle-radio"
+              id="js-sidebarYear5"
+              value="1997"
+              data-key="facet"
+              data-ftflg="issuet" disabled="disabled"
+            />
+            <label for="js-sidebarYear5">
+              <span class="c-checkbox__label"> ～ 1997年（0）</span>
+            </label>
+          </li>
+          <li class="l-sidebar__check-list">
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="year-min-range"
+                value=""
+              />&ensp;年&#65374;
+            </div>
+            <div class="l-sidebar__search-input">
+              <input
+                type="number"
+                class="c-input-text c-input-text--small"
+                name="year-max-range"
+                value=""
+              />&ensp;年
+            </div>
+          </li>
+        </ul>
+        <div class="l-sidebar__search-button-container">
+          <button type="button" class="l-sidebar__search-clear js-clearInput js-clearSideYear" data-name="year">クリア</button>
+          <button type="button" class="l-sidebar__search-button js-sidebar-search">検索する</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <ul>
+  <li class="l-sidebar__ad">
+    <a
+      href="http://www.discas.net/netdvd/entry_site.pl?SITE=movie_a00_n_adot_etc_99_007657&AP=comic_top&sc_cid=movie_a00_n_adot_etc_99_007657"
+      rel="nofollow"
+      target="_blank"
+    >
+      <img
+        src="/images/banner/side/sidemenu-2m-banner.webp"
+        alt="TSUTAYA DISCAS"
+      />
+    </a>
+  </li>
+</ul>
+</div>
+
+        <div class="l-common__container">
+          <section>
+            <div class="l-search__inner">
+              <ul class="l-search__tag-list">
+                
+              </ul>
+              <h1 class="c-heading--main c-heading--main--marginless">9784000000000の古本 検索結果</h1>
+            </div>
+            <ul class="c-tab">
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-0"
+                  value=""
+                  autocomplete="off"
+                />
+                <label for="reservation-category-0">すべて</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-1"
+                  value="1002"
+                  autocomplete="off" checked="checked"
+                />
+                <label for="reservation-category-1">古本・中古本(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-2"
+                  value="1001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-2">コミック(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-3"
+                  value="5001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-3">ゲーム(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-4"
+                  value="7001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-4">DVD・Blu-ray(0)</label>
+              </li>
+              <li class="c-tab__list">
+                <input
+                  type="radio"
+                  name="reservation-category"
+                  id="reservation-category-5"
+                  value="3001"
+                  autocomplete="off"
+                />
+                <label for="reservation-category-5">CD(0)</label>
+              </li>
+            </ul>
+
+            <div class="c-sort-button-container l-search__button-container">
+              <form action="/cmdtyallsearch/" name="stockForm">
+                <input
+                  type="hidden"
+                  name="clFrom"
+                  value="0"
+                /><input
+                  type="hidden"
+                  name="cat"
+                  value="1002"
+                /><input
+                  type="hidden"
+                  name="clTo"
+                  value="0"
+                /><input
+                  type="hidden"
+                  name="clNext"
+                  value="100"
+                /><input
+                  type="hidden"
+                  name="clPrev"
+                  value="-100"
+                /><input
+                  type="hidden"
+                  name="word"
+                  value="9784000000000"
+                /><input
+                  type="hidden"
+                  name="dnum"
+                  value="100"
+                /><input
+                  type="hidden"
+                  name="pageMax"
+                  value="1"
+                />
+                <div>
+                  <input
+                    name="stock"
+                    type="checkbox"
+                    class="c-checkbox js-research"
+                    id="stock"
+                    value="1"
+                    onchange="document.forms.stockForm.submit()"
+                  />
+                  <label for="stock">
+                    <span class="c-checkbox__label c-checkbox__label--small">在庫あり</span>
+                  </label>
+                </div>
+              </form>
+              <div class="c-sort-button-container__buttons">
+                <button type="button" class="c-sort-button-container__button c-sort-button-container__button--sort js-toggle" data-target="js-sort-modal">並び替え</button>
+                <button type="button" class="c-sort-button-container__button c-sort-button-container__button--filter js-toggle" data-target="js-filter-tab-modal">絞込み</button>
+              </div>
+            </div>
+            
+
+            <div>
+              <div class="l-search__result-text">
+                <p>検索の結果、商品を見つけることができませんでした。</p>
+                <p>CERO「Z」指定ゲームをお探しの方は、<button onclick="setCookie()">こちら</button>をクリックしてから再度検索をお願いします。<br /></p>
+                <p>
+                  ゲーム機本体をお探しの方は<a
+                    href="/cmdtyallsearch/?cat=5001&amp;stock=1&amp;genre=76&amp;dnum=50"
+                    >こちら</a
+                  >。
+                </p>
+              </div>
+              <div class="l-search__link-back is-sp-show">
+                <a href="" class="c-button--outline">前のページに戻る</a>
+              </div>
+
+              <div class="l-search__info-container l-search__info-container--center">
+                <p class="l-search__info-text">
+                  <span class="bold">在庫あり検索で商品が見つからない時は・・・</span><br />
+                  入荷したらすぐメールでお知らせ！<br />
+                  入荷メール登録をご利用ください！
+                </p>
+                <img class="is-sp-show" src="/img/search_result_img1.png" alt="" />
+                <img class="is-sp-hidden" src="/img/search_result_img1_pc.png" alt="" />
+              </div>
+
+              <article class="l-search__info-container">
+                <h3 class="l-search__info-heading">チェックポイント！</h3>
+                <div class="l-search__info-inner">
+                  <p>絞り込み条件を変えることで見つかる場合があります！</p>
+                  <div class="l-search__info-img">
+                    <img class="is-sp-show" src="/img/search_result_img2.png" alt="" />
+                    <img class="is-sp-hidden" src="/img/search_result_img2_pc.png" alt="" />
+                  </div>
+                  <div class="l-search__info-img">
+                    <img class="is-sp-show" src="/img/search_result_img3.png" alt="" />
+                    <img class="is-sp-hidden" src="/img/search_result_img3_pc.png" alt="" />
+                  </div>
+                </div>
+              </article>
+
+              <article class="l-search__info-container">
+                <h3 class="l-search__info-heading">検索のコツ！</h3>
+                <div class="l-search__info-inner">
+                  <p>探している商品を見つけやすくするための「検索のコツ」をご紹介します！</p>
+                  <dl>
+                    <div class="l-search__info-wrap">
+                      <dt class="l-search__info-title">検索のコツ【その1】</dt>
+                      <dd>
+                        複数のキーワードで検索するときは、スペースで区切ってください。半角でも全角でもOK！
+                        <div class="l-search__info-img">
+                          <img class="is-sp-show" src="/img/search_result_img4.png" alt="" />
+                          <img class="is-sp-hidden" src="/img/search_result_img4_pc.png" alt="" />
+                        </div>
+                      </dd>
+                    </div>
+                    <div class="l-search__info-wrap">
+                      <dt class="l-search__info-title">検索のコツ【その2】</dt>
+                      <dd>
+                        「、」や「・」「ー(ハイフン)」などの文字を含めずに検索すると、ヒットしやすくなります。
+                        <div class="l-search__info-img">
+                          <img class="is-sp-show" src="/img/search_result_img5.png" alt="" />
+                          <img class="is-sp-hidden" src="/img/search_result_img5_pc.png" alt="" />
+                        </div>
+                        <div class="l-search__info-img l-search__info-img--icon">
+                          <img class="is-sp-show" src="/img/search_result_img6.png" alt="" />
+                          <img class="is-sp-hidden" src="/img/search_result_img6_pc.png" alt="" />
+                        </div>
+                      </dd>
+                    </div>
+                    <div class="l-search__info-wrap">
+                      <dt class="l-search__info-title">検索のコツ【その3】</dt>
+                      <dd>
+                        タイトルや人名にアルファベットが含まれる時は、カナで検索してみてください。<br />
+                        「アルファベットの綴りにちょっと自身がない...」というときは、カナで検索してみてください。
+                        <div class="l-search__info-img">
+                          <img class="is-sp-show" src="/img/search_result_img7.png" alt="" />
+                          <img class="is-sp-hidden" src="/img/search_result_img7_pc.png" alt="" />
+                        </div>
+                        <div class="l-search__info-img l-search__info-img--icon">
+                          <img class="is-sp-show" src="/img/search_result_img8.png" alt="" />
+                          <img class="is-sp-hidden" src="/img/search_result_img8_pc.png" alt="" />
+                        </div>
+                      </dd>
+                    </div>
+                    <div class="l-search__info-wrap">
+                      <div class="l-search__info-warp--small">
+                        <dt>基本事項</dt>
+                        <dd>
+                          ・大文字、小文字、全角、半角の区別はされません。<br />
+                          ・入力された語句の全てが検索キーワードとして反映されます。（and検索）
+                        </dd>
+                      </div>
+                    </div>
+                  </dl>
+                </div>
+                <div class="l-search__link-back">
+                  <a href="" class="c-button--outline">前のページに戻る</a>
+                </div>
+              </article>
+            </div>
+
+            <!-- 一覧 -->
+            
+
+            <!-- ページネーション -->
+            
+            
+          </section>
+
+          <section>
+            <h2>
+              <a
+                class="c-heading--gray c-heading--gray--recommend"
+                href="/recommend/"
+              >
+                あなたにおすすめの商品
+                <span class="c-heading__link">もっと見る</span>
+              </a>
+            </h2>
+            <div class="splide c-splide__products js-productListSlideLarge">
+  <div class="splide__arrows">
+    <button class="splide__arrow splide__arrow--prev c-slider__arrow--gray">
+      <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="前へ" />
+    </button>
+    <button class="splide__arrow splide__arrow--next c-slider__arrow--gray">
+      <img class="c-slider__arrow--gray-img" src="/img/arrow_gray.svg" alt="次へ" />
+    </button>
+  </div>
+  <div class="splide__track c-splide__track-small">
+    <ul class="splide__list">
+      <li class="splide__slide">
+        <a
+          href="/ipad/"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0014131002.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >iPad 7th Wi-Fi 32GB</span>
+          <span class="c-splide__products-price">17,578円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0012496582/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/noimage_home_01.gif"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >建築基準法令集＜2017年版＞</span>
+          <span class="c-splide__products-price">990円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011668651/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011668651.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >アメリカに潰された政治家たち</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011838292/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011838292.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >To LOVEる ダークネス アニメイラスト集 Juicy</span>
+          <span class="c-splide__products-price">2,998円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000533042/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000533042.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >海峡の光</span>
+          <span class="c-splide__products-price">110円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0012085636/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0012085636.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >フライプレイ！ 監棺館殺人事件</span>
+          <span class="c-splide__products-price">275円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0013205916/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0013205916.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ペット訴訟ハンドブック 関係法・判例解説、交通事故、動物病院、飼い主が加害者となる場合、ペットショップ、ペットホテル、トリミ</span>
+          <span class="c-splide__products-price">1,480円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010468607/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010468607.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >他者／死者／私</span>
+          <span class="c-splide__products-price">630円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010841963/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010841963.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【特典DVD付】キイナ－不可能犯罪捜査官－ DVD－BOX</span>
+          <span class="c-splide__products-price">7,498円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0001127325/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0001127325.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >「∀ガンダム」オリジナルサウンドトラック</span>
+          <span class="c-splide__products-price">1,320円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011996676/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011996676.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >天の神話 地の永遠＜9＞</span>
+          <span class="c-splide__products-price">110円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010068817/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010068817.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >ペーパークイリング 細長い紙をくるくる巻いて作るペーパーアート</span>
+          <span class="c-splide__products-price">400円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0010569599/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0010569599.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >「仮面ライダー電王」～Double－Action Wing form／野上良太郎＆ジーク（CV．佐藤健・三木眞一郎）</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011548819/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011548819.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【CD＋DVD】スーパーガール JAPAN TOUR Special Edition</span>
+          <span class="c-splide__products-price">330円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011712325/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011712325.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >一礼して、キス＜1＞</span>
+          <span class="c-splide__products-price">110円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0012880640/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0012880640.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【CD＋DVD】明星 初回生産限定盤</span>
+          <span class="c-splide__products-price">440円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000995304/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0000995304.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >劇空間プロ野球 AT THE END OF THE CENTURY 1999</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0011188079/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0011188079.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >「FORTUNE ARTERIAL～赤い約束～」エンディング主題歌～I miss you</span>
+          <span class="c-splide__products-price">165円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0012351571/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0012351571.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >【小説・特製冊子付】STEINS；GATE 無限遠点のアルタイル 初回限定版</span>
+          <span class="c-splide__products-price">1,980円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0013499734/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/cmdty/0013499734.jpg"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >「解き方」がわかる国語 文章読解</span>
+          <span class="c-splide__products-price">330円</span>
+        </a>
+      </li>
+      <li class="splide__slide">
+        <a
+          href="/detail/0000178378/?model=200"
+          class="c-splide__products-list"
+        >
+          <div class="c-splide__products-img">
+            <img
+              src="/ebimage/noimage_home_01.gif"
+              alt=""
+            />
+          </div>
+          <span
+            class="c-splide__products-name"
+          >日本名建築写真選集〈9〉／醍醐寺</span>
+          <span class="c-splide__products-price">343円</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+          </section>
+        </div>
+      </div>
+      <form action="/cmdtyallsearch/" name="sortModalForm1">
+        <input
+          type="hidden"
+          name="clFrom"
+          value="0"
+        /><input
+          type="hidden"
+          name="cat"
+          value="1002"
+        /><input
+          type="hidden"
+          name="clTo"
+          value="0"
+        /><input
+          type="hidden"
+          name="clNext"
+          value="100"
+        /><input
+          type="hidden"
+          name="clPrev"
+          value="-100"
+        /><input
+          type="hidden"
+          name="word"
+          value="9784000000000"
+        /><input
+          type="hidden"
+          name="dnum"
+          value="100"
+        /><input
+          type="hidden"
+          name="pageMax"
+          value="1"
+        />
+        <div class="c-modal" id="js-sort-modal">
+  <div class="c-modal__background js-toggle" data-target="js-sort-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle" data-target="js-sort-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <p class="l-sort__modal--title">並び順</p>
+    </div>
+    <div class="c-modal__inner--scroll">
+      <ul class="l-sort__modal--categorylist">
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--1">
+            <input
+              type="radio"
+              id="sort--modal--1"
+              name="sort"
+              data-text="関連度順"
+              value="relevance" checked="checked"
+            />
+            <span class="c-radio">関連度順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--2">
+            <input
+              type="radio"
+              id="sort--modal--2"
+              name="sort"
+              data-text="よく見られている順"
+              value="popular"
+            />
+            <span class="c-radio">よく見られている順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--3">
+            <input
+              type="radio"
+              id="sort--modal--3"
+              name="sort"
+              data-text="発売日が新しい順"
+              value="newest"
+            />
+            <span class="c-radio">発売日が新しい順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--4">
+            <input
+              type="radio"
+              id="sort--modal--4"
+              name="sort"
+              data-text="発売日が古い順"
+              value="oldest"
+            />
+            <span class="c-radio">発売日が古い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--5">
+            <input
+              type="radio"
+              id="sort--modal--5"
+              name="sort"
+              data-text="価格が安い順"
+              value="cheap"
+            />
+            <span class="c-radio">価格が安い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--6">
+            <input
+              type="radio"
+              id="sort--modal--6"
+              name="sort"
+              data-text="価格が高い順"
+              value="expensive"
+            />
+            <span class="c-radio">価格が高い順</span>
+          </label>
+        </li>
+      </ul>
+      
+        <p class="l-sort__modal--title l-sort__modal--title--number">表示件数</p>
+        <ul>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-1">
+              <input
+                type="radio"
+                id="sort--modal-1"
+                name="display-amount"
+                class=""
+                value="50"
+              />
+              <span class="c-radio">50件</span>
+            </label>
+          </li>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-2">
+              <input
+                type="radio"
+                id="sort--modal-2"
+                name="display-amount"
+                class=""
+                value="100" checked="checked"
+              />
+              <span class="c-radio">100件</span>
+            </label>
+          </li>
+        </ul>
+      
+    </div>
+    <div class="l-sort__modal--button">
+      <!-- フォームサブミット -->
+      <button type="submit" class="c-button--search-orange" id="js-sortButton">変更する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <form action="/cmdtyallsearch/" name="filterModalForm1">
+        <input type="hidden" name="word" value="9784000000000" />
+        <!-- ソートモーダル -->
+        <div
+  class="c-modal"
+  id="js-filter-tab-modal"
+>
+  <div class="c-modal__background js-toggle" data-target="js-filter-tab-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle c-modal__close-adjust" data-target="js-filter-tab-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-filter-tab__list--title-flex">
+        <p class="l-filter-tab__list--title">絞込み</p>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm pc-none" data-target="js-filterTabForm">条件をリセット</button>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm sp-none" data-target="js-filterTabForm">条件をリセット</button>
+      </div>
+    </div>
+    
+    <div class="c-modal__inner--scroll" id="js-filterTabForm">
+      <div>
+        <h4 class="l-filter-tab__title--category">カテゴリ</h4>
+        <ul class="l-filter-tab__list js-filter-list-category">
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_1"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="7001"
+            />
+            <label for="filter_category_1" class="c-checkbox__label--tag">DVD・Blu-ray(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_2"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="5001"
+            />
+            <label for="filter_category_2" class="c-checkbox__label--tag">ゲーム(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_3"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1002" checked="checked"
+            />
+            <label for="filter_category_3" class="c-checkbox__label--tag">古本・中古本(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_4"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1001"
+            />
+            <label for="filter_category_4" class="c-checkbox__label--tag">コミック(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_5"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="3001"
+            />
+            <label for="filter_category_5" class="c-checkbox__label--tag">CD(0)</label>
+          </li>
+        </ul>
+      </div>
+      
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">ジャンル</h4>
+          <ul class="l-filter-tab__list js-filter-list-genre">
+            <li style="width: 100%; margin-top: 8px; display: flex; justify-content: center"><p>カテゴリを選択してください。</p></li>
+          </ul>
+        </div>
+      
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">著者/アーティスト</h4>
+          <ul class="l-filter-tab__list js-filter-list-artist">
+            <li style="width: 100%; margin-top: 8px; display: flex; justify-content: center"><p>カテゴリを選択してください。</p></li>
+          </ul>
+        </div>
+      
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">在庫</h4>
+        <div class="l-filter-tab__list--checkbox">
+          <input name="filter_stock" type="checkbox" class="c-checkbox" id="filter_tag_stock" value="1" />
+          <label for="filter_tag_stock">
+            <span class="c-checkbox__label">在庫あり</span>
+          </label>
+        </div>
+      </div>
+      <div>
+        <h4 class="l-filter-tab__title--category">価格帯</h4>
+        <div class="js_filter_modal_price_container">
+          <div class="l-filter-tab__list--input">
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_min" value="" />&ensp;円&#65374;
+            </div>
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_max" value="" />&ensp;円
+            </div>
+            <div class="l-filter-tab__list--input-error">
+              <span class="c-input-text__error-message">価格帯は半角数字のみで入力してください。</span>
+            </div>
+          </div>
+          <ul class="l-filter-tab__list">
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp10" name="filter_tag_price_110" class="c-checkbox__tag js_filter_modal_price" value="0_110" />
+              <label for="filter_tmp10" class="c-checkbox__label--tag">&#65374; 110円以下</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp11" name="filter_tag_price_111_500" class="c-checkbox__tag js_filter_modal_price" value="111_500" />
+              <label for="filter_tmp11" class="c-checkbox__label--tag">111円 &#65374; 500円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp12" name="filter_tag_price_501_1000" class="c-checkbox__tag js_filter_modal_price" value="501_1000" />
+              <label for="filter_tmp12" class="c-checkbox__label--tag">501円 &#65374; 1,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp13" name="filter_tag_price_1001_3000" class="c-checkbox__tag js_filter_modal_price" value="1001_3000" />
+              <label for="filter_tmp13" class="c-checkbox__label--tag">1,001円 &#65374; 3,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp14" name="filter_tag_price_3001_5000" class="c-checkbox__tag js_filter_modal_price" value="3001_5000" />
+              <label for="filter_tmp14" class="c-checkbox__label--tag">3,001円 &#65374; 5,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp15" name="filter_tag_price_5001" class="c-checkbox__tag js_filter_modal_price" value="5001_0" />
+              <label for="filter_tmp15" class="c-checkbox__label--tag">5,001円 &#65374; </label>
+            </li>
+          </ul>
+        </div>
+      </div>
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">サイズ</h4>
+          <ul class="l-filter-tab__list js-filter-list-size">
+            <p>カテゴリを選択してください。</p>
+          </ul>
+        </div>
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">おすすめ</h4>
+        <ul class="l-filter-tab__list">
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_1" name="filter_recommend_1" class="c-checkbox__tag" value="1" />
+            <label for="filter_recommend_1" class="c-checkbox__label--tag">メール便対象商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_2" name="filter_recommend_2" class="c-checkbox__tag" value="2" />
+            <label for="filter_recommend_2" class="c-checkbox__label--tag">値下げ商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_3" name="filter_recommend_3" class="c-checkbox__tag" value="3" />
+            <label for="filter_recommend_3" class="c-checkbox__label--tag">激安商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_4" name="filter_recommend_4" class="c-checkbox__tag" value="4" />
+            <label for="filter_recommend_4" class="c-checkbox__label--tag">タダ本対象商品</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="l-sort__modal--button l-filter-tab__button">
+      <button type="submit" class="c-button--search-orange" id="js-filterButton">検索する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <!-- 下部固定ナビゲーション -->
+      <div class="c-bottom-nav" id="js-searchModal">
+  <div class="c-bottom-nav__button-container">
+    <div class="c-bottom-nav__buttons">
+      <button type="" class="c-button--outline c-button-nav__clear-button" data-target="js-bottomNavSortForm">条件を解除する</button>
+      <button type="" class="c-button--next-green c-button-nav__search-button" disabled>検索する</button>
+    </div>
+
+    <nav>
+      <ul class="c-bottom-nav__list">
+        <li class="c-bottom-nav__nav">
+          <button type="button" class="c-bottom-nav__link js-toggle" data-target="js-searchModal" id="memory-ajax">
+            <span class="c-button-nav__search">商品を探す</span>
+            <span class="c-button-nav__close">閉じる</span>
+          </button>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/myfavorite/" class="c-bottom-nav__link">
+            
+            
+            お気に入り
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/incomingmaillist/" class="c-bottom-nav__link">
+            
+            
+            入荷・予約
+          </a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/mypage/browsinghistory/" class="c-bottom-nav__link">閲覧履歴</a>
+        </li>
+        <li class="c-bottom-nav__nav">
+          <a href="/purchase/cart/" class="c-bottom-nav__link">
+            
+            カート
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="c-bottom-nav__modal">
+    <ul class="c-bottom-nav__tab-list">
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="search-srot" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab2" />
+        <label for="search-srot" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--sort" onclick="handleTabClick('search', null, null)">商品を探す</label>
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="recommend" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab3" />
+        <label for="recommend" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--recommend" onclick="handleTabClick('taglist', null, '1002')"
+          >ネットオフの<br />おすすめ</label
+        >
+      </li>
+      <li class="c-bottom-nav__tab">
+        <input type="radio" id="memory" name="bottom-nav-tab" class="js-tabRadio" data-target="js-bottomNavTab1" />
+        <label for="memory" class="c-bottom-nav__tab-label c-bottom-nav__tab-label--memory" onclick="handleTabClick('memory', null, null)">思い出の作品</label>
+      </li>
+    </ul>
+
+    <!-- 思い出の作品 -->
+    <div class="c-bottom-nav__modal-inner">
+      <div class="c-bottom-nav__modal-contents c-bottom-nav__memory js-tabContent" id="js-bottomNavTab1">
+        <ul class="l-bottom-nav__select-container">
+          <!-- ジャンル表示ここから -->
+          <li class="c-bottom-nav__memory-category-list l-bottom-nav__category-list" id="memory-select-container-category">
+            <div class="c-select js-select" data-target="js-bottomNavCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavCategory"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavCategory">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="男性向けコミック" data-value="男性向けコミック" id="bottomNavCategory1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory1">男性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="女性向けコミック" data-value="女性向けコミック" id="bottomNavCategory2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory2">女性向けコミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="文庫小説・エッセイ" data-value="文庫小説・エッセイ" id="bottomNavCategory3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory3">文庫小説・エッセイ </label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="単行本小説・エッセイ" data-value="単行本小説・エッセイ" id="bottomNavCategory4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory4">単行本小説・エッセイ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ライトノベル" data-value="ライトノベル" id="bottomNavCategory5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory5">ライトノベル</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="ゲーム" data-value="ゲーム" id="bottomNavCategory6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory6">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="映画・ドラマ" data-value="映画・ドラマ" id="bottomNavCategory7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory7">映画・ドラマ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="アニメ" data-value="アニメ" id="bottomNavCategory8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory8">アニメ</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="邦楽" data-value="邦楽" id="bottomNavCategory9" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavCategory9">邦楽</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- ジャンル表示ここまで -->
+          <!-- 年表示ここから -->
+          <li class="l-bottom-nav__generation-list" id="memory-select-container-generation">
+            <div class="c-select js-select" data-target="js-bottomNavGeneration" tabindex="0">
+              <div class="c-select__label js-selectLabel js-memory-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavGeneration"></div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavGeneration">
+                <!-- <div>
+                  <input type="radio" name="search-category" value="2000年" data-value="2000" id="bottomNavGeneration1" checked class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration1">2000年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2005年" data-value="2005" id="bottomNavGeneration2" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration2">2005年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2010年" data-value="2010" id="bottomNavGeneration3" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration3">2010年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2015年" data-value="2015" id="bottomNavGeneration4" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration4">2015年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2020年" data-value="2020" id="bottomNavGeneration5" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration5">2020年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2021年" data-value="2021" id="bottomNavGeneration6" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration6">2021年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2022年" data-value="2022" id="bottomNavGeneration7" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration7">2022年</label>
+                </div>
+                <div>
+                  <input type="radio" name="search-category" value="2023年" data-value="2023" id="bottomNavGeneration8" class="js-selectOption" />
+                  <label class="c-select__options" for="bottomNavGeneration8">2023年</label>
+                </div> -->
+              </div>
+            </div>
+          </li>
+          <!-- 年表示ここまで -->
+          <li>
+            <div class="l-bottom-nav__btn-wrap">
+              <button type="submit" class="l-bottom-nav__submit-btn" id="memory-submit-btn"></button>
+            </div>
+          </li>
+        </ul>
+        <div class="l-bottom-nav__ranking-container">
+          
+          <ul id="memory-container" class="c-bottom-nav__ranking-list">
+            <li>
+              <p class="l-bottom-nav__ranking-text">
+                作品がありません<br />
+                他の条件で探してみましょう！
+              </p>
+            </li>
+          </ul>
+          
+          <!-- <ul class="c-bottom-nav__ranking-list">
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--1">1</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--2">2</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy1.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--3">3</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy3.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】&emsp;＜全１８巻セット＞限定</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__ranking">
+              <span class="c-bottom-nav__rank c-bottom-nav__rank--4">4</span>
+              <div class="c-bottom-nav__ranking-img">
+                <img th:src="@{/img/dummy/product_dummy4.png}" alt="" />
+              </div>
+              <div class="c-bottom-nav__ranking-product">
+                <p class="c-bottom-nav__ranking-product-name">
+                  <a hre="" class="c-bottom-nav__ranking-product-link">鋼の錬金術師&emsp;【完全版】</a>
+                </p>
+                <div class="c-bottom-nav__ranking-product-info">
+                  <ul class="c-bottom-nav__ranking-tag-list">
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--red">コミック</li>
+                    <li class="c-bottom-nav__ranking-tag c-bottom-nav__ranking-tag--orange">少年コミック</li>
+                  </ul>
+                  <span class="c-bottom-nav__ranking-product-price">4,498円<span class="c-bottom-nav__ranking-product-text">(税込)</span></span>
+                </div>
+              </div>
+            </li>
+          </ul> -->
+        </div>
+      </div>
+    </div>
+    <!-- 思い出の作品 -->
+
+    <form id="js-bottomNavSortForm" method="GET" action="/cmdtyallsearch/">
+      <!-- 絞り込み -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab2">
+        <div class="c-bottom-nav__input">
+          <input id="js-bottomNavWord" type="text" name="word" placeholder="キーワードを入力" />
+          <input type="hidden" id="hiddenCat" name="cat" value="" />
+          <input type="hidden" id="hiddenGenre" name="genre" value="" />
+          <button type="button" class="c-bottom_nav__input-button">
+            <img src="/img/search_simple_icon.svg" alt="search" />
+          </button>
+        </div>
+        <ul id="search-category">
+          
+          <!-- <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory1">古本・中古本</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory1">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks1" />
+                    <label for="js-bottomNavSortGenreBooks1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks2" />
+                    <label for="js-bottomNavSortGenreBooks2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks3" />
+                    <label for="js-bottomNavSortGenreBooks3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-books" type="radio" class="c-checkbox" id="js-bottomNavSortGenreBooks4" />
+                    <label for="js-bottomNavSortGenreBooks4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown is-active" data-target="js-bottomNavSortCategory2">コミック</div>
+              <div class="c-bottom-nav__sort-genre-container" id="js-bottomNavSortCategory2">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics1" />
+                    <label for="js-bottomNavSortGenreComics1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics2" />
+                    <label for="js-bottomNavSortGenreComics2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics3" />
+                    <label for="js-bottomNavSortGenreComics3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comics" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComics4" />
+                    <label for="js-bottomNavSortGenreComics4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory3">コミックセット</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory3">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet1" />
+                    <label for="js-bottomNavSortGenreComicsSet1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet2" />
+                    <label for="js-bottomNavSortGenreComicsSet2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet3" />
+                    <label for="js-bottomNavSortGenreComicsSet3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet4" />
+                    <label for="js-bottomNavSortGenreComicsSet4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-comicsSet" type="radio" class="c-checkbox" id="js-bottomNavSortGenreComicsSet5" />
+                    <label for="js-bottomNavSortGenreComicsSet5">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory4">ゲーム</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory4">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames1" />
+                    <label for="js-bottomNavSortGenreGames1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames2" />
+                    <label for="js-bottomNavSortGenreGames2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames3" />
+                    <label for="js-bottomNavSortGenreGames3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-games" type="radio" class="c-checkbox" id="js-bottomNavSortGenreGames4" />
+                    <label for="js-bottomNavSortGenreGames4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory5">トレカ</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory5">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards1" />
+                    <label for="js-bottomNavSortGenreCards1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards2" />
+                    <label for="js-bottomNavSortGenreCards2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards3" />
+                    <label for="js-bottomNavSortGenreCards3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cards" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCards4" />
+                    <label for="js-bottomNavSortGenreCards4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory6">DVD・Blu-ray</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory6">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD1" />
+                    <label for="js-bottomNavSortGenreDVD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD2" />
+                    <label for="js-bottomNavSortGenreDVD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD3" />
+                    <label for="js-bottomNavSortGenreDVD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-dvd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreDVD4" />
+                    <label for="js-bottomNavSortGenreDVD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="c-bottom-nav__sort-tab-list">
+              <div class="c-bottom-nav__sort-tab js-navPullDown" data-target="js-bottomNavSortCategory7">CD</div>
+              <div class="c-bottom-nav__sort-genre-container c-bottom-nav__sort-genre-container--close" id="js-bottomNavSortCategory7">
+                <ul class="c-bottom-nav__sort-genre-list">
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD1" />
+                    <label for="js-bottomNavSortGenreCD1">
+                      <span class="c-checkbox__label">青年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD2" />
+                    <label for="js-bottomNavSortGenreCD2">
+                      <span class="c-checkbox__label">少年コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD3" />
+                    <label for="js-bottomNavSortGenreCD3">
+                      <span class="c-checkbox__label">少女コミック</span>
+                    </label>
+                  </li>
+                  <li class="c-bottom-nav__sort-genre">
+                    <input name="sort-cd" type="radio" class="c-checkbox" id="js-bottomNavSortGenreCD4" />
+                    <label for="js-bottomNavSortGenreCD4">
+                      <span class="c-checkbox__label">レディースコミック</span>
+                    </label>
+                  </li>
+                </ul>
+              </div>
+            </li> -->
+        </ul>
+      </div>
+      <!-- 絞り込み -->
+      <!-- ネットオフのおすすめ -->
+      <div class="c-bottom-nav__modal-contents js-tabContent" id="js-bottomNavTab3">
+        <p class="c-bottom-nav__tag-heading">人気タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavPopularCategory" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavPopularCategory">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavPopularCategory">
+                <div>
+                  <input type="radio" name="popular-category" value="古本・中古本" data-value="1002" id="popular-category1" checked class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category1" id="popular-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミック" data-value="1001" id="popular-category2" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category2" id="popular-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="コミックセット" data-value="1011" id="popular-category3" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="ゲーム" data-value="5001" id="popular-category4" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="DVD・Blu-ray" data-value="7001" id="popular-category5" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="popular-category" value="CD" data-value="3001" id="popular-category6" class="js-selectOption popularCategoryOption" />
+                  <label class="c-select__options" for="popular-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="popularTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <p class="c-bottom-nav__tag-heading">新着タグからおすすめ商品を探す</p>
+        <div>
+          <ul class="c-bottom-nav__tag-category-list">
+            <li class="c-select js-select" data-target="js-bottomNavTagNewCategory1" tabindex="0">
+              <div class="c-select__label js-selectLabel c-bottom-nav__select-label" data-target="js-bottomNavTagNewCategory1">古本・中古本</div>
+              <div class="c-select__option-container c-bottom-nav__select-option" id="js-bottomNavTagNewCategory1">
+                <div>
+                  <input type="radio" name="new-category" value="古本・中古本" data-value="1002" id="new-category1" checked class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category1">古本・中古本</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミック" data-value="1001" id="new-category2" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category2">コミック</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="コミックセット" data-value="1011" id="new-category3" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category3">コミックセット</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="ゲーム" data-value="5001" id="new-category4" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category4">ゲーム</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="DVD・Blu-ray" data-value="7001" id="new-category5" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category5">DVD・Blu-ray</label>
+                </div>
+                <div>
+                  <input type="radio" name="new-category" value="CD" data-value="3001" id="new-category6" class="js-selectOption newCategoryOption" />
+                  <label class="c-select__options" for="new-category6">CD</label>
+                </div>
+              </div>
+            </li>
+            <li class="c-bottom-nav__tag-container">
+              <ul class="c-bottom-nav__tag-list" id="newTagsList">
+                
+                <!-- <li>
+                  <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li> -->
+                
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </li>
+          </ul>
+
+          <!-- <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown is-active" data-target="js-bottomNavTagCategory1">コミック</div>
+            <div class="c-bottom-nav__tag-container" id="js-bottomNavTagCategory1">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li>
+          <li class="c-bottom-nav__tag-category-list">
+            <div class="c-bottom-nav__tag-category js-pullDown" data-target="js-bottomNavTagCategory2">コミックセット</div>
+            <div class="c-bottom-nav__tag-container c-bottom-nav__tag-container--close" id="js-bottomNavTagCategory2">
+              <ul class="c-bottom-nav__tag-list">
+                <li> -->
+          <!-- <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                    <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                      <span>2023年映画化</span>
+                    </label> -->
+          <!-- <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+                </li>
+                <li>
+                  <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+                </li>
+              </ul>
+              <div class="c-bottom-nav__tag-link-container">
+                <a href="" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+              </div>
+            </div>
+          </li> -->
+        </div>
+        <p class="c-bottom-nav__tag-heading">好きな商品の関連商品を探す</p>
+        <div class="l-bottom-nav__tag-search">
+          <p class="l-bottom-nav__lead-text c-link--blue">お好きな商品を含むタグの一覧を表示します</p>
+          <div class="c-bottom-nav__input" method="GET" action="/cmdtyallsearch/">
+            <input type="text" name="word" id="wordInput" placeholder="キーワードを入力" />
+            <button type="button" class="c-bottom_nav__input-button" onclick="handleButtonClick()">
+              <img src="/img/search_simple_icon.svg" alt="search" />
+            </button>
+          </div>
+          <div class="c-bottom-nav__tag-container">
+            <ul class="c-bottom-nav__tag-list" id="tagSearch">
+              <!-- <li>
+                <input name="tag-comics" type="checkbox" class="c-bottom-nav__tag" id="js-bottomNavTagNewComics1" />
+                  <label for="js-bottomNavTagNewComics1" class="c-bottom-nav__tag-label">
+                    <span>2023年映画化</span>
+                  </label>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">2023年映画化</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">胸キュン少女漫画</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">完結TOP100</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">全国書店員おすすめ</span></a>
+              </li>
+              <li>
+                <a th:href="@{/tag/tagdetails}" class="c-bottom-nav__tag"><span class="c-bottom-nav__tag-label">泣けるBL</span></a>
+              </li> -->
+            </ul>
+            <div class="c-bottom-nav__tag-link-container">
+              <a href="/label/" class="c-bottom-nav__tag-link">すべてのタグを見る</a>
+            </div>
+          </div>
+        </div>
+        <p class="c-bottom-nav__tag-heading">おすすめの特集から探す</p>
+        <ul class="l-bottom-nav__campaign-list">
+          <li class="l-bottom-nav__campaign-item">
+            <a href="https://www.netoff.co.jp/special/comicset.jsp">
+  <img src="/images/banner/main/serchmodal-1m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/ranking2023/">
+  <img src="/images/banner/main/serchmodal-2m-banner.webp" alt="" />
+</a>
+<a href="https://www.netoff.co.jp/special/bl_comic.jsp">
+  <img src="/images/banner/main/serchmodal-3m-banner.webp" alt="" />
+</a>
+
+          </li>
+        </ul>
+      </div>
+      <!-- ネットオフのおすすめ -->
+    </form>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/bottom-navigation.js" defer></script>
+  </div>
+</div>
+
+      <form action="/cmdtyallsearch/" name="sortModalForm2">
+        <input
+          type="hidden"
+          name="clFrom"
+          value="0"
+        /><input
+          type="hidden"
+          name="cat"
+          value="1002"
+        /><input
+          type="hidden"
+          name="clTo"
+          value="0"
+        /><input
+          type="hidden"
+          name="clNext"
+          value="100"
+        /><input
+          type="hidden"
+          name="clPrev"
+          value="-100"
+        /><input
+          type="hidden"
+          name="word"
+          value="9784000000000"
+        /><input
+          type="hidden"
+          name="dnum"
+          value="100"
+        /><input
+          type="hidden"
+          name="pageMax"
+          value="1"
+        />
+        <!-- ソートモーダル -->
+        <div class="c-modal" id="js-sort-modal">
+  <div class="c-modal__background js-toggle" data-target="js-sort-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle" data-target="js-sort-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <p class="l-sort__modal--title">並び順</p>
+    </div>
+    <div class="c-modal__inner--scroll">
+      <ul class="l-sort__modal--categorylist">
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--1">
+            <input
+              type="radio"
+              id="sort--modal--1"
+              name="sort"
+              data-text="関連度順"
+              value="relevance" checked="checked"
+            />
+            <span class="c-radio">関連度順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--2">
+            <input
+              type="radio"
+              id="sort--modal--2"
+              name="sort"
+              data-text="よく見られている順"
+              value="popular"
+            />
+            <span class="c-radio">よく見られている順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--3">
+            <input
+              type="radio"
+              id="sort--modal--3"
+              name="sort"
+              data-text="発売日が新しい順"
+              value="newest"
+            />
+            <span class="c-radio">発売日が新しい順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--4">
+            <input
+              type="radio"
+              id="sort--modal--4"
+              name="sort"
+              data-text="発売日が古い順"
+              value="oldest"
+            />
+            <span class="c-radio">発売日が古い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--5">
+            <input
+              type="radio"
+              id="sort--modal--5"
+              name="sort"
+              data-text="価格が安い順"
+              value="cheap"
+            />
+            <span class="c-radio">価格が安い順</span>
+          </label>
+        </li>
+        <li class="l-sort__modal--list">
+          <label class="c-radio__label l-sort__modal--radio" for="sort--modal--6">
+            <input
+              type="radio"
+              id="sort--modal--6"
+              name="sort"
+              data-text="価格が高い順"
+              value="expensive"
+            />
+            <span class="c-radio">価格が高い順</span>
+          </label>
+        </li>
+      </ul>
+      
+        <p class="l-sort__modal--title l-sort__modal--title--number">表示件数</p>
+        <ul>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-1">
+              <input
+                type="radio"
+                id="sort--modal-1"
+                name="display-amount"
+                class=""
+                value="50"
+              />
+              <span class="c-radio">50件</span>
+            </label>
+          </li>
+          <li class="l-sort__modal--list">
+            <label class="c-radio__label l-sort__modal--radio" for="sort--modal-2">
+              <input
+                type="radio"
+                id="sort--modal-2"
+                name="display-amount"
+                class=""
+                value="100" checked="checked"
+              />
+              <span class="c-radio">100件</span>
+            </label>
+          </li>
+        </ul>
+      
+    </div>
+    <div class="l-sort__modal--button">
+      <!-- フォームサブミット -->
+      <button type="submit" class="c-button--search-orange" id="js-sortButton">変更する</button>
+    </div>
+  </div>
+</div>
+      </form>
+
+      <form action="/cmdtyallsearch/" name="filterModalForm2">
+        <input type="hidden" name="word" value="9784000000000" />
+        <div
+  class="c-modal"
+  id="js-filter-tab-modal"
+>
+  <div class="c-modal__background js-toggle" data-target="js-filter-tab-modal"></div>
+  <div class="c-modal__inner c-modal__inner--sort l-sort-modal">
+    <div>
+      <button type="button" class="c-modal__close js-toggle c-modal__close-adjust" data-target="js-filter-tab-modal">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-filter-tab__list--title-flex">
+        <p class="l-filter-tab__list--title">絞込み</p>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm pc-none" data-target="js-filterTabForm">条件をリセット</button>
+        <button type="button" class="l-filter-tab__button--filter js-clearAllInput js-clearFilterTabForm sp-none" data-target="js-filterTabForm">条件をリセット</button>
+      </div>
+    </div>
+    
+    <div class="c-modal__inner--scroll" id="js-filterTabForm">
+      <div>
+        <h4 class="l-filter-tab__title--category">カテゴリ</h4>
+        <ul class="l-filter-tab__list js-filter-list-category">
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_1"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="7001"
+            />
+            <label for="filter_category_1" class="c-checkbox__label--tag">DVD・Blu-ray(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_2"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="5001"
+            />
+            <label for="filter_category_2" class="c-checkbox__label--tag">ゲーム(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_3"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1002" checked="checked"
+            />
+            <label for="filter_category_3" class="c-checkbox__label--tag">古本・中古本(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_4"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="1001"
+            />
+            <label for="filter_category_4" class="c-checkbox__label--tag">コミック(0)</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input
+              type="radio"
+              id="filter_category_5"
+              name="filter_category"
+              class="c-checkbox__tag js-filter-modal-category"
+              value="3001"
+            />
+            <label for="filter_category_5" class="c-checkbox__label--tag">CD(0)</label>
+          </li>
+        </ul>
+      </div>
+      
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">ジャンル</h4>
+          <ul class="l-filter-tab__list js-filter-list-genre">
+            <li style="width: 100%; margin-top: 8px; display: flex; justify-content: center"><p>カテゴリを選択してください。</p></li>
+          </ul>
+        </div>
+      
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">著者/アーティスト</h4>
+          <ul class="l-filter-tab__list js-filter-list-artist">
+            <li style="width: 100%; margin-top: 8px; display: flex; justify-content: center"><p>カテゴリを選択してください。</p></li>
+          </ul>
+        </div>
+      
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">在庫</h4>
+        <div class="l-filter-tab__list--checkbox">
+          <input name="filter_stock" type="checkbox" class="c-checkbox" id="filter_tag_stock" value="1" />
+          <label for="filter_tag_stock">
+            <span class="c-checkbox__label">在庫あり</span>
+          </label>
+        </div>
+      </div>
+      <div>
+        <h4 class="l-filter-tab__title--category">価格帯</h4>
+        <div class="js_filter_modal_price_container">
+          <div class="l-filter-tab__list--input">
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_min" value="" />&ensp;円&#65374;
+            </div>
+            <div class="l-filter-tab__search-input">
+              <input type="text" class="c-input-text c-input-text--small" name="filter_price_max" value="" />&ensp;円
+            </div>
+            <div class="l-filter-tab__list--input-error">
+              <span class="c-input-text__error-message">価格帯は半角数字のみで入力してください。</span>
+            </div>
+          </div>
+          <ul class="l-filter-tab__list">
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp10" name="filter_tag_price_110" class="c-checkbox__tag js_filter_modal_price" value="0_110" />
+              <label for="filter_tmp10" class="c-checkbox__label--tag">&#65374; 110円以下</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp11" name="filter_tag_price_111_500" class="c-checkbox__tag js_filter_modal_price" value="111_500" />
+              <label for="filter_tmp11" class="c-checkbox__label--tag">111円 &#65374; 500円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp12" name="filter_tag_price_501_1000" class="c-checkbox__tag js_filter_modal_price" value="501_1000" />
+              <label for="filter_tmp12" class="c-checkbox__label--tag">501円 &#65374; 1,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp13" name="filter_tag_price_1001_3000" class="c-checkbox__tag js_filter_modal_price" value="1001_3000" />
+              <label for="filter_tmp13" class="c-checkbox__label--tag">1,001円 &#65374; 3,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp14" name="filter_tag_price_3001_5000" class="c-checkbox__tag js_filter_modal_price" value="3001_5000" />
+              <label for="filter_tmp14" class="c-checkbox__label--tag">3,001円 &#65374; 5,000円</label>
+            </li>
+            <li class="l-filter-tab__list--item">
+              <input type="checkbox" id="filter_tmp15" name="filter_tag_price_5001" class="c-checkbox__tag js_filter_modal_price" value="5001_0" />
+              <label for="filter_tmp15" class="c-checkbox__label--tag">5,001円 &#65374; </label>
+            </li>
+          </ul>
+        </div>
+      </div>
+      
+        
+        <div>
+          <h4 class="l-filter-tab__title--category">サイズ</h4>
+          <ul class="l-filter-tab__list js-filter-list-size">
+            <p>カテゴリを選択してください。</p>
+          </ul>
+        </div>
+      
+      <div>
+        <h4 class="l-filter-tab__title--category">おすすめ</h4>
+        <ul class="l-filter-tab__list">
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_1" name="filter_recommend_1" class="c-checkbox__tag" value="1" />
+            <label for="filter_recommend_1" class="c-checkbox__label--tag">メール便対象商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_2" name="filter_recommend_2" class="c-checkbox__tag" value="2" />
+            <label for="filter_recommend_2" class="c-checkbox__label--tag">値下げ商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_3" name="filter_recommend_3" class="c-checkbox__tag" value="3" />
+            <label for="filter_recommend_3" class="c-checkbox__label--tag">激安商品</label>
+          </li>
+          <li class="l-filter-tab__list--item">
+            <input type="checkbox" id="filter_recommend_4" name="filter_recommend_4" class="c-checkbox__tag" value="4" />
+            <label for="filter_recommend_4" class="c-checkbox__label--tag">タダ本対象商品</label>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="l-sort__modal--button l-filter-tab__button">
+      <button type="submit" class="c-button--search-orange" id="js-filterButton">検索する</button>
+    </div>
+  </div>
+</div>
+      </form>
+    </main>
+
+    <footer>
+      <div class="l-footer l-footer--sp">
+  <nav>
+    <ul>
+      <li>
+        <div class="l-footer__heading">カテゴリから探す</div>
+        <ul>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav1">古本・中古本</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav1">
+              <li>
+                <a href="/book/" class="l-footer__nav-list l-footer__nav-list--category-link">古本・中古本 TOP</a>
+              </li>
+              <li>
+                <a href="/book/10/" class="l-footer__nav-list l-footer__nav-list--category-link">文芸</a>
+              </li>
+              <li>
+                <a href="/book/11/" class="l-footer__nav-list l-footer__nav-list--category-link">ビジネス</a>
+              </li>
+              <li>
+                <a href="/book/12/" class="l-footer__nav-list l-footer__nav-list--category-link">政治・経済・法律</a>
+              </li>
+              <li>
+                <a href="/book/13/" class="l-footer__nav-list l-footer__nav-list--category-link">料理・趣味・児童</a>
+              </li>
+              <li>
+                <a href="/book/14/" class="l-footer__nav-list l-footer__nav-list--category-link">教育・福祉・資格</a>
+              </li>
+              <li>
+                <a href="/book/15/" class="l-footer__nav-list l-footer__nav-list--category-link">女性・生活・コンピュータ</a>
+              </li>
+              <li>
+                <a href="/book/16/" class="l-footer__nav-list l-footer__nav-list--category-link">産業・学術・歴史</a>
+              </li>
+              <li>
+                <a href="/book/17/" class="l-footer__nav-list l-footer__nav-list--category-link">スポーツ・健康・医療</a>
+              </li>
+              <li>
+                <a href="/book/18/" class="l-footer__nav-list l-footer__nav-list--category-link">写真集</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav2">コミック</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav2">
+              <li>
+                <a href="/comic/" class="l-footer__nav-list l-footer__nav-list--category-link">コミック TOP</a>
+              </li>
+              <li>
+                <a href="/comic/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comic/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comic/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comic/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <li>
+                <a href="/comic/26/" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li>
+              <li>
+                <a href="/comic/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav3">コミックセット</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav3">
+              <li>
+                <a href="/comicset/" class="l-footer__nav-list l-footer__nav-list--category-link">コミックセット TOP</a>
+              </li>
+              <li>
+                <a href="/comicset/20/" class="l-footer__nav-list l-footer__nav-list--category-link">青年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/21/" class="l-footer__nav-list l-footer__nav-list--category-link">少年コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/22/" class="l-footer__nav-list l-footer__nav-list--category-link">少女コミック</a>
+              </li>
+              <li>
+                <a href="/comicset/23/" class="l-footer__nav-list l-footer__nav-list--category-link">レディースコミック</a>
+              </li>
+              <li>
+                <a href="/comicset/24/" class="l-footer__nav-list l-footer__nav-list--category-link">ボーイズラブ</a>
+              </li>
+              <!-- <li>
+                <a href="/comicset/26" class="l-footer__nav-list l-footer__nav-list--category-link">アンソロジーコミック</a>
+              </li> -->
+              <li>
+                <a href="/comicset/27/" class="l-footer__nav-list l-footer__nav-list--category-link">復刻・愛蔵・文庫</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav4">ゲーム</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav4">
+              <li><a href="/game/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲーム TOP</a></li>
+              <li><a href="/game/80/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch2</a></li>
+              <li><a href="/game/75/" class="l-footer__nav-list l-footer__nav-list--category-link">Nintendo Switch</a></li>
+              <li><a href="/game/72/" class="l-footer__nav-list l-footer__nav-list--category-link">WiiU</a></li>
+              <li><a href="/game/67/" class="l-footer__nav-list l-footer__nav-list--category-link">Wii</a></li>
+              <li><a href="/game/70/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドー3DS</a></li>
+              <li><a href="/game/56/" class="l-footer__nav-list l-footer__nav-list--category-link">ニンテンドーDS</a></li>
+              <!-- <li><a href="/game/54/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/game/57/" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=54&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームボーイアドバンス</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=57&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">ゲームキューブ</a></li>
+              <li><a href="/game/77/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション5</a></li>
+              <li><a href="/game/73/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション4</a></li>
+              <li><a href="/game/66/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション3</a></li>
+              <li><a href="/game/51/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション2</a></li>
+              <li><a href="/game/52/" class="l-footer__nav-list l-footer__nav-list--category-link">プレイステーション</a></li>
+              <li><a href="/game/71/" class="l-footer__nav-list l-footer__nav-list--category-link">PS Vita</a></li>
+              <li><a href="/game/53/" class="l-footer__nav-list l-footer__nav-list--category-link">PSP</a></li>
+              <!-- <li><a href="/game/74/" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/game/65/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/game/61/" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li> -->
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=74&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">XboxOne</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=65&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox360</a></li>
+              <li><a href="/cmdtyallsearch/?cat=5001&genre=61&stock=1&dnum=50" class="l-footer__nav-list l-footer__nav-list--category-link">Xbox</a></li>
+              <li><a href="/game/78/" class="l-footer__nav-list l-footer__nav-list--category-link">レトロゲーム</a></li>
+              <li><a href="/game/68/" class="l-footer__nav-list l-footer__nav-list--category-link">PCゲーム</a></li>
+            </ul>
+          </li>
+          <!-- <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav5">トレカ</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav5">
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">トレカ TOP</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ポケモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ワンピースカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">シャドウバース エボルブ</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">遊戯王</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">デジモンカード</a>
+              </li>
+              <li>
+                <a href="#" class="l-footer__nav-list l-footer__nav-list--category-link">ヴァンガード</a>
+              </li>
+            </ul>
+          </li> -->
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav6">DVD・Blu-ray</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav6">
+              <li>
+                <a href="/dvd/" class="l-footer__nav-list l-footer__nav-list--category-link">DVD・Blu-ray TOP</a>
+              </li>
+              <li>
+                <a href="/dvd/41/" class="l-footer__nav-list l-footer__nav-list--category-link">洋画</a>
+              </li>
+              <li>
+                <a href="/dvd/42/" class="l-footer__nav-list l-footer__nav-list--category-link">邦画</a>
+              </li>
+              <li>
+                <a href="/dvd/43/" class="l-footer__nav-list l-footer__nav-list--category-link">ミュージック</a>
+              </li>
+              <li>
+                <a href="/dvd/44/" class="l-footer__nav-list l-footer__nav-list--category-link">アニメ</a>
+              </li>
+              <li>
+                <a href="/dvd/45/" class="l-footer__nav-list l-footer__nav-list--category-link">芸能・スポーツ・その他</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <div class="l-footer__nav-list l-footer__pullDown js-pullDown" data-target="js-footerNav7">CD</div>
+            <ul class="l-footer__nav-list-container" id="js-footerNav7">
+              <li>
+                <a href="/cd/" class="l-footer__nav-list l-footer__nav-list--category-link">CD TOP</a>
+              </li>
+              <li>
+                <a href="/cd/31/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャパニーズポップス</a>
+              </li>
+              <li>
+                <a href="/cd/32/" class="l-footer__nav-list l-footer__nav-list--category-link">海外のロック＆ポップス</a>
+              </li>
+              <li>
+                <a href="/cd/33/" class="l-footer__nav-list l-footer__nav-list--category-link">ジャズ＆フュージョン</a>
+              </li>
+              <li>
+                <a href="/cd/34/" class="l-footer__nav-list l-footer__nav-list--category-link">イージーリスニング</a>
+              </li>
+              <li>
+                <a href="/cd/35/" class="l-footer__nav-list l-footer__nav-list--category-link">クラシック</a>
+              </li>
+              <li>
+                <a href="/cd/36/" class="l-footer__nav-list l-footer__nav-list--category-link">サウンドトラック</a>
+              </li>
+              <li>
+                <a href="/cd/37/" class="l-footer__nav-list l-footer__nav-list--category-link">童謡・民謡・その他</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__heading">おすすめから探す</div>
+        <ul>
+          <li><a class="l-footer__nav-list" href="/special/">キャンペーン・特集</a></li>
+          <li><a class="l-footer__nav-list" href="/timesale/">タイムセール</a></li>
+          <!-- <li>
+            <a th:with="result = ${T(www.netoff.co.jp.web.config.UrlConfig).TAG_DETAILS_URL}" th:href="${result + '?tagid=19821&cat=7001'}">110円～！激安人気作ランキング</a>
+          </li>
+          <li>
+            <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}" class="l-footer__nav-list"
+              >あなたにおすすめの商品</a
+            >
+          </li> -->
+        </ul>
+      </li>
+      <li>
+        <div class="l-footer__purchase">
+          <span>ラクして売るなら</span>
+          ネットオフ宅配買取
+        </div>
+        <ul>
+          <li>
+            <a href="/sell/book/" class="l-footer__nav-list l-footer__nav-list--accent">本＆ゲーム買取コース</a>
+          </li>
+          <li>
+            <a href="/sell/book/book/" class="l-footer__nav-list">古本・中古本買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/comic/" class="l-footer__nav-list">コミック買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/" class="l-footer__nav-list">ゲームソフト買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/game/body.jsp" class="l-footer__nav-list">ゲーム機本体買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/dvd/" class="l-footer__nav-list">DVD・Blu-ray買取</a>
+          </li>
+          <li>
+            <a href="/sell/book/cd/" class="l-footer__nav-list">CD買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/moetaku/" class="l-footer__nav-list l-footer__nav-list--accent">ホビー・フィギュア買取 もえたく！</a>
+          </li>
+          <li>
+            <a href="/figure/" class="l-footer__nav-list">フィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/kuji_prize/" class="l-footer__nav-list">プライズフィギュア買取</a>
+          </li>
+          <li>
+            <a href="/figure/plamodel/" class="l-footer__nav-list">プラモデル買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/" class="l-footer__nav-list">トレカ買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/pokemon_card/" class="l-footer__nav-list">ポケモンカード買取</a>
+          </li>
+          <li>
+            <a href="/moetaku/tcg/onepiece/" class="l-footer__nav-list">ワンピースカード買取</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a href="/sell/general/" class="l-footer__nav-list l-footer__nav-list--accent">ブランド＆総合買取コース</a>
+          </li>
+          <li>
+            <a href="/kaden/" class="l-footer__nav-list">家電買取</a>
+          </li>
+          <li>
+            <a href="/kaden/camera/" class="l-footer__nav-list">カメラ買取</a>
+          </li>
+          <li>
+            <a href="/kaden/gamingpc/" class="l-footer__nav-list">ゲーミングPC買取</a>
+          </li>
+          <li>
+            <a href="/kaden/deditalstationery/lcdtablet/" class="l-footer__nav-list">液タブ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/" class="l-footer__nav-list">スマホ買取</a>
+          </li>
+          <li>
+            <a href="/mobilebuy/smartphone/iphone/" class="l-footer__nav-list">iPhone買取</a>
+          </li>
+          <li>
+            <a href="/clothes/" class="l-footer__nav-list">洋服・古着買取</a>
+          </li>
+          <li>
+            <a href="/brand/brand/" class="l-footer__nav-list">ブランド買取</a>
+          </li>
+          <li>
+            <a href="/brand/jewelry/" class="l-footer__nav-list">金・プラチナ買取</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  ﻿<aside id="footer-1m-banner" class="l-footer__banner">
+  <!-- バナー -->
+  <a href="https://page.line.me/trp3160p?oat__id=699595&openQrModal=true" target="0">
+    <img src="/images/banner/main/footer-1m-banner.webp" alt="LINE 公式アカウント"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?category=1643943081566646275" target="0">
+    <img src="/images/banner/main/footer-2m-banner.webp" alt="もえたく 社員募集"/>
+  </a>
+  <a href="https://hrmos.co/pages/renetjapan/jobs?jobType=PART&category=1644999205883056129" target="0">
+    <img src="/images/banner/main/footer-3m-banner.webp" alt="ネットオフ アルバイト募集"/>
+  </a>
+</aside>
+
+
+  <nav>
+    <ul>
+      <li>
+        <a href="/kaitori-navi/" class="l-footer__nav-list">買取ナビTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/" class="l-footer__nav-list">VODチョイスTOP</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/ebook/" class="l-footer__nav-list">おすすめ電子書籍</a>
+      </li>
+      <li>
+        <a href="https://vod.netoff.co.jp/vod/" class="l-footer__nav-list">おすすめ動画配信サービス</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/" class="l-footer__nav-list">インターネット比較TOP</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/pocket-wifi/" class="l-footer__nav-list">おすすめポケット型WiFi</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/wimax-comparison/" class="l-footer__nav-list">おすすめWiMAX</a>
+      </li>
+      <li>
+        <a href="https://internet.netoff.co.jp/hikari-recommendation/" class="l-footer__nav-list">おすすめ光回線</a>
+      </li>
+      <li>
+        <a href="https://fortune.netoff.co.jp/" class="l-footer__nav-list">占ナビTOP</a>
+      </li>
+      <li>
+        <a href="/notification/noticelist/" class="l-footer__nav-list">お知らせ</a>
+      </li>
+      <li>
+        <a href="/guide/beginner.jsp" class="l-footer__nav-list">初めての方へ</a>
+      </li>
+      <li>
+        <a href="/guide/" class="l-footer__nav-list">ヘルプ・お問い合わせ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__info-container">
+    <img
+      src="/img/icon_mothers_sp.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+    <div class="l-footer__button-container">
+      
+        <!-- 未ログイン -->
+        <a href="/sell/" class="l-footer__button l-footer__button--purchase l-footer__button--flex">宅配買取</a>
+        <a
+          class="l-footer__button l-footer__button--sign l-footer__button--flex"
+          href="/registration/enterinformation/"
+          >新規会員登録</a
+        >
+      
+      
+    </div>
+    <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+  </div>
+
+  <nav>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/company/">会社案内</a>
+      </li>
+      <li>
+        <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+      </li>
+    </ul>
+    <ul class="l-footer__site-nav">
+      <li>
+        <a href="/guide/netoff.jsp">品質ポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/">プライバシーポリシー</a>
+      </li>
+      <li>
+        <a href="/policy/#policy02">個人情報保護方針</a>
+      </li>
+      <li>
+        <a href="/customer/">お客様への対応について</a>
+      </li>
+      <li>
+        <a href="/use/">ご利用規約</a>
+      </li>
+      <li>
+        <a href="/settlement/">資金決済法に基づく表示</a>
+      </li>
+      <li>
+        <a href="/sitemap/">サイトマップ</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="l-footer__netoff">
+    <span>ネットオフ株式会社</span>
+    古物商許可番号 542782100600 愛知県公安委員会許可<br />
+    <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+  </div>
+
+  <small class="l-footer__copyright">Copyright &copy; NETOFF,inc.</small>
+  <!-- ログアウト -->
+  <div class="c-modal" id="js-logout">
+  <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+  <form action="/logout" method="post" id="logoutForm"><input type="hidden" name="_csrf" value="b87c4825-6cb9-415b-aeb1-b165dbbe8203"/>
+    <div class="c-modal__background js-toggle" data-target="js-logout"></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <input type="hidden" name="_csrf" value="${_csrf.token}" />
+        <button type="button" class="c-button--black js-toggle" data-target="js-logout">キャンセル</button>
+        <button type="submit" class="c-button--black-outline">ログアウト</button>
+      </div>
+    </div>
+  </form>
+</div>
+  <!-- ログアウト -->
+  <!-- <div class="c-modal" id="js-footerLogout">
+    <div
+      class="c-modal__background js-toggle"
+      data-target="js-footerLogout"
+    ></div>
+    <div class="c-modal__inner l-header__modal">
+      <p>ログアウトしますか？</p>
+      <div class="l-header__logout">
+        <button
+          type="button"
+          class="c-button--black js-toggle"
+          data-target="js-footerLogout"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          class="c-button--black-outline"
+          onClick="window.location.href='/'"
+        >
+          ログアウト
+        </button>
+      </div>
+    </div>
+  </div> -->
+</div>
+      <div class="l-footer l-footer--pc">
+  <div class="l-footer__about">
+    <img
+      src="/img/icon_mothers_pc.png"
+      alt="ネットオフ株式会社は、リネットジャパングループ株式会社の100％子会社です。リネットジャパングループ株式会社は東京証券取引所に上場しています。"
+    />
+  </div>
+
+  <div class="l-footer__container">
+    <div class="l-footer__scroll-top">
+      <button type="button" onclick="window.scrollTo({ top: 0 })">▲ このページの先頭に戻る</button>
+    </div>
+    <div class="l-footer__inner">
+      <nav class="l-footer__main-nav-container">
+        <ul>
+          <li>
+            <div class="l-footer__heading">カテゴリから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/book/">古本・中古本</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comic/">コミック</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/comicset/">コミックセット</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/game/">ゲーム</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">トレカ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/dvd/">DVD・Blu-ray</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/cd/">CD</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">おすすめから探す</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/special/">キャンペーン・特集</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/timesale/">タイムセール</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="">110円～！激安人気作ランキング</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a th:with="recommend = ${T(www.netoff.co.jp.web.config.UrlConfig).RECOMMEND_RECOMMEND_URL}" th:href="${recommend}">あなたにおすすめの商品</a>
+              </li> -->
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">マイページ</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/mypagetop/">マイページトップ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/myfavorite/">お気に入り</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/incomingmaillist/">入荷メール</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mypage/customerinfochange/">お客様情報</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ご利用サポート・その他</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/guide/">ヘルプ・お問い合わせ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a href="/landingpage/shippingfeeexplanation">送料について</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/guide/beginner.jsp">はじめての方へ</a>
+              </li>
+              <!-- <li class="l-footer__nav-list">
+                <a th:with="noticelist = ${T(www.netoff.co.jp.web.config.UrlConfig).NOTIFICATION_NOTICELIST_URL}" th:href="${noticelist}">お知らせ</a>
+              </li> -->
+              <li class="l-footer__nav-list">
+                <a href="/kaitori-navi/">買取ナビ</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://vod.netoff.co.jp/">VODチョイス</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://internet.netoff.co.jp/">インターネット比較</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="https://fortune.netoff.co.jp/">占ナビ</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <div class="l-footer__heading">ネットオフ宅配買取</div>
+            <ul>
+              <li class="l-footer__nav-list">
+                <a href="/sell/book/">本・ゲーム買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/moetaku/tcg/pokemon_card/">トレカ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/figure/">フィギュア買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/mobilebuy/">スマホ買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/kaden/">家電買取</a>
+              </li>
+              <li class="l-footer__nav-list">
+                <a href="/sell/general/">ブランド・総合買取</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+
+      <nav class="l-footer__site-nav-container">
+        <ul class="l-footer__site-nav">
+          <li>
+            <a href="/company/">会社案内</a>
+          </li>
+          <li>
+            <a href="https://hrmos.co/pages/renetjapan" target="_blank" rel="noopener noreferrer">採用情報</a>
+          </li>
+          <li>
+            <a href="/guide/netoff.jsp">品質ポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/">プライバシーポリシー</a>
+          </li>
+          <li>
+            <a href="/policy/#policy02">個人情報保護方針</a>
+          </li>
+          <li>
+            <a href="/customer/">お客様への対応について</a>
+          </li>
+          <li>
+            <a href="/use/">ご利用規約</a>
+          </li>
+          <li>
+            <a href="/settlement/">資金決済法に基づく表示</a>
+          </li>
+          <li>
+            <a href="/sitemap/">サイトマップ</a>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="l-footer__info-container">
+        <small>本WEBサイトの販売価格は、すべて税込み表示です</small>
+      </div>
+
+      <div class="l-footer__netoff-container">
+        <div>
+          <a href="/" class="l-footer__logo">
+            <picture>
+              <source srcset="/img/logo-netoff.webp" type="image/webp" />
+              <img src="/img/logo-netoff.png" alt="NET OFF" />
+            </picture>
+          </a>
+          <div class="l-footer__netoff l-footer__netoff--main">
+            <span>ネットオフ株式会社</span>
+            古物商許可番号 542782100600 愛知県公安委員会許可<br />
+            <a href="/law/" target="_blank" rel="noopener noreferrer">特定商取引法に基づく表記</a>
+          </div>
+        </div>
+
+        <small class="l-footer__copyright l-footer__copyright--main">Copyright &copy; NETOFF,inc.</small>
+      </div>
+    </div>
+  </div>
+</div>
+    </footer>
+
+    <!-- /* 商品カセット用モーダル */ -->
+    <div>
+  
+  <div class="c-snackbar" id="js-addcart-ng">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-addcart-ng">閉じる</button>
+  </div>
+  <div class="c-snackbar" id="js-snack-common">
+    <p class="c-snackbar__text"></p>
+    <button type="button" class="c-snackbar__close js-snackbar" data-snackbar="js-snack-common">閉じる</button>
+  </div>
+  
+  
+  
+</div>
+    <div>
+  <!-- /* 入荷メール&予約モーダル */ -->
+  <div class="c-modal" id="js-mailReserve">
+    <div class="c-modal__background js-toggle" data-target="js-mailReserve"></div>
+    <div class="c-modal__inner c-modal__inner--sort">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailReserve">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="l-search__modal">
+        <div class="l-search__modal__inner l-search__modal__inner--green">
+          <p class="l-search__modal-heading">商品が入荷したらメールでお知らせ</p>
+          <p class="l-search__modal-text">
+            取り置きではありませんので、<br />
+            すぐに売り切れになる場合もございます。
+          </p>
+          <button type="button" class="c-button--mail l-search__modal-button js-incomingMailButton" data-target="js-mailSetting">入荷メールを登録（無料）</button>
+          <p class="l-search__modal-text js-mailregistercount-text"></p>
+        </div>
+        <div class="l-search__modal__inner l-search__modal__inner--red js-reserve-region"></div>
+      </div>
+    </div>
+  </div>
+</div>
+    <div>
+  <!-- /* 商品カセット用カート追加モーダル */ -->
+  <div class="c-modal" id="js-addcart">
+    <div class="c-modal__background js-toggle" data-target="js-addcart"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-addcart">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をカートに入れました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addcart">閉じる</button>
+          <a type="button" class="c-button--cart js-toggle" data-target="js-addcart" href="/purchase/cart/">カートに進む</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用入荷メールモーダル */ -->
+  <div class="c-modal" id="js-mailSetting">
+    <div class="c-modal__background js-toggle" data-target="js-mailSetting"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-mailSetting">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品を入荷メールに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-mailSetting">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り登録モーダル */ -->
+  <div class="c-modal" id="js-addfav">
+    <div class="c-modal__background js-toggle" data-target="js-addfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-addfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りに登録しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-addfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- /* 商品カセット用お気に入り解除モーダル */ -->
+  <div class="c-modal" id="js-delfav">
+    <div class="c-modal__background js-toggle" data-target="js-delfav"></div>
+    <div class="c-modal__inner">
+      <button type="button" class="c-modal__close js-toggle" data-target="js-delfav">
+        <img src="/img/close_black_icon.svg" alt="閉じる" />
+      </button>
+      <div class="c-modal__product-container">
+        <p>商品をお気に入りから登録解除しました。</p>
+        <div class="c-modal__product-container-button">
+          <button type="button" class="c-button--outline js-toggle" data-target="js-delfav">閉じる</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+    <script src="/js/common.js" defer></script>
+    <script src="/js/searchResult.js" defer></script>
+    <script>
+      // 検索条件
+      const condition = {"clFrom":"0","cat":"1002","clTo":"0","clNext":"100","page":"1","clPrev":"-100","word":"9784000000000","dnum":"100","pageMax":"1"};
+      // お気に入りリスト
+      const favCmdtyCodes = null;
+    </script>
+    <script>
+      function setCookie() {
+        var tmp = 'r18flg=1;';
+        tmp += 'path=/; expires=Tue, 31-Dec-2040 23:59:59; ';
+        document.cookie = tmp;
+        location.reload();
+      }
+    </script>
+    <script src="/js/jquery-3.7.1.min.js" defer></script>
+    <script src="/js/cart.js" defer></script>
+
+    
+      
+  
+    <script>
+      const MD5Email = null;
+    </script>
+    <script src="/js/criteo.js" defer></script>
+  
+
+    
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', () => {
+        let doc = document;
+        let head = doc.getElementsByTagName('head')[0];
+        let tagEmail = '';
+        tagEmail = '<%= MD5Email %>';
+        let criteoScript = document.createElement('script');
+        criteoScript.type = 'text/javascript';
+        criteoScript.src = '//static.criteo.net/js/ld/ld.js';
+        criteoScript.async = true;
+        head.appendChild(criteoScript);
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.innerHTML = 'window.criteo_q = window.criteo_q || [];';
+        script.innerHTML += 'window.criteo_q.push(';
+        script.innerHTML += '{ event: "setAccount", account: 85067 },';
+        script.innerHTML += '{ event: "setSiteType", type: "d" },';
+        if (tagEmail != '') {
+          script.innerHTML += '{ event: "setEmail", email:"' + tagEmail + '" },';
+        }
+        script.innerHTML += '{ event: "viewHome" }';
+        script.innerHTML += ');';
+        head.appendChild(script);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/used_book/valuebooks_product.html
+++ b/tests/fixtures/used_book/valuebooks_product.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8" />
+<meta http-equiv="content-language" content="ja" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport" />
+<meta name="format-detection" content="telephone=no, email=no, address=no" />
+<meta name="facebook-domain-verification" content="aowy7ydmb33fq6pi45xhx6ibomlggu" />
+<meta name="csrf-token" content="3gFsBtDBT5g2IGQSNv8ZRxDSQJ4Vthyu15Nnkr4z">
+        <link rel="canonical" id="canonical-link"
+          href="https://www.valuebooks.jp/%E6%B5%B7%E3%81%AB%E9%A1%98%E3%81%84%E3%82%92%E9%A2%A8%E3%81%AB%E7%A5%88%E3%82%8A%E3%82%92%E3%81%9D%E3%81%97%E3%81%A6%E5%90%9B%E3%81%AB%E8%AA%93%E3%81%84%E3%82%92--%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB-/bp/VS0051080734">
+<link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                                        <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                    <!-- declare GTM Data Layer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+dataLayer.push({
+    'user_id': '',
+    'page_id' : (new URL(window.location.href)).pathname, 
+});
+</script>
+<!-- End Data Layer declaring-->
+
+<!-- Google Tag Manager -->
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-ML5K92T');
+
+</script>
+<!-- End Google Tag Manager -->
+
+    <!-- Google Analytics - define gtag function -->
+    <script>
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-FSVYFJV0EY',{ 'send_page_view': false });
+    </script>
+    <!-- End Google Analytics -->
+
+    <!-- Salesforce Personalization Synchronous Integration -->
+    <script type="text/javascript" src="//cdn.evgnet.com/beacon/valuebookskk/engage/scripts/evergage.min.js"></script>
+    <title>海に願いを風に祈りをそして君に誓いを (スターツ出版文庫) | 検索 | 古本買取のバリューブックス</title>
+    <meta name="description" content="海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)（汐見夏衛 著／スターツ出版）の中古本の販売価格・在庫状況をチェック。バリューブックスならネットで簡単に古本を購入できます。">
+            <meta name="csrf-token" content="3gFsBtDBT5g2IGQSNv8ZRxDSQJ4Vthyu15Nnkr4z">
+    <!--OGP-->
+
+
+<meta property="og:type"   content="website">
+<meta property="fb:app_id" content="2374624702866002">
+
+      <meta property="og:url" content="https://www.valuebooks.jp/%E6%B5%B7%E3%81%AB%E9%A1%98%E3%81%84%E3%82%92%E9%A2%A8%E3%81%AB%E7%A5%88%E3%82%8A%E3%82%92%E3%81%9D%E3%81%97%E3%81%A6%E5%90%9B%E3%81%AB%E8%AA%93%E3%81%84%E3%82%92--%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB-/bp/VS0051080734">
+    <meta property="og:title" content="海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)">
+    <meta property="og:description" content="海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)（汐見夏衛 著／スターツ出版）の中古本の販売価格・在庫状況をチェック。バリューブックスならネットで簡単に古本を購入できます。">
+    <meta property="og:image" content="https://wcdn.valuebooks.jp/ws/np/images/9784813705185.jpg">
+    <meta name="twitter:image:src" content="https://wcdn.valuebooks.jp/ws/np/images/9784813705185.jpg">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@info_ValueBooks">
+    <meta name="msapplication-TileColor" content="transparent">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/android-chrome-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/android-chrome-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/android-chrome-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/android-chrome-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/android-chrome-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/android-chrome-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/android-chrome-152x152.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/android-chrome-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/android-chrome-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/icon-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/icon-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/icon-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/icon-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/icon-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/icon-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/icon-152x152.png">
+<link rel="icon" type="image/png" sizes="160x160" href="/icon-160x160.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/icon-192x192.png">
+<link rel="icon" type="image/png" sizes="196x196" href="/icon-196x196.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/icon-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/icon-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/icon-512x512.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/icon-16x16.png">
+<link rel="icon" type="image/png" sizes="24x24" href="/icon-24x24.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/icon-32x32.png">
+<link rel="manifest" href="/manifest.webmanifest">    <!--  System style-->
+<link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" />        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.3.3/css/swiper.css">
+                                                        <style>
+        .v-application--wrap {
+            min-height: unset !important;
+        }
+        .inner {
+            padding: unset !important;
+            min-width: unset !important;
+        }
+        .contents-header .breadcrumb-list {
+            padding-left: 16px !important;
+        }
+        @media screen and (min-width: 980px) {
+            .contents-header .breadcrumb-list {
+                padding-left: 40px !important;
+            }
+        }
+    </style>
+                                                    <style>
+                                .campaign-banner-item3 .campaign-banner-inner {
+                                    background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-sp.jpg");
+                                    background-size: 100% auto;
+                                    padding-top: 26.666666666%;
+                                    background-repeat: no-repeat;
+                                }
+
+                                .campaign-banner-item3 .campaign-banner-inner p {
+                                    overflow: hidden;
+                                    height: 0;
+                                }
+
+                                @media screen and (min-width: 896px) {
+                                    .campaign-banner.campaign-banner-item3  {
+                                        width: 100%;
+                                        max-width: 700px;
+                                    }
+
+                                    .campaign-banner-item3 .campaign-banner-inner {
+                                        background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-pc.jpg");
+                                        background-size: auto 100%;
+                                        background-position: center;
+                                        width: 100vw;
+                                         padding-top: unset;
+                                        height: 125px;
+                                         background-repeat: no-repeat;
+                                    }
+
+                                                                    .campaign-banner-item3 .campaign-banner-inner p {
+                                        overflow: hidden;
+                                        height: 0;
+                                    }
+                                }
+                            </style>
+                                                                                                <style>
+                                .campaign-banner-item1 .campaign-banner-inner {
+                                    background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-sp.jpg");
+                                    background-size: 100% auto;
+                                    padding-top: 26.666666666%;
+                                    background-repeat: no-repeat;
+                                }
+
+                                .campaign-banner-item1 .campaign-banner-inner p {
+                                    overflow: hidden;
+                                    height: 0;
+                                }
+
+                                @media screen and (min-width: 896px) {
+                                    .campaign-banner.campaign-banner-item1  {
+                                        width: 100%;
+                                        max-width: 700px;
+                                    }
+
+                                    .campaign-banner-item1 .campaign-banner-inner {
+                                        background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-pc.jpg");
+                                        background-size: auto 100%;
+                                        background-position: center;
+                                        width: 100vw;
+                                         padding-top: unset;
+                                        height: 125px;
+                                         background-repeat: no-repeat;
+                                    }
+
+                                                                    .campaign-banner-item1 .campaign-banner-inner p {
+                                        overflow: hidden;
+                                        height: 0;
+                                    }
+                                }
+                            </style>
+                                                <script src="/assets/js/jquery-3.1.1.min.js"></script>
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><script type="module" src="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js"></script>
+<script src="/assets/plugins/moment/moment.js"></script>
+
+<script src="/assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
+<script src="/assets/plugins/jquery-validation/dist/localization/messages_ja.js"></script>
+<script src="/assets/js/vb_jquery.validate.ex.js"></script>
+
+<script src="/assets/plugins/jquery-popup-overlay/jquery.popupoverlay.js"></script>
+<script src="/assets/js/vb/vb_animation.js" defer></script>
+<script src="/assets/plugins/moji/moji.js"></script>
+<script src="/assets/js/vb/header.js"></script>
+<script src="/assets/js/vb/booksearch.js?20230407" defer></script>
+
+<script>
+    $(function() {
+        // Initialize the plugin
+        $('#barcode-start').popup({
+            transition: 'all 0.3s'
+        });
+    });
+</script>
+
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexRouter.BNQuMytO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexStore.WaGYslW_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-footer.DKuqLAdl.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-login.CnxXX-9k.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/library.BvBhUYUN.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/notification-bar.CPzuYivJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-completed.DJqVKBsz.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/gtmOnVue.BGlUh-Jr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-coupon-code.hpFDK_OW.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/register-form.B8aR6ffc.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-breadcrumb.K16OEhRk.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelfScan.CH-rjMK_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js"></script>            <script type="application/ld+json">{"@context":"https://schema.org","@type":"Book","name":"海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)","author":{"@type":"Person","name":"汐見夏衛 著"},"isbn":"9784813705185","publisher":{"@type":"Organization","name":"スターツ出版"},"image":"https://wcdn.valuebooks.jp/ws/np/images/9784813705185.jpg","numberOfPages":313,"inLanguage":"ja","offers":{"@type":"Offer","url":"https://www.valuebooks.jp/%E6%B5%B7%E3%81%AB%E9%A1%98%E3%81%84%E3%82%92%E9%A2%A8%E3%81%AB%E7%A5%88%E3%82%8A%E3%82%92%E3%81%9D%E3%81%97%E3%81%A6%E5%90%9B%E3%81%AB%E8%AA%93%E3%81%84%E3%82%92--%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB-/bp/VS0051080734","priceCurrency":"JPY","price":287,"availability":"https://schema.org/InStock","itemCondition":"https://schema.org/UsedCondition","priceValidUntil":"2026-07-30","seller":{"@type":"Organization","name":"株式会社バリューブックス"}}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"TOP","item":"https://www.valuebooks.jp/"},{"@type":"ListItem","position":2,"name":"海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"株式会社バリューブックス","alternateName":"VALUE BOOKS","url":"https://www.valuebooks.jp","logo":"https://www.valuebooks.jp/assets/images/common/about/valuebooks_title.svg","sameAs":["https://twitter.com/info_ValueBooks"]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"古本買取のバリューブックス","url":"https://www.valuebooks.jp","potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.valuebooks.jp/search?keyword={search_term_string}"},"query-input":"required name=search_term_string"}}</script>
+</head>
+<body>
+
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-ML5K92T"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<input type="hidden" value="" name="bd_code1" id="bd_code1">
+    
+<div id="vb-app-header">
+    <vb-header :number-of-cart-items="0" :number-of-my-page-info="0" />
+</div>
+
+<div id="modal-estimate-searcing-failed" class="modal-content" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close">×</a></p>
+        </div>
+        <div class="modal-body">
+            商品が見つかりませんでした。<br>
+            キーワードを変更して検索し直してください。
+        </div>
+    </div>
+    <div id="modal-estimate-searcing" style="display: none;">
+        <div class="load-spinner"></div>
+    </div>
+
+    
+    
+    
+    <div class="barcode-start-modal modal-content" id="barcode-start" style="display: none;">
+        <a class="barcode-start_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a>
+        <div class="modal-header">
+            <h3 class="title"><em>本棚スキャン</em></h3>
+        </div>
+        <div class="barcode-start-box modal-body">
+            <div id="barcode-start-box-inner">
+                
+                <p class="info">本棚写真をご用意ください</p>
+                <img class="sample-scan-photo" src="/assets/images/common/sample_scan-photo.jpg" alt="本棚写真" />
+                <label for="bookshelf-image-file-input" class="take-picture-button" id="modal-bookshelf-button">
+                    <h3 class="btn">画像を選択する</h3>
+                </label>
+                <p class="smartphone-information">スマホなら本棚を撮影してすぐ査定！</p>
+            </div>
+            <div id="progressFileUploadDiv" style="display: none;">
+                <div id="fileUploadProgress" class="progressbar">
+                    
+                    <ul class="progress-bar-wrap">
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                    </ul>
+                    <div id="progress-bar"></div>
+                </div>
+                <p>本の背表紙をスキャンしています…</p>
+            </div>
+        </div>
+    </div>
+
+    
+    
+    <div id="modal-bookshelf-assessment-upload-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のアップロードに失敗しました。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-searching-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>商品が見つかりませんでした。</p>
+            <p>本棚画像を変更しておためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-image-too-big" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のファイルサイズが大きすぎます。</p>
+            <p>解像度を下げて、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-timeout" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-error" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>もう一度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+<div class="main">
+        <div id="app-information">
+                        <div id="campaign-banner-container" style="min-height: 64px;">
+                                                            <div class="campaign-banner-wrapper"
+                             style="width: 100%; height: fit-content; display: flex;background-color: #fefefe;">
+                            <div class="campaign-banner campaign-banner-item1">
+                                <a class="campaign-banner-inner" href="/sell/offer-with-registration?pattern=anniversary19"
+                                   target="_self">
+                                    <p>ソクフリをお選びいただいた方は、査定金額10％UP！【7/31まで】</p>
+                                </a>
+                            </div>
+                        </div>
+                    
+                                                </div>
+                                                                <div id="campaign-banner-container" style="min-height: 64px;">
+                                                            <div class="campaign-banner-wrapper sell-campaign"
+                             style="width: 100%; height: fit-content; display: flex;background-color: #f8f5ec;">
+                            <div class="campaign-banner campaign-banner-item3">
+                                <a class="campaign-banner-inner" href="https://cloud.msg.value-books.jp/20260719AnniversaryCampaign_zCg7Kz4A"
+                                   target="_blank">
+                                    <p>19周年の感謝を込めて「本から生まれたプレゼントキャンペーン」</p>
+                                </a>
+                            </div>
+                        </div>
+                    
+                                                </div>
+            
+    
+    <notification-bar
+            v-if="true"
+            class="notification-bar-container"></notification-bar>
+</div>
+    <div id="browserCaution">
+    お使いのブラウザでは内容が正しく表示されない場合があります。<br />
+    推奨のブラウザは<a href="/help/spec">こちら</a>をご確認ください。
+</div>
+            <div class="contents-header">
+            <div class="inner">
+                            <div class="breadcrumb-list">
+            <ul>
+                <li><a href="/">TOP</a></li>
+                <li> ></li>
+                <li>海に願いを風に祈りをそして君に誓いを (スターツ出版文庫)</li>
+            </ul>
+        </div>
+                </div>
+        </div>
+            <article class="estimate-pricing">
+        <section class="inner">
+            <div id="ec">
+                                    <router-view
+                            :item-info="{&quot;asinCode&quot;:&quot;4813705189&quot;,&quot;ancillaryText&quot;:[&quot;\u512a\u7b49\u751f\u3067\u3057\u3063\u304b\u308a\u8005\u3060\u3051\u3069\u5929\u306e\u90aa\u9b3c\u306a\u51ea\u6c99\u3068\u3001\u304a\u30d0\u30ab\u3060\u3051\u3069\u7d20\u76f4\u3067\u51ea\u6c99\u306e\u3053\u3068\u304c\u5927\u597d\u304d\u306a\u512a\u6d77\u306f\u3001\u5e7c\u99b4\u67d3\u3067\u604b\u4eba\u540c\u58eb\u3002\u304a\u4e92\u3044\u3092\u7406\u89e3\u3057\u5408\u3044\u3001\u5f37\u3044\u7d46\u3067\u7d50\u3070\u308c\u3066\u3044\u308b\u3075\u305f\u308a\u3060\u3051\u308c\u3069\u3001\u3042\u308b\u65e5\u3092\u5883\u306b\u3001\u51ea\u6c99\u306f\u512a\u6d77\u3078\u306e\u614b\u5ea6\u3092\u4e00\u5909\u3055\u305b\u308b\u3002\u7518\u3048\u3092\u8a31\u3055\u305a\u3001\u53b3\u3057\u304f\u512a\u6d77\u3092\u935b\u3048\u308b\u65e5\u3005\u3002\u305d\u3053\u306b\u306f\u60b2\u3057\u3059\u304e\u308b\u79d8\u5bc6\u304c\u96a0\u3055\u308c\u3066\u3044\u305f\u2015\u2015\u3002\u4e92\u3044\u3092\u60f3\u3046\u5fc3\u306b\u3001\u3042\u305f\u305f\u304b\u3044\u611b\u306b\u3001\u305d\u3057\u3066\u4e88\u60f3\u3082\u3057\u306a\u304b\u3063\u305f\u7d50\u672b\u306b\u3001\u3042\u3075\u308c\u308b\u6d99\u304c\u6b62\u307e\u3089\u306a\u3044!!&quot;],&quot;author&quot;:&quot;\u6c50\u898b\u590f\u885b \u8457&quot;,&quot;authors&quot;:[&quot;\u6c50\u898b\u590f\u885b&quot;],&quot;base_price_in_tax&quot;:803,&quot;bookAge&quot;:&quot;7\u5e74&quot;,&quot;cCodes&quot;:{&quot;c1&quot;:{&quot;code&quot;:&quot;0&quot;,&quot;name&quot;:&quot;\u4e00\u822c&quot;},&quot;c2&quot;:{&quot;code&quot;:&quot;1&quot;,&quot;name&quot;:&quot;\u6587\u5eab&quot;},&quot;c3_4&quot;:{&quot;code&quot;:&quot;93&quot;,&quot;name&quot;:&quot;\u65e5\u672c\u6587\u5b66\u5c0f\u8aac\u30fb\u7269\u8a9e&quot;}},&quot;childItem&quot;:[],&quot;childItemSet&quot;:[],&quot;description&quot;:null,&quot;vbDescription&quot;:null,&quot;estimatePrice&quot;:50,&quot;eventTicket&quot;:[],&quot;format&quot;:&quot;A6\/\u6587\u5eab&quot;,&quot;genreValuebooks&quot;:{&quot;6&quot;:&quot;\u30e9\u30a4\u30c8\u30ce\u30d9\u30eb\u30fbBL&quot;,&quot;5&quot;:&quot;\u6587\u82b8&quot;,&quot;4&quot;:&quot;\u6587\u5eab&quot;},&quot;genpinList&quot;:[{&quot;conditionCode&quot;:&quot;N10&quot;,&quot;conditionName&quot;:&quot;NEW&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true},{&quot;conditionCode&quot;:&quot;U20&quot;,&quot;conditionName&quot;:&quot;VERY_GOOD&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true},{&quot;conditionCode&quot;:&quot;U30&quot;,&quot;conditionName&quot;:&quot;GOOD&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:287,&quot;stock&quot;:1,&quot;genpinId&quot;:&quot;G260702112317&quot;,&quot;isEmpty&quot;:false},{&quot;conditionCode&quot;:&quot;U40&quot;,&quot;conditionName&quot;:&quot;ACCEPTABLE&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true}],&quot;isComicSet&quot;:false,&quot;isOriginal&quot;:false,&quot;isParentItemSet&quot;:false,&quot;image_url&quot;:[&quot;https:\/\/wcdn.valuebooks.jp\/ws\/np\/images\/9784813705185.jpg&quot;],&quot;isbnCode10&quot;:&quot;4813705189&quot;,&quot;isbnCode13&quot;:&quot;9784813705185&quot;,&quot;library_item_id&quot;:null,&quot;min_sell_price&quot;:287,&quot;min_sell_price_acceptable_stock_id&quot;:null,&quot;min_sell_price_condition&quot;:&quot;U30&quot;,&quot;parentItemSet&quot;:[],&quot;pageNumber&quot;:&quot;313&quot;,&quot;publishDate&quot;:&quot;2018-08-26&quot;,&quot;publisher&quot;:&quot;\u30b9\u30bf\u30fc\u30c4\u51fa\u7248&quot;,&quot;recommendUsageCategories&quot;:{&quot;category01&quot;:[{&quot;id&quot;:&quot;465392&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465392&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465392&quot;,&quot;name&quot;:&quot;\u672c&quot;}],&quot;category02&quot;:[{&quot;id&quot;:&quot;465610&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465610&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465610&quot;,&quot;name&quot;:&quot;\u672c&quot;}],&quot;category03&quot;:[{&quot;id&quot;:&quot;2501045051&quot;,&quot;name&quot;:&quot;\u30b3\u30df\u30c3\u30af\u30fb\u30e9\u30ce\u30d9\u30fbBL&quot;},{&quot;id&quot;:&quot;466284&quot;,&quot;name&quot;:&quot;\u6587\u5b66\u30fb\u8a55\u8ad6&quot;},{&quot;id&quot;:&quot;2189048051&quot;,&quot;name&quot;:&quot;\u6587\u5eab&quot;}],&quot;category04&quot;:[{&quot;id&quot;:&quot;2189052051&quot;,&quot;name&quot;:&quot;\u30e9\u30a4\u30c8\u30ce\u30d9\u30eb&quot;},{&quot;id&quot;:&quot;548206&quot;,&quot;name&quot;:&quot;\u6587\u82b8\u4f5c\u54c1&quot;}]},&quot;subtitle&quot;:null,&quot;title&quot;:&quot;\u6d77\u306b\u9858\u3044\u3092\u98a8\u306b\u7948\u308a\u3092\u305d\u3057\u3066\u541b\u306b\u8a93\u3044\u3092 (\u30b9\u30bf\u30fc\u30c4\u51fa\u7248\u6587\u5eab)&quot;,&quot;title_for_url&quot;:&quot;%E6%B5%B7%E3%81%AB%E9%A1%98%E3%81%84%E3%82%92%E9%A2%A8%E3%81%AB%E7%A5%88%E3%82%8A%E3%82%92%E3%81%9D%E3%81%97%E3%81%A6%E5%90%9B%E3%81%AB%E8%AA%93%E3%81%84%E3%82%92--%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%84%E5%87%BA%E7%89%88%E6%96%87%E5%BA%AB-&quot;,&quot;vs_catalog_id&quot;:&quot;VS0051080734&quot;,&quot;briefSummary&quot;:&quot;\u5730\u65b9\u306e\u6e2f\u753a\u306b\u4f4f\u3080\u5e7c\u306a\u3058\u307f\u3067\u604b\u4eba\u540c\u58eb\u306e\u51ea\u6c99\u3068\u512a\u6d77\u3002\u4e8c\u4eba\u306f\u4e92\u3044\u3092\u652f\u3048\u5408\u3044\u306a\u304c\u3089\u751f\u6d3b\u3057\u3066\u3044\u305f\u304c\u3001\u3042\u308b\u65e5\u51ea\u6c99\u306e\u614b\u5ea6\u306b\u5909\u5316\u304c\u3002\u51ea\u6c99\u306f\u904b\u547d\u3092\u53d7\u3051\u5165\u308c\u306a\u304c\u3089\u512a\u6d77\u3078\u306e\u6e29\u304b\u306a\u611b\u3092\u793a\u3059\u5207\u306a\u3044\u604b\u306e\u7269\u8a9e\u3002&quot;,&quot;keywords&quot;:[&quot;\u604b\u611b&quot;,&quot;\u5e7c\u306a\u3058\u307f&quot;,&quot;\u904b\u547d&quot;,&quot;\u611f\u52d5&quot;,&quot;\u7d46&quot;],&quot;karte&quot;:{&quot;ai_generated_info&quot;:{&quot;short_summary&quot;:&quot;\u6d77\u3068\u98a8\u3092\u30c6\u30fc\u30de\u306b\u3057\u305f\u8a93\u3044\u306e\u7269\u8a9e\u3002&quot;,&quot;highlight_points&quot;:[&quot;\u5fc3\u306b\u97ff\u304f\u7269\u8a9e\u3068\u3057\u3066\u65e5\u672c\u6587\u5b66\u30d5\u30a1\u30f3\u306b\u304a\u3059\u3059\u3081&quot;,&quot;\u611f\u60c5\u7684\u306a\u30c6\u30fc\u30de\u304c\u4e2d\u5fc3&quot;,&quot;\u4eba\u6c17\u306e\u30b9\u30bf\u30fc\u30c4\u51fa\u7248\u6587\u5eab\u304b\u3089\u306e\u4e00\u518a&quot;],&quot;review_summary&quot;:&quot;&quot;,&quot;related_books&quot;:[],&quot;purpose_oriented_summary&quot;:&quot;\u300c\u6d77\u306b\u9858\u3044\u3092\u98a8\u306b\u7948\u308a\u3092\u305d\u3057\u3066\u541b\u306b\u8a93\u3044\u3092\u300d\u306f\u3001\u5fc3\u306b\u97ff\u304f\u65e5\u672c\u6587\u5b66\u306e\u7269\u8a9e\u3067\u3001\u4eba\u751f\u306e\u6df1\u3044\u6d1e\u5bdf\u3092\u63d0\u4f9b\u3057\u307e\u3059\u3002\u4e00\u822c\u8aad\u8005\u306b\u6700\u9069\u3067\u3059\u3002&quot;,&quot;estimated_reading_time&quot;:{&quot;max_hour&quot;:9,&quot;min_hour&quot;:6}},&quot;tag_based_info&quot;:{&quot;book_feature&quot;:{&quot;target_levels&quot;:[&quot;\u4e00\u822c\u5411\u3051&quot;],&quot;book_format_types&quot;:[&quot;\u6587\u5eab&quot;],&quot;content_structures&quot;:[&quot;\u30a4\u30e9\u30b9\u30c8\u30fb\u5199\u771f\u306a\u3057&quot;]},&quot;main_keywords&quot;:[&quot;\u65e5\u672c\u6587\u5b66&quot;,&quot;\u6587\u5eab&quot;,&quot;\u7269\u8a9e&quot;],&quot;primary_genre&quot;:&quot;\u6587\u5b66\u30fb\u5c0f\u8aac (Literature &amp; Fiction)&quot;,&quot;age_restriction&quot;:&quot;\u5168\u5e74\u9f62\u5bfe\u8c61&quot;,&quot;writing_style_tags&quot;:[],&quot;sub_genres&quot;:[[{&quot;confidence&quot;:0.9,&quot;genre&quot;:&quot;\u65e5\u672c\u6587\u5b66&quot;}]],&quot;emotion_keywords&quot;:[],&quot;estimated_readers&quot;:[&quot;\u4e00\u822c\u5411\u3051&quot;]}},&quot;isRestocking&quot;:false,&quot;isSalesCountDisplayEnabled&quot;:false,&quot;audioUrl&quot;:&quot;https:\/\/wcdn.valuebooks.jp\/ws\/audio\/vp\/VS0051080734.mp3&quot;,&quot;language&quot;:&quot;jpn&quot;}"
+                            :book-chart="{&quot;brief_summary&quot;:&quot;\u5730\u65b9\u306e\u6e2f\u753a\u306b\u4f4f\u3080\u5e7c\u306a\u3058\u307f\u3067\u604b\u4eba\u540c\u58eb\u306e\u51ea\u6c99\u3068\u512a\u6d77\u3002\u4e8c\u4eba\u306f\u4e92\u3044\u3092\u652f\u3048\u5408\u3044\u306a\u304c\u3089\u751f\u6d3b\u3057\u3066\u3044\u305f\u304c\u3001\u3042\u308b\u65e5\u51ea\u6c99\u306e\u614b\u5ea6\u306b\u5909\u5316\u304c\u3002\u51ea\u6c99\u306f\u904b\u547d\u3092\u53d7\u3051\u5165\u308c\u306a\u304c\u3089\u512a\u6d77\u3078\u306e\u6e29\u304b\u306a\u611b\u3092\u793a\u3059\u5207\u306a\u3044\u604b\u306e\u7269\u8a9e\u3002&quot;,&quot;search_query_prompt&quot;:&quot;\u611f\u52d5\u7684\u306a\u604b\u611b\u5c0f\u8aac\u3092\u8aad\u307f\u305f\u3044\u3067\u3059\u304b\uff1f\u9ad8\u6821\u751f\u306e\u7518\u9178\u3063\u3071\u3044\u604b\u7269\u8a9e\u306b\u8208\u5473\u306f\u3042\u308a\u307e\u3059\u304b\uff1f\u904b\u547d\u3068\u3069\u3046\u5411\u304d\u5408\u3046\u304b\u3092\u63cf\u3044\u305f\u5c0f\u8aac\u3092\u63a2\u3057\u3066\u3044\u307e\u3059\u304b\uff1f&quot;,&quot;related_keywords&quot;:[&quot;\u6e29\u3082\u308a&quot;,&quot;\u79d8\u5bc6&quot;,&quot;\u611b\u60c5&quot;,&quot;\u652f\u3048\u5408\u3044&quot;,&quot;\u5207\u306a\u3055&quot;,&quot;\u6d99&quot;],&quot;target_audience&quot;:&quot;\u6df1\u3044\u611b\u3092\u611f\u3058\u305f\u3044\u4eba\u3001\u611f\u52d5\u7684\u3067\u5207\u306a\u3044\u7269\u8a9e\u304c\u597d\u304d\u306a\u4eba\u3001\u611b\u3068\u7d46\u306b\u3064\u3044\u3066\u8003\u3048\u305f\u3044\u4eba\u306b\u306f\u7279\u306b\u304a\u3059\u3059\u3081\u3067\u3059\u3002&quot;,&quot;keyword04&quot;:{&quot;weight&quot;:7,&quot;keyword&quot;:&quot;\u611f\u52d5&quot;},&quot;keyword03&quot;:{&quot;weight&quot;:6,&quot;keyword&quot;:&quot;\u904b\u547d&quot;},&quot;keyword05&quot;:{&quot;weight&quot;:5,&quot;keyword&quot;:&quot;\u7d46&quot;},&quot;keyword02&quot;:{&quot;weight&quot;:8,&quot;keyword&quot;:&quot;\u5e7c\u306a\u3058\u307f&quot;},&quot;feedback_after_reading&quot;:&quot;\u611f\u52d5,\u6d99,\u5207\u306a\u3055,\u5171\u611f,\u9a5a\u304d&quot;,&quot;keyword01&quot;:{&quot;weight&quot;:10,&quot;keyword&quot;:&quot;\u604b\u611b&quot;},&quot;format_choice&quot;:[&quot;\u5c0f\u8aac&quot;],&quot;target_age&quot;:&quot;18\u6b73\u4ee5\u4e0a&quot;,&quot;review&quot;:&quot;\u5f15\u304d\u8fbc\u3080\u60c5\u666f\u63cf\u5199\u3068\u611f\u60c5\u79fb\u5165\u306e\u3057\u3084\u3059\u3044\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u3067\u3001\u591a\u304f\u306e\u8aad\u8005\u306e\u5fc3\u3092\u63b4\u3093\u3067\u3044\u308b\u3002\u4f5c\u54c1\u306e\u4f0f\u7dda\u304c\u7d42\u76e4\u3067\u660e\u3089\u304b\u306b\u306a\u308a\u3001\u885d\u6483\u306e\u7d50\u672b\u306b\u591a\u304f\u306e\u8aad\u8005\u304c\u6d99\u3057\u3066\u8a55\u4fa1\u3057\u3066\u3044\u308b\u3002\u6c50\u898b\u590f\u885b\u306e\u4f5c\u54c1\u3068\u3057\u3066\u3001\u6620\u50cf\u304c\u7f8e\u3057\u304f\u30ad\u30e9\u30ad\u30e9\u3068\u3057\u3066\u3044\u308b\u3068\u306e\u58f0\u3082\u3042\u308b\u3002&quot;,&quot;genre&quot;:[&quot;\u6587\u5b66&quot;],&quot;detail_genre&quot;:[&quot;\u604b\u611b\u5c0f\u8aac&quot;,&quot;\u9752\u6625\u5c0f\u8aac&quot;],&quot;search_words&quot;:[&quot;\u5207\u306a\u3044\u7269\u8a9e&quot;,&quot;\u9752\u6625\u6587\u5b66&quot;,&quot;\u604b\u611b\u5c0f\u8aac&quot;],&quot;keywords&quot;:[&quot;\u604b\u611b&quot;,&quot;\u5e7c\u306a\u3058\u307f&quot;,&quot;\u904b\u547d&quot;,&quot;\u611f\u52d5&quot;,&quot;\u7d46&quot;]}"
+                    ></router-view>
+                            </div>
+
+            <div id="vb-app" v-cloak>
+                
+                <validation-observer v-slot="propsSlot">
+                    <library-folder v-slot="localState"
+                                              :getloginstatus="false"
+                                              :getinvalid="propsSlot.invalid" ref="folderContainer">
+                        <div>
+                            <vb-modal :state="localState">
+                                <div v-if="localState.loginStatus" id="add-library-modal-inner">
+                                    <component :is="localState.component"
+                                               action-message="追加するフォルダを選択してください"
+                                               action-button-label="追加">
+                                    </component>
+                                </div>
+                                <modal-login v-else></modal-login>
+                            </vb-modal>
+                            <vb-toast v-if="localState.toastActive" @hidden="$refs.folderContainer.closeToast()">{{ localState.successed }}</vb-toast>
+                        </div>
+                    </library-folder>
+                </validation-observer>
+            </div>
+            <div style="visibility: hidden">
+                <div name="library-data"
+                     data-folder-share-disable=""
+                     data-nickname=''
+                     data-full-name=''
+                ></div>
+            </div>
+        </section>
+    </article>
+    <div id="book_selection" data-is-original="false">
+        <vb-book-selection-button></vb-book-selection-button>
+    </div>
+</div>
+
+<div id="vb-app-footer" style="margin-top: auto">
+    <vb-footer previous-page-url="" />
+</div>
+
+<style>
+    #vb-app .v-application--wrap {
+        min-height: fit-content;
+    }
+    select, textarea {
+        border: 1px solid #ccc;
+    }
+    .theme--light.v-btn:hover::before,
+    .v-tab:hover::before
+    {
+        opacity: 0.08 !important;
+        color: #2c2c2c !important;
+    }
+
+    .v-btn--text:before
+    {
+        left: -4px !important;
+        right: -4px !important;
+        border-radius: 4px !important;
+    }
+    .v-tab:before
+    {
+        border-radius: 4px !important;
+    }
+</style>
+    <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vue_app.BYr0Bs5V.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecStore.KrjOXUqq.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecRouter.CQIXDxxp.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ISBNUtils.CC0coUgF.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-search-navbar.DklBcU9C.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio.K5xQfZog.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/openAi.hE1M9Ibm.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item-image-set.pdDVR3DG.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/error-message.DESX--YO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-bubble.C2cN5ahd.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-items-display.Dlpne48Q.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-header.q76rHVQ1.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-price.DSv7JUk3.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app.CfaCJozo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-login.CnxXX-9k.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vue_app.BYr0Bs5V.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js"></script><script type="module" src="https://www.valuebooks.jp/build/js/vue_app.CfaCJozo.js"></script><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js"></script>        <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_banner.BOK4r4oK.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/notification-bar.CPzuYivJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_banner.BOK4r4oK.js"></script>
+</body>
+</html>

--- a/tests/fixtures/used_book/valuebooks_product_oos.html
+++ b/tests/fixtures/used_book/valuebooks_product_oos.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8" />
+<meta http-equiv="content-language" content="ja" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport" />
+<meta name="format-detection" content="telephone=no, email=no, address=no" />
+<meta name="facebook-domain-verification" content="aowy7ydmb33fq6pi45xhx6ibomlggu" />
+<meta name="csrf-token" content="eEy9w21Zu7VIosDLrsYorsaaVCUkaAEJmAUEnxWR">
+        <link rel="canonical" id="canonical-link"
+          href="https://www.valuebooks.jp/%E7%8B%90%E3%81%A8%E4%B9%99%E5%A5%B3%E3%81%AE%E5%A4%A7%E6%AD%A3%E6%81%8B%E6%97%A5%E8%A8%98-%E8%B2%B4%E6%96%B9%E3%80%81%E6%AD%8C%E5%8A%87%E5%A0%B4%E3%81%AB%E6%86%91%E3%81%84%E3%81%A6%E3%81%BE%E3%81%99%EF%BC%9F--%E8%A7%92%E5%B7%9D%E3%83%93%EF%BC%8D.../bp/VS0040563019">
+<link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                                        <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                    <!-- declare GTM Data Layer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+dataLayer.push({
+    'user_id': '',
+    'page_id' : (new URL(window.location.href)).pathname, 
+});
+</script>
+<!-- End Data Layer declaring-->
+
+<!-- Google Tag Manager -->
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-ML5K92T');
+
+</script>
+<!-- End Google Tag Manager -->
+
+    <!-- Google Analytics - define gtag function -->
+    <script>
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-FSVYFJV0EY',{ 'send_page_view': false });
+    </script>
+    <!-- End Google Analytics -->
+
+    <!-- Salesforce Personalization Synchronous Integration -->
+    <script type="text/javascript" src="//cdn.evgnet.com/beacon/valuebookskk/engage/scripts/evergage.min.js"></script>
+    <title>狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－... | 検索 | 古本買取のバリューブックス</title>
+    <meta name="description" content="狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－ンズ文庫)（月本ナシオ 〔著〕／角川書店）の中古本の販売価格・在庫状況をチェック。バリューブックスならネットで簡単に古本を購入できます。">
+            <meta name="csrf-token" content="eEy9w21Zu7VIosDLrsYorsaaVCUkaAEJmAUEnxWR">
+    <!--OGP-->
+
+
+<meta property="og:type"   content="website">
+<meta property="fb:app_id" content="2374624702866002">
+
+      <meta property="og:url" content="https://www.valuebooks.jp/%E7%8B%90%E3%81%A8%E4%B9%99%E5%A5%B3%E3%81%AE%E5%A4%A7%E6%AD%A3%E6%81%8B%E6%97%A5%E8%A8%98-%E8%B2%B4%E6%96%B9%E3%80%81%E6%AD%8C%E5%8A%87%E5%A0%B4%E3%81%AB%E6%86%91%E3%81%84%E3%81%A6%E3%81%BE%E3%81%99%EF%BC%9F--%E8%A7%92%E5%B7%9D%E3%83%93%EF%BC%8D.../bp/VS0040563019">
+    <meta property="og:title" content="狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－...">
+    <meta property="og:description" content="狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－ンズ文庫)（月本ナシオ 〔著〕／角川書店）の中古本の販売価格・在庫状況をチェック。バリューブックスならネットで簡単に古本を購入できます。">
+    <meta property="og:image" content="https://wcdn.valuebooks.jp/ws/np/images/9784041004098.jpg">
+    <meta name="twitter:image:src" content="https://wcdn.valuebooks.jp/ws/np/images/9784041004098.jpg">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@info_ValueBooks">
+    <meta name="msapplication-TileColor" content="transparent">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/android-chrome-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/android-chrome-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/android-chrome-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/android-chrome-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/android-chrome-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/android-chrome-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/android-chrome-152x152.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/android-chrome-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/android-chrome-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/icon-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/icon-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/icon-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/icon-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/icon-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/icon-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/icon-152x152.png">
+<link rel="icon" type="image/png" sizes="160x160" href="/icon-160x160.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/icon-192x192.png">
+<link rel="icon" type="image/png" sizes="196x196" href="/icon-196x196.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/icon-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/icon-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/icon-512x512.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/icon-16x16.png">
+<link rel="icon" type="image/png" sizes="24x24" href="/icon-24x24.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/icon-32x32.png">
+<link rel="manifest" href="/manifest.webmanifest">    <!--  System style-->
+<link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" />        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.3.3/css/swiper.css">
+                                                        <style>
+        .v-application--wrap {
+            min-height: unset !important;
+        }
+        .inner {
+            padding: unset !important;
+            min-width: unset !important;
+        }
+        .contents-header .breadcrumb-list {
+            padding-left: 16px !important;
+        }
+        @media screen and (min-width: 980px) {
+            .contents-header .breadcrumb-list {
+                padding-left: 40px !important;
+            }
+        }
+    </style>
+                                                    <style>
+                                .campaign-banner-item3 .campaign-banner-inner {
+                                    background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-sp.jpg");
+                                    background-size: 100% auto;
+                                    padding-top: 26.666666666%;
+                                    background-repeat: no-repeat;
+                                }
+
+                                .campaign-banner-item3 .campaign-banner-inner p {
+                                    overflow: hidden;
+                                    height: 0;
+                                }
+
+                                @media screen and (min-width: 896px) {
+                                    .campaign-banner.campaign-banner-item3  {
+                                        width: 100%;
+                                        max-width: 700px;
+                                    }
+
+                                    .campaign-banner-item3 .campaign-banner-inner {
+                                        background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-pc.jpg");
+                                        background-size: auto 100%;
+                                        background-position: center;
+                                        width: 100vw;
+                                         padding-top: unset;
+                                        height: 125px;
+                                         background-repeat: no-repeat;
+                                    }
+
+                                                                    .campaign-banner-item3 .campaign-banner-inner p {
+                                        overflow: hidden;
+                                        height: 0;
+                                    }
+                                }
+                            </style>
+                                                                                                <style>
+                                .campaign-banner-item1 .campaign-banner-inner {
+                                    background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-sp.jpg");
+                                    background-size: 100% auto;
+                                    padding-top: 26.666666666%;
+                                    background-repeat: no-repeat;
+                                }
+
+                                .campaign-banner-item1 .campaign-banner-inner p {
+                                    overflow: hidden;
+                                    height: 0;
+                                }
+
+                                @media screen and (min-width: 896px) {
+                                    .campaign-banner.campaign-banner-item1  {
+                                        width: 100%;
+                                        max-width: 700px;
+                                    }
+
+                                    .campaign-banner-item1 .campaign-banner-inner {
+                                        background-image: url("https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-pc.jpg");
+                                        background-size: auto 100%;
+                                        background-position: center;
+                                        width: 100vw;
+                                         padding-top: unset;
+                                        height: 125px;
+                                         background-repeat: no-repeat;
+                                    }
+
+                                                                    .campaign-banner-item1 .campaign-banner-inner p {
+                                        overflow: hidden;
+                                        height: 0;
+                                    }
+                                }
+                            </style>
+                                                <script src="/assets/js/jquery-3.1.1.min.js"></script>
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><script type="module" src="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js"></script>
+<script src="/assets/plugins/moment/moment.js"></script>
+
+<script src="/assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
+<script src="/assets/plugins/jquery-validation/dist/localization/messages_ja.js"></script>
+<script src="/assets/js/vb_jquery.validate.ex.js"></script>
+
+<script src="/assets/plugins/jquery-popup-overlay/jquery.popupoverlay.js"></script>
+<script src="/assets/js/vb/vb_animation.js" defer></script>
+<script src="/assets/plugins/moji/moji.js"></script>
+<script src="/assets/js/vb/header.js"></script>
+<script src="/assets/js/vb/booksearch.js?20230407" defer></script>
+
+<script>
+    $(function() {
+        // Initialize the plugin
+        $('#barcode-start').popup({
+            transition: 'all 0.3s'
+        });
+    });
+</script>
+
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexRouter.BNQuMytO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexStore.WaGYslW_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-footer.DKuqLAdl.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-login.CnxXX-9k.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/library.BvBhUYUN.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/notification-bar.CPzuYivJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-completed.DJqVKBsz.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/gtmOnVue.BGlUh-Jr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-coupon-code.hpFDK_OW.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/register-form.B8aR6ffc.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-breadcrumb.K16OEhRk.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelfScan.CH-rjMK_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js"></script>            <script type="application/ld+json">{"@context":"https://schema.org","@type":"Book","name":"狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－ンズ文庫)","author":{"@type":"Person","name":"月本ナシオ 〔著〕"},"isbn":"9784041004098","publisher":{"@type":"Organization","name":"角川書店"},"image":"https://wcdn.valuebooks.jp/ws/np/images/9784041004098.jpg","numberOfPages":219,"inLanguage":"ja"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"TOP","item":"https://www.valuebooks.jp/"},{"@type":"ListItem","position":2,"name":"狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－..."}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"株式会社バリューブックス","alternateName":"VALUE BOOKS","url":"https://www.valuebooks.jp","logo":"https://www.valuebooks.jp/assets/images/common/about/valuebooks_title.svg","sameAs":["https://twitter.com/info_ValueBooks"]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"古本買取のバリューブックス","url":"https://www.valuebooks.jp","potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.valuebooks.jp/search?keyword={search_term_string}"},"query-input":"required name=search_term_string"}}</script>
+</head>
+<body>
+
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-ML5K92T"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<input type="hidden" value="" name="bd_code1" id="bd_code1">
+    
+<div id="vb-app-header">
+    <vb-header :number-of-cart-items="0" :number-of-my-page-info="0" />
+</div>
+
+<div id="modal-estimate-searcing-failed" class="modal-content" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close">×</a></p>
+        </div>
+        <div class="modal-body">
+            商品が見つかりませんでした。<br>
+            キーワードを変更して検索し直してください。
+        </div>
+    </div>
+    <div id="modal-estimate-searcing" style="display: none;">
+        <div class="load-spinner"></div>
+    </div>
+
+    
+    
+    
+    <div class="barcode-start-modal modal-content" id="barcode-start" style="display: none;">
+        <a class="barcode-start_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a>
+        <div class="modal-header">
+            <h3 class="title"><em>本棚スキャン</em></h3>
+        </div>
+        <div class="barcode-start-box modal-body">
+            <div id="barcode-start-box-inner">
+                
+                <p class="info">本棚写真をご用意ください</p>
+                <img class="sample-scan-photo" src="/assets/images/common/sample_scan-photo.jpg" alt="本棚写真" />
+                <label for="bookshelf-image-file-input" class="take-picture-button" id="modal-bookshelf-button">
+                    <h3 class="btn">画像を選択する</h3>
+                </label>
+                <p class="smartphone-information">スマホなら本棚を撮影してすぐ査定！</p>
+            </div>
+            <div id="progressFileUploadDiv" style="display: none;">
+                <div id="fileUploadProgress" class="progressbar">
+                    
+                    <ul class="progress-bar-wrap">
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                    </ul>
+                    <div id="progress-bar"></div>
+                </div>
+                <p>本の背表紙をスキャンしています…</p>
+            </div>
+        </div>
+    </div>
+
+    
+    
+    <div id="modal-bookshelf-assessment-upload-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のアップロードに失敗しました。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-searching-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>商品が見つかりませんでした。</p>
+            <p>本棚画像を変更しておためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-image-too-big" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のファイルサイズが大きすぎます。</p>
+            <p>解像度を下げて、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-timeout" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-error" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>もう一度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+<div class="main">
+        <div id="app-information">
+                        <div id="campaign-banner-container" style="min-height: 64px;">
+                                                            <div class="campaign-banner-wrapper"
+                             style="width: 100%; height: fit-content; display: flex;background-color: #fefefe;">
+                            <div class="campaign-banner campaign-banner-item1">
+                                <a class="campaign-banner-inner" href="/sell/offer-with-registration?pattern=anniversary19"
+                                   target="_self">
+                                    <p>ソクフリをお選びいただいた方は、査定金額10％UP！【7/31まで】</p>
+                                </a>
+                            </div>
+                        </div>
+                    
+                                                </div>
+                                                                <div id="campaign-banner-container" style="min-height: 64px;">
+                                                            <div class="campaign-banner-wrapper sell-campaign"
+                             style="width: 100%; height: fit-content; display: flex;background-color: #f8f5ec;">
+                            <div class="campaign-banner campaign-banner-item3">
+                                <a class="campaign-banner-inner" href="https://cloud.msg.value-books.jp/20260719AnniversaryCampaign_zCg7Kz4A"
+                                   target="_blank">
+                                    <p>19周年の感謝を込めて「本から生まれたプレゼントキャンペーン」</p>
+                                </a>
+                            </div>
+                        </div>
+                    
+                                                </div>
+            
+    
+    <notification-bar
+            v-if="true"
+            class="notification-bar-container"></notification-bar>
+</div>
+    <div id="browserCaution">
+    お使いのブラウザでは内容が正しく表示されない場合があります。<br />
+    推奨のブラウザは<a href="/help/spec">こちら</a>をご確認ください。
+</div>
+            <div class="contents-header">
+            <div class="inner">
+                            <div class="breadcrumb-list">
+            <ul>
+                <li><a href="/">TOP</a></li>
+                <li> ></li>
+                <li>狐と乙女の大正恋日記 貴方、歌劇場に憑いてます？ (角川ビ－...</li>
+            </ul>
+        </div>
+                </div>
+        </div>
+            <article class="estimate-pricing">
+        <section class="inner">
+            <div id="ec">
+                                    <router-view
+                            :item-info="{&quot;asinCode&quot;:&quot;4041004098&quot;,&quot;ancillaryText&quot;:[],&quot;author&quot;:&quot;\u6708\u672c\u30ca\u30b7\u30aa \u3014\u8457\u3015&quot;,&quot;authors&quot;:[&quot;\u6708\u672c\u30ca\u30b7\u30aa&quot;],&quot;base_price_in_tax&quot;:545,&quot;bookAge&quot;:&quot;13\u5e74&quot;,&quot;cCodes&quot;:{&quot;c1&quot;:{&quot;code&quot;:&quot;0&quot;,&quot;name&quot;:&quot;\u4e00\u822c&quot;},&quot;c2&quot;:{&quot;code&quot;:&quot;1&quot;,&quot;name&quot;:&quot;\u6587\u5eab&quot;},&quot;c3_4&quot;:{&quot;code&quot;:&quot;93&quot;,&quot;name&quot;:&quot;\u65e5\u672c\u6587\u5b66\u5c0f\u8aac\u30fb\u7269\u8a9e&quot;}},&quot;childItem&quot;:[],&quot;childItemSet&quot;:[],&quot;description&quot;:null,&quot;vbDescription&quot;:null,&quot;estimatePrice&quot;:0,&quot;eventTicket&quot;:[],&quot;format&quot;:&quot;A6\/\u6587\u5eab&quot;,&quot;genreValuebooks&quot;:{&quot;6&quot;:&quot;\u30e9\u30a4\u30c8\u30ce\u30d9\u30eb\u30fbBL&quot;,&quot;4&quot;:&quot;\u6587\u5eab&quot;},&quot;genpinList&quot;:[{&quot;conditionCode&quot;:&quot;N10&quot;,&quot;conditionName&quot;:&quot;NEW&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true},{&quot;conditionCode&quot;:&quot;U20&quot;,&quot;conditionName&quot;:&quot;VERY_GOOD&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true},{&quot;conditionCode&quot;:&quot;U30&quot;,&quot;conditionName&quot;:&quot;GOOD&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true},{&quot;conditionCode&quot;:&quot;U40&quot;,&quot;conditionName&quot;:&quot;ACCEPTABLE&quot;,&quot;conditionMemo&quot;:&quot;&quot;,&quot;price&quot;:null,&quot;stock&quot;:0,&quot;isEmpty&quot;:true}],&quot;isComicSet&quot;:false,&quot;isOriginal&quot;:false,&quot;isParentItemSet&quot;:false,&quot;image_url&quot;:[&quot;https:\/\/wcdn.valuebooks.jp\/ws\/np\/images\/9784041004098.jpg&quot;],&quot;isbnCode10&quot;:&quot;4041004098&quot;,&quot;isbnCode13&quot;:&quot;9784041004098&quot;,&quot;library_item_id&quot;:null,&quot;min_sell_price&quot;:null,&quot;min_sell_price_acceptable_stock_id&quot;:null,&quot;min_sell_price_condition&quot;:null,&quot;parentItemSet&quot;:[],&quot;pageNumber&quot;:&quot;219&quot;,&quot;publishDate&quot;:&quot;2012-08-01&quot;,&quot;publisher&quot;:&quot;\u89d2\u5ddd\u66f8\u5e97&quot;,&quot;recommendUsageCategories&quot;:{&quot;category01&quot;:[{&quot;id&quot;:&quot;465392&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465392&quot;,&quot;name&quot;:&quot;\u672c&quot;}],&quot;category02&quot;:[{&quot;id&quot;:&quot;465610&quot;,&quot;name&quot;:&quot;\u672c&quot;},{&quot;id&quot;:&quot;465610&quot;,&quot;name&quot;:&quot;\u672c&quot;}],&quot;category03&quot;:[{&quot;id&quot;:&quot;2501045051&quot;,&quot;name&quot;:&quot;\u30b3\u30df\u30c3\u30af\u30fb\u30e9\u30ce\u30d9\u30fbBL&quot;},{&quot;id&quot;:&quot;2189048051&quot;,&quot;name&quot;:&quot;\u6587\u5eab&quot;}],&quot;category04&quot;:[{&quot;id&quot;:&quot;2189052051&quot;,&quot;name&quot;:&quot;\u30e9\u30a4\u30c8\u30ce\u30d9\u30eb&quot;}],&quot;category05&quot;:[{&quot;id&quot;:&quot;2189056051&quot;,&quot;name&quot;:&quot;\u5973\u6027\u5411\u3051&quot;}],&quot;category06&quot;:[{&quot;id&quot;:&quot;2219996051&quot;,&quot;name&quot;:&quot;\u89d2\u5ddd\u30d3\u30fc\u30f3\u30ba\u6587\u5eab&quot;}]},&quot;subtitle&quot;:null,&quot;title&quot;:&quot;\u72d0\u3068\u4e59\u5973\u306e\u5927\u6b63\u604b\u65e5\u8a18 \u8cb4\u65b9\u3001\u6b4c\u5287\u5834\u306b\u6191\u3044\u3066\u307e\u3059\uff1f (\u89d2\u5ddd\u30d3\uff0d\u30f3\u30ba\u6587\u5eab)&quot;,&quot;title_for_url&quot;:&quot;%E7%8B%90%E3%81%A8%E4%B9%99%E5%A5%B3%E3%81%AE%E5%A4%A7%E6%AD%A3%E6%81%8B%E6%97%A5%E8%A8%98-%E8%B2%B4%E6%96%B9%E3%80%81%E6%AD%8C%E5%8A%87%E5%A0%B4%E3%81%AB%E6%86%91%E3%81%84%E3%81%A6%E3%81%BE%E3%81%99%EF%BC%9F--%E8%A7%92%E5%B7%9D%E3%83%93%EF%BC%8D...&quot;,&quot;vs_catalog_id&quot;:&quot;VS0040563019&quot;,&quot;briefSummary&quot;:null,&quot;keywords&quot;:[],&quot;karte&quot;:null,&quot;isRestocking&quot;:false,&quot;isSalesCountDisplayEnabled&quot;:false,&quot;audioUrl&quot;:null,&quot;language&quot;:&quot;jpn&quot;}"
+                            :book-chart="null"
+                    ></router-view>
+                            </div>
+
+            <div id="vb-app" v-cloak>
+                
+                <validation-observer v-slot="propsSlot">
+                    <library-folder v-slot="localState"
+                                              :getloginstatus="false"
+                                              :getinvalid="propsSlot.invalid" ref="folderContainer">
+                        <div>
+                            <vb-modal :state="localState">
+                                <div v-if="localState.loginStatus" id="add-library-modal-inner">
+                                    <component :is="localState.component"
+                                               action-message="追加するフォルダを選択してください"
+                                               action-button-label="追加">
+                                    </component>
+                                </div>
+                                <modal-login v-else></modal-login>
+                            </vb-modal>
+                            <vb-toast v-if="localState.toastActive" @hidden="$refs.folderContainer.closeToast()">{{ localState.successed }}</vb-toast>
+                        </div>
+                    </library-folder>
+                </validation-observer>
+            </div>
+            <div style="visibility: hidden">
+                <div name="library-data"
+                     data-folder-share-disable=""
+                     data-nickname=''
+                     data-full-name=''
+                ></div>
+            </div>
+        </section>
+    </article>
+    <div id="book_selection" data-is-original="false">
+        <vb-book-selection-button></vb-book-selection-button>
+    </div>
+</div>
+
+<div id="vb-app-footer" style="margin-top: auto">
+    <vb-footer previous-page-url="" />
+</div>
+
+<style>
+    #vb-app .v-application--wrap {
+        min-height: fit-content;
+    }
+    select, textarea {
+        border: 1px solid #ccc;
+    }
+    .theme--light.v-btn:hover::before,
+    .v-tab:hover::before
+    {
+        opacity: 0.08 !important;
+        color: #2c2c2c !important;
+    }
+
+    .v-btn--text:before
+    {
+        left: -4px !important;
+        right: -4px !important;
+        border-radius: 4px !important;
+    }
+    .v-tab:before
+    {
+        border-radius: 4px !important;
+    }
+</style>
+    <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vue_app.BYr0Bs5V.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecStore.KrjOXUqq.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecRouter.CQIXDxxp.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ISBNUtils.CC0coUgF.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-search-navbar.DklBcU9C.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio.K5xQfZog.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/openAi.hE1M9Ibm.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item-image-set.pdDVR3DG.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/error-message.DESX--YO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-bubble.C2cN5ahd.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-items-display.Dlpne48Q.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-header.q76rHVQ1.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-price.DSv7JUk3.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app.CfaCJozo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-login.CnxXX-9k.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vue_app.BYr0Bs5V.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js"></script><script type="module" src="https://www.valuebooks.jp/build/js/vue_app.CfaCJozo.js"></script><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js"></script>        <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_banner.BOK4r4oK.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/notification-bar.CPzuYivJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_banner.BOK4r4oK.js"></script>
+</body>
+</html>

--- a/tests/fixtures/used_book/valuebooks_search_empty.html
+++ b/tests/fixtures/used_book/valuebooks_search_empty.html
@@ -1,0 +1,297 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8" />
+<meta http-equiv="content-language" content="ja" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport" />
+<meta name="format-detection" content="telephone=no, email=no, address=no" />
+<meta name="facebook-domain-verification" content="aowy7ydmb33fq6pi45xhx6ibomlggu" />
+<meta name="csrf-token" content="7YZjC9SUXk902jb5hEYttb5gjjjYYbY4ZZFGNNeW">
+        <link rel="canonical"
+          href="https://www.valuebooks.jp/search?keyword=9784000000000&amp;kana_word=%5B%5D&amp;other_readings=%5B%5D">
+<link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                                        <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-sp.jpg" as="image" type="image/png" media="(max-width: 895px)">
+            <link rel="preload" href="https://wcdn.valuebooks.jp/ws/site/assets/images/campaign/campaign-sell-2607-pc.jpg" as="image" type="image/png" media="(min-width:896px)">
+                <!-- declare GTM Data Layer -->
+<script>
+window.dataLayer = window.dataLayer || [];
+dataLayer.push({
+    'user_id': '',
+    'page_id' : (new URL(window.location.href)).pathname, 
+});
+</script>
+<!-- End Data Layer declaring-->
+
+<!-- Google Tag Manager -->
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-ML5K92T');
+
+</script>
+<!-- End Google Tag Manager -->
+
+    <!-- Google Analytics - define gtag function -->
+    <script>
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-FSVYFJV0EY',{ 'send_page_view': false });
+    </script>
+    <!-- End Google Analytics -->
+
+    <!-- Salesforce Personalization Synchronous Integration -->
+    <script type="text/javascript" src="//cdn.evgnet.com/beacon/valuebookskk/engage/scripts/evergage.min.js"></script>
+    <title>検索 | 古本買取のバリューブックス</title>
+    <meta name="description" content="ご自宅まで集荷に伺うので、本は詰めておくだけ。キャンセルも手軽にできるので、安心してご利用ください。">
+            <!--OGP-->
+
+
+<meta property="og:type"   content="website">
+<meta property="fb:app_id" content="2374624702866002">
+
+  <meta property="og:url"    content="https://www.valuebooks.jp/">
+  <meta property="og:title"  content="古本買取のVALUE BOOKS">
+  <meta property="og:description"  content="ご自宅まで集荷に伺うので、本は詰めておくだけ。キャンセルも手軽にできるので、安心してご利用ください。">
+  <meta property="og:image" content="https://www.valuebooks.jp/assets/images/ogp/valuebooks.jpg">
+  <meta name="twitter:image:src" content="https://www.valuebooks.jp/assets/images/ogp/valuebooks.jpg">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@info_ValueBooks">
+    <meta name="msapplication-TileColor" content="transparent">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/android-chrome-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/android-chrome-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/android-chrome-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/android-chrome-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/android-chrome-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/android-chrome-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/android-chrome-152x152.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/android-chrome-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/android-chrome-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+<link rel="icon" type="image/png" sizes="36x36" href="/icon-36x36.png">
+<link rel="icon" type="image/png" sizes="48x48" href="/icon-48x48.png">
+<link rel="icon" type="image/png" sizes="72x72" href="/icon-72x72.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/icon-96x96.png">
+<link rel="icon" type="image/png" sizes="128x128" href="/icon-128x128.png">
+<link rel="icon" type="image/png" sizes="144x144" href="/icon-144x144.png">
+<link rel="icon" type="image/png" sizes="152x152" href="/icon-152x152.png">
+<link rel="icon" type="image/png" sizes="160x160" href="/icon-160x160.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/icon-192x192.png">
+<link rel="icon" type="image/png" sizes="196x196" href="/icon-196x196.png">
+<link rel="icon" type="image/png" sizes="256x256" href="/icon-256x256.png">
+<link rel="icon" type="image/png" sizes="384x384" href="/icon-384x384.png">
+<link rel="icon" type="image/png" sizes="512x512" href="/icon-512x512.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/icon-16x16.png">
+<link rel="icon" type="image/png" sizes="24x24" href="/icon-24x24.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/icon-32x32.png">
+<link rel="manifest" href="/manifest.webmanifest">    <!--  System style-->
+<link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/style.C5-zW9PS.css" />            <script src="/assets/js/jquery-3.1.1.min.js"></script>
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><script type="module" src="https://www.valuebooks.jp/build/js/bookshelf_assessment.L9UnoMSH.js"></script>
+<script src="/assets/plugins/moment/moment.js"></script>
+
+<script src="/assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
+<script src="/assets/plugins/jquery-validation/dist/localization/messages_ja.js"></script>
+<script src="/assets/js/vb_jquery.validate.ex.js"></script>
+
+<script src="/assets/plugins/jquery-popup-overlay/jquery.popupoverlay.js"></script>
+<script src="/assets/js/vb/vb_animation.js" defer></script>
+<script src="/assets/plugins/moji/moji.js"></script>
+<script src="/assets/js/vb/header.js"></script>
+<script src="/assets/js/vb/booksearch.js?20230407" defer></script>
+
+<script>
+    $(function() {
+        // Initialize the plugin
+        $('#barcode-start').popup({
+            transition: 'all 0.3s'
+        });
+    });
+</script>
+
+
+ <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexRouter.BNQuMytO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/indexStore.WaGYslW_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-footer.DKuqLAdl.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-login.CnxXX-9k.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/library.BvBhUYUN.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/notification-bar.CPzuYivJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-completed.DJqVKBsz.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/gtmOnVue.BGlUh-Jr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-coupon-code.hpFDK_OW.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/register-form.B8aR6ffc.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-breadcrumb.K16OEhRk.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/bookshelfScan.CH-rjMK_.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/amplify-vendor.qxgBYarL.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/subscriptions.BfjPphzJ.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/browser-image-compression.Z8FcVmq7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/indexRouter.B5sbJGlz.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-footer.q5JSSNff.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-login.C9yBQ4cE.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/library.C6XwxoBo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/notification-bar.C-ghQvKP.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-completed.CpvdCqiu.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/gtmOnVue.BWgIWOKa.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-coupon-code.C9TKm-M3.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/register-form.DlTvdMq5.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-breadcrumb.CHT_Z0Ih.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_index.C-vC8D45.js"></script></head>
+<body>
+<div id="search-main">
+    <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-ML5K92T"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+    <input type="hidden" value="" name="bd_code1" id="bd_code1">
+    
+<div id="vb-app-header">
+    <vb-header :number-of-cart-items="0" :number-of-my-page-info="0" />
+</div>
+
+<div id="modal-estimate-searcing-failed" class="modal-content" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close">×</a></p>
+        </div>
+        <div class="modal-body">
+            商品が見つかりませんでした。<br>
+            キーワードを変更して検索し直してください。
+        </div>
+    </div>
+    <div id="modal-estimate-searcing" style="display: none;">
+        <div class="load-spinner"></div>
+    </div>
+
+    
+    
+    
+    <div class="barcode-start-modal modal-content" id="barcode-start" style="display: none;">
+        <a class="barcode-start_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a>
+        <div class="modal-header">
+            <h3 class="title"><em>本棚スキャン</em></h3>
+        </div>
+        <div class="barcode-start-box modal-body">
+            <div id="barcode-start-box-inner">
+                
+                <p class="info">本棚写真をご用意ください</p>
+                <img class="sample-scan-photo" src="/assets/images/common/sample_scan-photo.jpg" alt="本棚写真" />
+                <label for="bookshelf-image-file-input" class="take-picture-button" id="modal-bookshelf-button">
+                    <h3 class="btn">画像を選択する</h3>
+                </label>
+                <p class="smartphone-information">スマホなら本棚を撮影してすぐ査定！</p>
+            </div>
+            <div id="progressFileUploadDiv" style="display: none;">
+                <div id="fileUploadProgress" class="progressbar">
+                    
+                    <ul class="progress-bar-wrap">
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                        <li></li>
+                    </ul>
+                    <div id="progress-bar"></div>
+                </div>
+                <p>本の背表紙をスキャンしています…</p>
+            </div>
+        </div>
+    </div>
+
+    
+    
+    <div id="modal-bookshelf-assessment-upload-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のアップロードに失敗しました。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-searching-failed" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>商品が見つかりませんでした。</p>
+            <p>本棚画像を変更しておためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-image-too-big" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像のファイルサイズが大きすぎます。</p>
+            <p>解像度を下げて、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-timeout" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>しばらく待ってから、再度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+
+    
+    <div id="modal-bookshelf-assessment-error" class="modal-content modal-content-error" style="display: none;">
+        <div class="modal-header">
+            <p class="modal-close-btn"><a id="" class="modal-bank_close"><img class="icon-close" src="/assets/images/header/icon_close_black.svg" /></a></p>
+        </div>
+        <div class="modal-body decode-failed">
+            <p>本棚画像を読み取ることができませんでした。</p>
+            <p>もう一度おためしください。</p>
+            <p>また、本棚スキャンについて詳しくは「<a href="/sell/faq#faq-search">よくある質問</a>」をご覧下さい。</p>
+        </div>
+    </div>
+    
+        <div role="main" id="ec">
+            <vb-search></vb-search>
+    </div>
+</div>
+
+    <div id="book_selection">
+        <vb-book-selection-button></vb-book-selection-button>
+    </div>
+
+<div id="vb-app-footer" style="margin-top: auto">
+    <vb-footer previous-page-url="" />
+</div>
+
+<style>
+    #vb-app .v-application--wrap {
+        min-height: fit-content;
+    }
+    select, textarea {
+        border: 1px solid #ccc;
+    }
+    .theme--light.v-btn:hover::before,
+    .v-tab:hover::before
+    {
+        opacity: 0.08 !important;
+        color: #2c2c2c !important;
+    }
+
+    .v-btn--text:before
+    {
+        left: -4px !important;
+        right: -4px !important;
+        border-radius: 4px !important;
+    }
+    .v-tab:before
+    {
+        border-radius: 4px !important;
+    }
+</style>
+<link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecStore.KrjOXUqq.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecRouter.CQIXDxxp.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ISBNUtils.CC0coUgF.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/dialog-line-user-id-mapping-incomplete.ZTPJHVP0.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-search-navbar.DklBcU9C.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/search.7RrBn9Uy.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio.K5xQfZog.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/openAi.hE1M9Ibm.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item-image-set.pdDVR3DG.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/error-message.DESX--YO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-bubble.C2cN5ahd.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-items-display.Dlpne48Q.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-header.q76rHVQ1.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-price.DSv7JUk3.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/dialog-line-user-id-mapping-incomplete.C0mjBXQf.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-search-navbar.0o0g5ocx.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vue_app_ec.Bqz-d-p8.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_ec.B-pPglKv.js"></script>    <link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="preload" as="style" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue-vendor.-5bc5rh4.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vuetify.EjKoVsqO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/utils-vendor.BxwSdHnB.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vue.config.C-gFF8iV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/openAi.hE1M9Ibm.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.9UoZLPI6.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio.K5xQfZog.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ecRouter.CQIXDxxp.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/veeValidate.BY7Fh1ym.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-book-selection-button.DSnsst7N.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/ui-vendor.DjXZmoUr.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item.BCL4OxpC.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useStore.BI-7lv5P.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/composables.BgeZyr8Y.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/useVuetify.DbwYdWa5.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/_plugin-vue2_normalizer.1gAS2wYV.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-item.BW53da3r.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/audio-controller.DWlj26-f.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/item-image-set.pdDVR3DG.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/error-message.DESX--YO.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/InputValueConversion.DMQp4m_e.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-bubble.C2cN5ahd.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-items-display.Dlpne48Q.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/modal-header.q76rHVQ1.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/timer-display.Dfa9Afid.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/buy-price.DSv7JUk3.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/slide-item.CH0-pcbo.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/vb-modal.BYSS7aC7.js" /><link rel="modulepreload" href="https://www.valuebooks.jp/build/js/close-icon.C-GSZJL4.js" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/materialdesignicons.BfqFKt-d.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ecRouter.BLsFoRZo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-book-selection-button.Cvy9NBmD.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/ui-vendor.GeAqu7z6.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-item.C2wiPKT1.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/audio-controller.ClcMfUCB.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/item-image-set.BCjbUzHW.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/error-message.bZdg_sRR.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-bubble.D3VcUgLO.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-items-display.B86e0gXo.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/modal-header.CKxDfwb4.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/timer-display.tn0RQdqM.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/buy-price.DnLf45j2.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/slide-item.D1gGlPNh.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/vb-modal.7qpvmuMs.css" /><link rel="stylesheet" href="https://www.valuebooks.jp/build/css/close-icon.CcPHY1Ma.css" /><script type="module" src="https://www.valuebooks.jp/build/js/vue_app_book_selection.BpARXme9.js"></script>    
+</body>
+</html>

--- a/tests/used_book_db.rs
+++ b/tests/used_book_db.rs
@@ -1,0 +1,90 @@
+//! 中古本オファーの DB まわりの統合テスト
+//!
+//! `PostgreSQL` が必要なため CI では実行しない。実行する場合:
+//!
+//! ```sh
+//! docker compose up -d postgres
+//! DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres \
+//!   cargo test --test used_book_db -- --ignored
+//! ```
+
+use anyhow::anyhow;
+use bookmeter_discounts::model::Entity as Book;
+use bookmeter_discounts::used_book::UsedBookSite;
+use bookmeter_discounts::used_book_offer::Entity as UsedBookOffer;
+use bookmeter_discounts::BookMeterDiscounts;
+use sea_orm::{ActiveValue::Set, ColumnTrait, Database, EntityTrait, ModelTrait, QueryFilter};
+
+const DATABASE_URL_ENV: &str = "DATABASE_URL";
+
+/// 吾輩は猫である (文春文庫) の ISBN-13
+const ISBN: &str = "9784167158057";
+
+#[tokio::test]
+#[ignore = "requires a PostgreSQL database and network access"]
+async fn used_book_offer_roundtrip() -> anyhow::Result<()> {
+    let db = Database::connect(
+        std::env::var(DATABASE_URL_ENV)
+            .map_err(|e| anyhow!("DATABASE_URL must be set to run this test: {e}"))?,
+    )
+    .await?;
+    let app = BookMeterDiscounts::new("0", db.clone(), 0);
+
+    // 対象の本を登録 (binding_name が「文庫」なので中古本オファー取得の対象)
+    let bookmeter_id: i64 = 9_999_999_001;
+    Book::insert(bookmeter_discounts::model::ActiveModel {
+        bookmeter_id: Set(bookmeter_id),
+        amazon_url: Set("https://www.amazon.co.jp/dp/4167158054".to_string()),
+        kindle_id: Set(None),
+        title: Set("吾輩は猫である".to_string()),
+        basis_price: Set(None),
+        price: Set(None),
+        discount_rate: Set(None),
+        is_kindle_unlimited: Set(false),
+        updated_at: Set(chrono::Utc::now().naive_utc()),
+        active_at: Set(None),
+        binding_name: Set(Some("文庫".to_string())),
+    })
+    .exec(&db)
+    .await?;
+    let book = Book::find_by_id(bookmeter_id)
+        .one(&db)
+        .await?
+        .ok_or_else(|| anyhow!("book should exist"))?;
+
+    // 漫画・ライトノベル除外のクエリが対象の本を拾うこと
+    let eligible = Book::find()
+        .filter(bookmeter_discounts::model::Column::BindingName.is_not_null())
+        .filter(
+            bookmeter_discounts::model::Column::BindingName.is_not_in(["コミック", "ライトノベル"]),
+        )
+        .all(&db)
+        .await?;
+    assert!(eligible.iter().any(|b| b.bookmeter_id == bookmeter_id));
+
+    // 実サイトからオファーを取得して保存
+    app.update_used_book_offer(&book, UsedBookSite::Bookoff, ISBN)
+        .await?;
+    let offer = UsedBookOffer::find_by_id((bookmeter_id, "bookoff".to_string()))
+        .one(&db)
+        .await?
+        .ok_or_else(|| anyhow!("offer should exist"))?;
+    assert_eq!(offer.product_id.as_deref(), Some("0016731582"));
+
+    // 既知の商品 URL を使った再取得でも product_id が維持されること
+    app.update_used_book_offer(&book, UsedBookSite::Bookoff, ISBN)
+        .await?;
+    let offer = UsedBookOffer::find_by_id((bookmeter_id, "bookoff".to_string()))
+        .one(&db)
+        .await?
+        .ok_or_else(|| anyhow!("offer should exist"))?;
+    assert_eq!(offer.product_id.as_deref(), Some("0016731582"));
+
+    // 本を削除するとオファーも cascade で削除されること
+    book.delete(&db).await?;
+    let deleted = UsedBookOffer::find_by_id((bookmeter_id, "bookoff".to_string()))
+        .one(&db)
+        .await?;
+    assert!(deleted.is_none());
+    Ok(())
+}

--- a/tests/used_book_live.rs
+++ b/tests/used_book_live.rs
@@ -1,0 +1,74 @@
+//! 実際の中古本サイトにアクセスするライブテスト
+//!
+//! セレクタが実サイトの HTML と乖離していないかを手元で確認するためのもので、
+//! CI では実行しない。実行する場合:
+//!
+//! ```sh
+//! cargo test --test used_book_live -- --ignored
+//! ```
+
+use anyhow::anyhow;
+use bookmeter_discounts::used_book::UsedBookSite;
+
+/// 海に願いを風に祈りをそして君に誓いを (スターツ出版文庫) の ISBN-13
+const ISBN: &str = "9784813705185";
+
+#[tokio::test]
+#[ignore = "hits real websites"]
+async fn bookoff_live() -> anyhow::Result<()> {
+    let hit = UsedBookSite::Bookoff
+        .search(ISBN)
+        .await?
+        .ok_or_else(|| anyhow!("BOOKOFF search should find the book"))?;
+    assert_eq!(hit.product_id, "0019117467");
+    let details = UsedBookSite::Bookoff
+        .fetch_details(&hit.product_url)
+        .await?;
+    assert!(details.price.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "hits real websites"]
+async fn valuebooks_live() -> anyhow::Result<()> {
+    let hit = UsedBookSite::ValueBooks
+        .search(ISBN)
+        .await?
+        .ok_or_else(|| anyhow!("ValueBooks search should find the book"))?;
+    assert!(hit.product_id.starts_with("VS"));
+    let details = hit
+        .details
+        .ok_or_else(|| anyhow!("ValueBooks search parses details inline"))?;
+    assert!(details.price.is_some() || !details.in_stock);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "hits real websites"]
+async fn netoff_live() -> anyhow::Result<()> {
+    let hit = UsedBookSite::NetOff
+        .search(ISBN)
+        .await?
+        .ok_or_else(|| anyhow!("NetOff search should find the book"))?;
+    assert_eq!(hit.product_id, "0012822282");
+    let details = UsedBookSite::NetOff.fetch_details(&hit.product_url).await?;
+    assert!(details.price.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "hits real websites"]
+async fn refresh_offer_with_known_product_live() -> anyhow::Result<()> {
+    let update = UsedBookSite::Bookoff
+        .refresh_offer(
+            ISBN,
+            Some((
+                "0019117467",
+                "https://shopping.bookoff.co.jp/used/0019117467",
+            )),
+        )
+        .await?;
+    assert_eq!(update.product_id.as_deref(), Some("0019117467"));
+    assert!(update.price.is_some());
+    Ok(())
+}


### PR DESCRIPTION
## 概要

読書メーターの本ページから書籍の形式 (`binding_name`: コミック / ライトノベル / 文庫 / 新書 / 単行本 など) を取得し、**コミック・ライトノベル以外**の本について、紙書籍 ASIN (= ISBN-10) を ISBN-13 に変換して中古本サイト (BOOKOFF / バリューブックス / ネットオフ) を検索、価格・在庫・状態を `used_book_offers` テーブルに保存する。

## 変更点

- `books.binding_name` カラムと `used_book_offers` テーブルを追加 (`init.sql`)
- `src/isbn.rs`: ISBN-10 → ISBN-13 変換 (チェックディジット計算、ユニットテスト付き)
- `src/used_book/`: 3サイトの検索・商品ページパーサー。HTTP 取得とパースを分離し、`tests/fixtures/used_book/` の保存済み HTML でユニットテスト可能に
  - BOOKOFF / ネットオフ: 検索 → 商品ページ (JSON-LD または HTML 要素) の2段階
  - バリューブックス: 検索が商品ページへリダイレクトされるため、埋め込み `:item-info` JSON をその場で解析
  - 既知の商品 URL があれば検索をスキップして直接商品ページを再取得 (404 時に古いデータを消さないよう検索へのフォールバックは意図的に行わない)
- `src/lib.rs`: `update_discounts` に binding_name 補完ステップと中古本オファー取得ステップを追加 (既存と同じ stream + interval sleep のパターン)
- `src/metrics.rs`: `bookmeter.used_book_offer_fetched` カウンタを追加 (site ラベル付き)
- 手動実行用の統合テスト (`tests/used_book_db.rs`, DB 要) とライブテスト (`tests/used_book_live.rs`) を `--ignored` で追加

## レビューで対応した点

- `parse_binding_name` が空文字列を `Some("")` で返すと漫画除外フィルタをすり抜ける問題を修正 (空は `None` に)
- 形式が取得できない本を毎回 UPDATE していたのを、`None` の場合は書き込まず次回再取得に変更
- 検索ヒットなしの場合に中身のない NULL 行を insert しないよう変更
- `from_id` / `fetch_binding_name` のリトライブロックを共通ヘルパに集約
- `used_book_offer::ActiveModel` の `apply_update` / `From` の二重管理を解消

## デプロイ時の注意

`init.sql` は postgres イメージの初回初期化時にしか実行されないため、**既存の DB ボリュームには手動で以下を実行する必要があります** (従来のカラム追加と同じ運用):

```sql
alter table books add column if not exists binding_name text;
create table if not exists used_book_offers (
    bookmeter_id bigint not null references books(bookmeter_id) on delete cascade,
    site text not null,
    product_id text,
    product_url text,
    price integer,
    condition text,
    in_stock boolean not null default false,
    updated_at timestamp not null,
    primary key (bookmeter_id, site)
);
create index if not exists used_book_offers_product_id_index on used_book_offers (product_id);
```