### PR TITLE
Add used_book_offers_with_books view for dashboard

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -47,3 +47,17 @@ create table if not exists public.used_book_offers (
     constraint used_book_offers_bookmeter_id_fkey foreign key (bookmeter_id) references public.books (bookmeter_id) on delete cascade
 );
 create index if not exists used_book_offers_product_id_index on public.used_book_offers (product_id);
+
+-- 中古本オファーと書籍情報の結合ビュー (外部サービスから参照される)
+create or replace view public.used_book_offers_with_books as
+SELECT o.bookmeter_id,
+    o.site,
+    o.product_url,
+    o.price,
+    o.condition,
+    o.in_stock,
+    o.updated_at,
+    b.title,
+    b.amazon_url
+   FROM used_book_offers o
+     JOIN books b ON b.bookmeter_id = o.bookmeter_id;


### PR DESCRIPTION
## Summary
- Add a `used_book_offers_with_books` view joining `used_book_offers` and `books` for the mydashboard2 dashboard to display a list of used-book offers via gqlforge.
- Required by takumi3488/mydashboard2#328. **Merge this PR first**: gqlforge validates the view against the live DB schema at startup and crash-loops if it is missing.

## Test plan
- [x] sync-db dry-run PR comment shows only `CREATE VIEW` (no DROP operations) — confirmed: single `OpCreateView public.used_book_offers_with_books` operation
